### PR TITLE
feat(layout): AI Layout Designer — Phase 2 (AI Designer + History)

### DIFF
--- a/Plans/2026-06-24-layout-ai-designer-phase2-completion.md
+++ b/Plans/2026-06-24-layout-ai-designer-phase2-completion.md
@@ -1,0 +1,71 @@
+# AI Layout Designer — Phase 2 (AI Designer + History) Completion Summary
+
+**Last Updated:** 2026-06-24 12:15
+**Branch:** `feat/layout-ai-designer-phase2` (based on merged `main` incl. Phase 1)
+**Status:** ✅ Phase 2 complete — all 7 tasks implemented, reviewed, and green.
+**Spec:** `Plans/2026-06-24-layout-ai-designer-design.md` (§5 AI designer, §6 history)
+**Plan:** `Plans/2026-06-24-layout-ai-designer-phase2-designer.md`
+
+---
+
+## What shipped
+
+The Layout tab can now **design itself with AI**: describe a page (or type a change), the
+text LLM proposes a structured layout (and/or asks clarifying questions) rendered on the
+canvas, and you iterate in a loop — with a browsable **history** of every iteration
+(snapshot / restore / branch), persisted with the project.
+
+| Area | Module(s) |
+|---|---|
+| Snapshot model + history persistence | `core/layout/models.py` (`Snapshot`, `DocumentSpec.history`), `core/layout/schema.py` |
+| History manager (append/restore/branch) | `core/layout/history.py` |
+| Designer prompt builder | `core/layout/designer.py` (`build_messages`) |
+| Response parse + fallback + run_design + LLM call | `core/layout/designer.py` (`DesignerResult`, `parse_response`, `fallback_result`, `run_design`, `run_completion`) |
+| Designer panel + QThread worker + status console | `gui/layout/designer_panel.py` |
+| Browsable history window | `gui/layout/history_window.py` |
+| Tab integration (design button, apply+snapshot, restore, History…) | `gui/layout/layout_tab.py` |
+
+## Architecture
+
+- **Network isolation:** the only LLM network call is `designer.run_completion`. Every other
+  layer (`build_messages` / `parse_response` / `run_design` / worker / panel / tab) takes an
+  injectable `completion_fn`, so all designer logic is unit-tested **headless without a
+  network**. The production worker runs on a `QThread`; the injected/test path runs inline.
+- **Robust + graceful:** markdown-fenced JSON parsed via the shared `LLMResponseParser`;
+  non-list `questions` guarded; LLM geometry clamped into the page via `normalize_region`;
+  empty/garbage responses degrade to a fallback layout (spec §5), never crash.
+- **History hygiene:** snapshots never nest their own timeline (no unbounded growth); restore
+  re-attaches the live timeline so branching works; persists in the project JSON and is
+  backward-compatible with Phase-1 files.
+- **§8 LLM logging:** the full request (provider/model/temperature/messages) and full response
+  are logged to the file logger and surfaced in the designer status console.
+
+## Tests
+
+21 new tests (56 total under `tests/layout/`), headless offscreen Qt, **56 passed, 0
+warnings**. Reuses the existing `LiteLLMHandler` / `LLMResponseParser` / `DialogStatusConsole`
+and the model registry (`get_provider_models` / `get_provider_prefix`); no new runtime deps.
+
+## Process
+
+Subagent-driven TDD (implementer + reviewer per task, fix loops) + a final whole-branch review
+(opus; verdict: *ready to merge with fixes* — applied). Review-loop catches included
+non-list-`questions` parsing, parsed-dict mutation, the design-button wiring (caught in Task 5,
+fixed in the Task-7 plan), and the §8 full-prompt/response logging gap.
+
+## Deferred / carry-forward (documented decisions)
+
+- **Provider display-name→id threading** (`designer_panel` + `run_completion`): correct for all
+  five registered providers and mirrors the proven `text_gen_dialog` two-map pattern. NOT
+  refactored here because the naive "pass the registry id" fix would **break Google gcloud/key
+  auth** (the app stores Google's key under `"google"` while the registry id is `"gemini"`). A
+  proper fix is a **repo-wide** provider-id refactor (touching `text_gen_dialog` too) and is out
+  of Phase-2 scope.
+- Minor polish logged in `.superpowers/sdd/progress.md` (e.g. `snapshots()` defensive copy,
+  `json.dumps(indent=0)`→`None` token trim) — non-blocking.
+
+## Next
+
+Phase 3 — project style system (fonts/colors/roles by content kind) + template export/import —
+gets its own spec→plan→PR cycle. Then Phase 4 (content MVP: import images + edit text) and
+Phase 5 (AI content + bundles).

--- a/Plans/2026-06-24-layout-ai-designer-phase2-designer.md
+++ b/Plans/2026-06-24-layout-ai-designer-phase2-designer.md
@@ -949,6 +949,17 @@ def test_restore_snapshot_reloads_document(qapp):
     assert [r.id for r in tab.document.pages[0].regions] == ["b"]
     tab.restore_snapshot(sid)
     assert [r.id for r in tab.document.pages[0].regions] == ["a"]  # back to v1
+
+
+def test_design_button_calls_start_design_with_page_size(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    captured = {}
+    tab.designer.start_design = lambda *a, **k: captured.setdefault("call", (a, k))
+    tab.designer.prompt_edit.setPlainText("a comic cover")
+    tab._on_design_clicked()
+    a, k = captured["call"]
+    assert a[0] == "a comic cover"                       # prompt text passed
+    assert a[1] == tab.document.pages[0].page_size_px    # current page size supplied
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -981,8 +992,11 @@ After `root.addWidget(self.page_setup)` add the designer panel:
 ```python
         self.designer = DesignerPanel(self.config)
         self.designer.layoutProposed.connect(self._on_layout_proposed)
+        self.designer.design_btn.clicked.connect(self._on_design_clicked)
         root.addWidget(self.designer)
 ```
+
+The designer panel's "Design / Iterate" button does not self-wire (it has no page size); the tab owns that wiring — it supplies the current page's pixel size and regions.
 
 In `new_document`, after building `self.document`, bind history:
 
@@ -1002,6 +1016,16 @@ In `open_project_from` and after any place `self.document` is reassigned, rebind
 Add the new methods:
 
 ```python
+    def _on_design_clicked(self):
+        if not self.document or not self.document.pages:
+            return
+        text = self.designer.prompt_edit.toPlainText().strip()
+        if not text:
+            return
+        page = self.document.pages[0]
+        self.designer.start_design(text, page.page_size_px,
+                                   current_regions=page.regions or None)
+
     def _on_layout_proposed(self, result):
         text = self.designer.prompt_edit.toPlainText().strip() if hasattr(self.designer, "prompt_edit") else ""
         self.apply_designer_result(result, user_text=text)
@@ -1032,7 +1056,7 @@ Note: `new_document` must set `self.history` BEFORE `_refresh()` is first called
 - [ ] **Step 4: Run tests to verify they pass**
 
 Run: `.venv_linux/bin/python -m pytest tests/layout/test_layout_tab_designer.py -v`
-Expected: PASS (2 passed).
+Expected: PASS (3 passed).
 
 - [ ] **Step 5: Run the FULL suite + import smoke**
 

--- a/Plans/2026-06-24-layout-ai-designer-phase2-designer.md
+++ b/Plans/2026-06-24-layout-ai-designer-phase2-designer.md
@@ -1,0 +1,1065 @@
+# AI Layout Designer — Phase 2 (AI Designer + Iteration History) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the AI layout *designer* — describe a page (or type a modification) → a text LLM proposes a structured layout (and/or asks clarifying questions) rendered on the canvas → iterate in a loop — plus a browsable iteration **history** (snapshot/restore/branch) persisted with the project.
+
+**Architecture:** Pure, testable core (`designer.py` builds the prompt and parses the LLM's JSON into `Region`s; `history.py` manages snapshots) with the network LLM call isolated behind an injectable `completion_fn` so everything is unit-testable headless without a network. The GUI (`designer_panel.py` with a `QThread` worker + status console, `history_window.py`) sits on top and wires into the Phase-1 `LayoutTab`. Reuses the existing `LiteLLMHandler`/`LLMResponseParser`/`DialogStatusConsole` and the model registry.
+
+**Tech Stack:** Python 3.12, PySide6 (`QThread`, `QDialog`), LiteLLM (via `gui/llm_utils.py`), `core/llm_models.resolve_model`, `pytest` (headless offscreen Qt). Builds on Phase 1 (`core/layout/{models,schema,qt_renderer,project_io}.py`, `gui/layout/{layout_tab,canvas_widget,page_setup_widget}.py`).
+
+## Global Constraints
+
+- Spec: `Plans/2026-06-24-layout-ai-designer-design.md` (§5 AI designer, §6 history). This plan implements **Phase 2**.
+- Python interpreter for all commands: `.venv_linux/bin/python` (never `.venv`). Run from repo root `/mnt/d/Documents/Code/GitHub/ImageAI`. **No `cd`.**
+- GUI tests run **headless** under `QT_QPA_PLATFORM=offscreen` (already set in `tests/conftest.py`; session `qapp` fixture). No `pytest-qt`.
+- **LLM logging (repo rule §8):** every request (provider, model, temperature, prompt) and full response must be shown in the designer's status console **and** the file logger. Handle empty responses with a fallback layout; parse JSON robustly (markdown fences).
+- **Model IDs:** resolve via `resolve_model()` / the model registry; never hardcode `claude-*`/`gpt-*`/`gemini-*`.
+- The LLM network call lives ONLY in `core/layout/designer.py::run_completion`; all other designer logic takes an injected `completion_fn(messages)->str` so it is testable without network.
+- Conventional Commits; commit subjects **≤72 chars**; commit after each task. Branch: `feat/layout-ai-designer-phase2`.
+- Extend Phase-1 modules in place; do not break the Phase-1 test suite (35 tests must stay green).
+
+---
+
+## File Structure
+
+**Create:**
+- `core/layout/history.py` — `History` manager (append/snapshots/get/restore over a `DocumentSpec`).
+- `core/layout/designer.py` — `DesignerResult`, `build_messages`, `parse_response`, `fallback_result`, `run_design`, `run_completion`.
+- `gui/layout/designer_panel.py` — `DesignerWorker(QThread)` + `DesignerPanel(QWidget)`.
+- `gui/layout/history_window.py` — `HistoryWindow(QDialog)`.
+- Tests: `tests/layout/test_history.py`, `test_designer.py`, `test_designer_panel.py`, `test_history_window.py`, `test_layout_tab_designer.py`.
+
+**Modify:**
+- `core/layout/models.py` — add `Snapshot` dataclass; add `history` field to `DocumentSpec`.
+- `core/layout/schema.py` — `snapshot_to_dict`/`snapshot_from_dict`; include `history` in `document_to_dict`/`document_from_dict`.
+- `gui/layout/layout_tab.py` — embed `DesignerPanel`, a "History…" button, content-kind; wire `layoutProposed` → apply + snapshot, restore → load.
+
+---
+
+### Task 1: Snapshot model + history persistence
+
+**Files:**
+- Modify: `core/layout/models.py`, `core/layout/schema.py`
+- Test: `tests/layout/test_history.py` (persistence portion)
+
+**Interfaces:**
+- Consumes: Phase-1 `DocumentSpec`, `schema.document_to_dict`/`document_from_dict`, `Region`/`PageSpec`.
+- Produces:
+  - `models.Snapshot(id: str, parent_id: Optional[str], timestamp: str, prompt: str, document: dict, thumbnail: Optional[str] = None)`
+  - `DocumentSpec.history: list[Snapshot] = []`
+  - `schema.snapshot_to_dict(s)`/`schema.snapshot_from_dict(d)`
+  - `document_to_dict`/`document_from_dict` round-trip `history`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/layout/test_history.py
+from core.layout.models import Snapshot, DocumentSpec, PageSpec, Region
+from core.layout import schema
+
+
+def test_snapshot_roundtrip_via_schema():
+    snap = Snapshot(id="s1", parent_id=None, timestamp="2026-06-24 12:00",
+                    prompt="a 9-panel comic", document={"title": "X", "pages": []})
+    d = schema.snapshot_to_dict(snap)
+    again = schema.snapshot_from_dict(d)
+    assert again.id == "s1"
+    assert again.prompt == "a 9-panel comic"
+    assert again.document == {"title": "X", "pages": []}
+
+
+def test_document_history_roundtrip():
+    doc = DocumentSpec(title="Doc", pages=[PageSpec(page_size_px=(100, 100),
+                       regions=[Region(id="r1", kind="text", text="hi")])])
+    doc.history.append(Snapshot(id="s1", parent_id=None, timestamp="t",
+                                prompt="p", document={"k": "v"}))
+    again = schema.document_from_dict(schema.document_to_dict(doc))
+    assert len(again.history) == 1
+    assert again.history[0].id == "s1"
+    assert again.history[0].document == {"k": "v"}
+    # content still intact
+    assert again.pages[0].regions[0].text == "hi"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_history.py -v`
+Expected: FAIL (`ImportError`: cannot import `Snapshot`).
+
+- [ ] **Step 3: Add `Snapshot` + `history` to `core/layout/models.py`**
+
+Add after the `Region` dataclass:
+
+```python
+@dataclass
+class Snapshot:
+    """One iteration of the layout designer (browsable in history)."""
+
+    id: str
+    parent_id: Optional[str]
+    timestamp: str
+    prompt: str
+    document: Dict  # serialized DocumentSpec (without its own history)
+    thumbnail: Optional[str] = None
+```
+
+Extend `DocumentSpec` — add after `schema_version` (keep it last; default factory):
+
+```python
+    history: List["Snapshot"] = field(default_factory=list)
+```
+
+- [ ] **Step 4: Add history serialization to `core/layout/schema.py`**
+
+Add `Snapshot` to the `from core.layout.models import (...)` line. Add these functions (place near `document_to_dict`):
+
+```python
+def snapshot_to_dict(s: "Snapshot") -> Dict:
+    return {
+        "id": s.id, "parent_id": s.parent_id, "timestamp": s.timestamp,
+        "prompt": s.prompt, "document": s.document, "thumbnail": s.thumbnail,
+    }
+
+
+def snapshot_from_dict(d: Dict) -> "Snapshot":
+    from core.layout.models import Snapshot
+    return Snapshot(
+        id=d["id"], parent_id=d.get("parent_id"), timestamp=d.get("timestamp", ""),
+        prompt=d.get("prompt", ""), document=d.get("document", {}),
+        thumbnail=d.get("thumbnail"),
+    )
+```
+
+In `document_to_dict`, add to the returned dict:
+
+```python
+        "history": [snapshot_to_dict(s) for s in doc.history],
+```
+
+In `document_from_dict`, add the field to the `DocumentSpec(...)` construction:
+
+```python
+        history=[snapshot_from_dict(s) for s in d.get("history", [])],
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_history.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Confirm Phase-1 suite still green**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/ -q`
+Expected: all pass (37 now), no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/layout/models.py core/layout/schema.py tests/layout/test_history.py
+git commit -m "feat(layout): add Snapshot model + history persistence in schema"
+```
+
+---
+
+### Task 2: History manager
+
+**Files:**
+- Create: `core/layout/history.py`
+- Test: `tests/layout/test_history.py` (append)
+
+**Interfaces:**
+- Consumes: `DocumentSpec`, `Snapshot`, `schema.document_to_dict`/`document_from_dict`.
+- Produces:
+  - `History(document: DocumentSpec)`
+  - `History.append(prompt: str, *, snapshot_id: str | None = None, timestamp: str | None = None, parent_id: str | None = None) -> Snapshot`
+  - `History.snapshots() -> list[Snapshot]`
+  - `History.get(snapshot_id: str) -> Snapshot | None`
+  - `History.restore(snapshot_id: str) -> DocumentSpec` (content of the snapshot, with the live timeline re-attached)
+
+- [ ] **Step 1: Write the failing test (append to `tests/layout/test_history.py`)**
+
+```python
+def _doc_with_text(t):
+    from core.layout.models import DocumentSpec, PageSpec, Region
+    return DocumentSpec(title="D", pages=[PageSpec(page_size_px=(100, 100),
+                        regions=[Region(id="r1", kind="text", text=t)])])
+
+
+def test_history_append_snapshots_current_doc():
+    from core.layout.history import History
+    doc = _doc_with_text("v1")
+    h = History(doc)
+    s1 = h.append("first", snapshot_id="s1", timestamp="t1")
+    assert s1.id == "s1" and s1.parent_id is None
+    # snapshot captured the doc WITHOUT nesting history inside it
+    assert "history" not in s1.document
+    assert s1.document["pages"][0]["regions"][0]["text"] == "v1"
+    assert len(h.snapshots()) == 1
+
+
+def test_history_parent_chain_and_restore():
+    from core.layout.history import History
+    doc = _doc_with_text("v1")
+    h = History(doc)
+    h.append("first", snapshot_id="s1", timestamp="t1")
+    # mutate the live doc, snapshot again
+    doc.pages[0].regions[0].text = "v2"
+    s2 = h.append("second", snapshot_id="s2", timestamp="t2")
+    assert s2.parent_id == "s1"  # auto-parents to previous snapshot
+    restored = h.restore("s1")
+    assert restored.pages[0].regions[0].text == "v1"  # got s1 content
+    assert len(restored.history) == 2  # timeline preserved on the restored doc
+
+
+def test_history_get_missing_returns_none():
+    from core.layout.history import History
+    h = History(_doc_with_text("v1"))
+    assert h.get("nope") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_history.py -v`
+Expected: FAIL (`ModuleNotFoundError: core.layout.history`).
+
+- [ ] **Step 3: Create `core/layout/history.py`**
+
+```python
+"""Iteration-history manager for the layout designer."""
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from core.layout.models import DocumentSpec, Snapshot
+from core.layout import schema
+
+
+class History:
+    """Append/browse/restore layout snapshots stored on a DocumentSpec."""
+
+    def __init__(self, document: DocumentSpec):
+        self.document = document
+
+    def snapshots(self) -> List[Snapshot]:
+        return self.document.history
+
+    def get(self, snapshot_id: str) -> Optional[Snapshot]:
+        for s in self.document.history:
+            if s.id == snapshot_id:
+                return s
+        return None
+
+    def append(self, prompt: str, *, snapshot_id: Optional[str] = None,
+               timestamp: Optional[str] = None, parent_id: Optional[str] = None) -> Snapshot:
+        doc_dict = schema.document_to_dict(self.document)
+        doc_dict.pop("history", None)  # never nest history inside a snapshot
+        if parent_id is None and self.document.history:
+            parent_id = self.document.history[-1].id
+        snap = Snapshot(
+            id=snapshot_id or uuid.uuid4().hex[:8],
+            parent_id=parent_id,
+            timestamp=timestamp or datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            prompt=prompt,
+            document=doc_dict,
+        )
+        self.document.history.append(snap)
+        return snap
+
+    def restore(self, snapshot_id: str) -> DocumentSpec:
+        snap = self.get(snapshot_id)
+        if snap is None:
+            raise KeyError(f"No snapshot {snapshot_id!r}")
+        restored = schema.document_from_dict(snap.document)
+        restored.history = list(self.document.history)  # keep the timeline
+        return restored
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_history.py -v`
+Expected: PASS (5 passed total in this file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/history.py tests/layout/test_history.py
+git commit -m "feat(layout): add History manager (append/restore/branch)"
+```
+
+---
+
+### Task 3: Designer prompt building
+
+**Files:**
+- Create: `core/layout/designer.py`
+- Test: `tests/layout/test_designer.py`
+
+**Interfaces:**
+- Consumes: `Region` (for current-layout context).
+- Produces:
+  - `designer.build_messages(content_kind: str, page_px: tuple[int,int], user_text: str, current_regions: list[Region] | None = None) -> list[dict]`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/layout/test_designer.py
+from core.layout.models import Region
+from core.layout import designer
+
+
+def test_build_messages_includes_context_and_json_instruction():
+    msgs = designer.build_messages("comic", (1000, 800), "9 panels that flow into each other")
+    assert isinstance(msgs, list) and msgs[0]["role"] == "system"
+    joined = " ".join(m["content"] for m in msgs)
+    assert "comic" in joined
+    assert "1000" in joined and "800" in joined
+    assert "9 panels that flow into each other" in joined
+    assert "JSON" in joined or "json" in joined
+    assert "regions" in joined  # tells the model our schema key
+
+
+def test_build_messages_includes_current_layout_when_iterating():
+    regions = [Region(id="r1", kind="image", bbox=(0, 0, 500, 500))]
+    msgs = designer.build_messages("comic", (1000, 800), "make the top panel bigger", regions)
+    joined = " ".join(m["content"] for m in msgs)
+    assert "r1" in joined  # current layout passed back for modification
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_designer.py -v`
+Expected: FAIL (`ModuleNotFoundError: core.layout.designer`).
+
+- [ ] **Step 3: Create `core/layout/designer.py` (prompt builder portion)**
+
+```python
+"""AI layout designer: prompt building, response parsing, and the LLM call."""
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional, Tuple, Callable
+
+from core.layout.models import Region
+from core.layout import schema
+
+logger = logging.getLogger("imageai.layout.designer")
+
+_SYSTEM = (
+    "You are a page-layout designer. You design the GEOMETRY of a single page as "
+    "regions (image or text placeholders). You never write the actual content. "
+    "Respond with a SINGLE JSON object and nothing else."
+)
+
+
+def build_messages(content_kind: str, page_px: Tuple[int, int], user_text: str,
+                   current_regions: Optional[List[Region]] = None) -> List[Dict[str, str]]:
+    pw, ph = page_px
+    current = ""
+    if current_regions:
+        current = (
+            "<current_layout>\n"
+            + json.dumps([schema.region_to_dict(r) for r in current_regions], indent=0)
+            + "\n</current_layout>\n"
+        )
+    user = (
+        f"<context>\n"
+        f"content_kind: {content_kind}\n"
+        f"page_pixels: {pw} x {ph} (x,y origin top-left; all coordinates in pixels)\n"
+        f"</context>\n"
+        f"{current}"
+        f"<request>\n{user_text}\n</request>\n"
+        f"<instructions>\n"
+        f"Return a JSON object with optional keys:\n"
+        f'  "questions": [strings]   // ask for missing detail if needed\n'
+        f'  "layout": {{ "regions": [ {{\n'
+        f'      "id": string, "kind": "image"|"text", "shape": "rect"|"polygon",\n'
+        f'      "bbox": [x,y,w,h], "points": [[x,y],...] (polygon only),\n'
+        f'      "z": int, "text": string (text only) }} ] }}\n'
+        f"All coordinates MUST be within the page ({pw} x {ph}). Prefer 'rect' unless the\n"
+        f"request implies panels that flow into each other (then use 'polygon'). You may\n"
+        f"return questions, a layout, or both.\n"
+        f"</instructions>"
+    )
+    return [{"role": "system", "content": _SYSTEM}, {"role": "user", "content": user}]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_designer.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/designer.py tests/layout/test_designer.py
+git commit -m "feat(layout): add designer prompt builder"
+```
+
+---
+
+### Task 4: Designer response parsing + fallback + run_design
+
+**Files:**
+- Modify: `core/layout/designer.py`
+- Test: `tests/layout/test_designer.py` (append)
+
+**Interfaces:**
+- Consumes: `schema.region_from_dict`/`normalize_region`, `gui.llm_utils.LLMResponseParser`.
+- Produces:
+  - `designer.DesignerResult(questions: list[str], regions: list[Region] | None, raw: str)`
+  - `designer.parse_response(content: str, page_px: tuple[int,int]) -> DesignerResult`
+  - `designer.fallback_result(page_px: tuple[int,int]) -> DesignerResult`
+  - `designer.run_design(messages: list[dict], page_px: tuple[int,int], completion_fn: Callable[[list[dict]], str]) -> DesignerResult`
+  - `designer.run_completion(config, provider: str, model: str, messages, temperature: float = 0.4) -> str` (real LLM call; not unit-tested)
+
+- [ ] **Step 1: Write the failing test (append to `tests/layout/test_designer.py`)**
+
+```python
+def test_parse_response_with_regions_and_questions():
+    content = (
+        "```json\n"
+        '{"questions": ["What palette?"],'
+        ' "layout": {"regions": [{"id": "p1", "kind": "image", "shape": "rect",'
+        ' "bbox": [0,0,500,400]}, {"id": "t1", "kind": "text", "bbox": [0,420,500,80],'
+        ' "text": "Title"}]}}'
+        "\n```"
+    )
+    res = designer.parse_response(content, (1000, 800))
+    assert res.questions == ["What palette?"]
+    assert [r.id for r in res.regions] == ["p1", "t1"]
+    assert res.regions[0].kind == "image"
+    # out-of-nothing clamp safety: bbox stays within page
+    x, y, w, h = res.regions[1].bbox
+    assert x + w <= 1000 and y + h <= 800
+
+
+def test_parse_response_questions_only():
+    res = designer.parse_response('{"questions": ["how many pages?"]}', (1000, 800))
+    assert res.questions == ["how many pages?"]
+    assert res.regions is None
+
+
+def test_parse_response_garbage_falls_back():
+    res = designer.parse_response("the model rambled with no json", (1000, 800))
+    assert res.regions is not None and len(res.regions) >= 1  # fallback layout
+    assert res.regions[0].bbox[2] > 0
+
+
+def test_run_design_uses_injected_completion():
+    captured = {}
+
+    def fake_completion(messages):
+        captured["msgs"] = messages
+        return '{"layout": {"regions": [{"id":"a","kind":"image","bbox":[0,0,100,100]}]}}'
+
+    msgs = designer.build_messages("comic", (200, 200), "one panel")
+    res = designer.run_design(msgs, (200, 200), fake_completion)
+    assert captured["msgs"] == msgs
+    assert [r.id for r in res.regions] == ["a"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_designer.py -v`
+Expected: FAIL (`AttributeError`: `parse_response`/`DesignerResult`).
+
+- [ ] **Step 3: Add parsing, fallback, run_design, run_completion to `core/layout/designer.py`**
+
+Append:
+
+```python
+@dataclass
+class DesignerResult:
+    questions: List[str] = field(default_factory=list)
+    regions: Optional[List[Region]] = None
+    raw: str = ""
+
+
+def fallback_result(page_px: Tuple[int, int]) -> DesignerResult:
+    pw, ph = page_px
+    region = Region(id="region1", kind="image", shape="rect",
+                    bbox=(0, 0, pw, ph), name="full page")
+    return DesignerResult(
+        questions=["I couldn't parse a layout — here's a single full-page frame. "
+                   "Tell me how to divide it."],
+        regions=[region], raw="")
+
+
+def parse_response(content: str, page_px: Tuple[int, int]) -> DesignerResult:
+    from gui.llm_utils import LLMResponseParser
+    data = LLMResponseParser.parse_json_response(content, expected_type=dict)
+    if not isinstance(data, dict):
+        logger.warning("Designer: unparseable response, using fallback")
+        return fallback_result(page_px)
+    questions = [str(q) for q in data.get("questions", []) if str(q).strip()]
+    regions = None
+    layout = data.get("layout")
+    if isinstance(layout, dict) and isinstance(layout.get("regions"), list):
+        regions = []
+        for i, rd in enumerate(layout["regions"]):
+            if not isinstance(rd, dict):
+                continue
+            rd.setdefault("id", f"region{i + 1}")
+            rd.setdefault("kind", "image")
+            region = schema.region_from_dict(rd)
+            regions.append(schema.normalize_region(region, page_px))
+        if not regions:
+            regions = None
+    if regions is None and not questions:
+        return fallback_result(page_px)
+    return DesignerResult(questions=questions, regions=regions, raw=content)
+
+
+def run_design(messages: List[Dict], page_px: Tuple[int, int],
+               completion_fn: Callable[[List[Dict]], str]) -> DesignerResult:
+    content = completion_fn(messages)
+    return parse_response(content or "", page_px)
+
+
+def run_completion(config, provider: str, model: str, messages: List[Dict],
+                   temperature: float = 0.4) -> str:
+    """Real LLM call (mirrors TextGenerationWorker). Not unit-tested (network)."""
+    from gui.llm_utils import LiteLLMHandler
+    from core.llm_models import get_provider_models, get_provider_prefix
+    ok, litellm = LiteLLMHandler.setup_litellm(enable_console_logging=True)
+    if not ok or litellm is None:
+        raise RuntimeError("Failed to initialize LiteLLM")
+    provider = provider or (config.get_layout_llm_provider() if config else "google")
+    provider_map = {"google": "google", "anthropic": "anthropic", "openai": "openai",
+                    "ollama": "ollama", "lm studio": "lmstudio"}
+    pid_api = provider_map.get(provider.lower(), provider.lower())
+    pid = "gemini" if pid_api == "google" else pid_api
+    api_key = None
+    auth_mode = "api-key"
+    if pid_api == "google" and config is not None:
+        am = config.get("auth_mode", "api-key")
+        auth_mode = "gcloud" if am in ("gcloud", "Google Cloud Account") else "api-key"
+    if auth_mode == "api-key" and config is not None:
+        api_key = config.get_api_key(pid_api)
+    models = get_provider_models(pid)
+    model_name = model or (models[0] if models else None)
+    if not model_name:
+        raise RuntimeError(f"No models available for provider {provider!r}")
+    prefix = get_provider_prefix(pid)
+    full_model = f"{prefix}{model_name}" if prefix else model_name
+    logger.info("Designer LLM call: model=%s temp=%s", full_model, temperature)
+    kwargs = {"model": full_model, "messages": messages, "temperature": temperature}
+    if api_key:
+        kwargs["api_key"] = api_key
+    resp = litellm.completion(**kwargs)
+    if not resp or not resp.choices:
+        raise RuntimeError("Empty LLM response")
+    return resp.choices[0].message.content or ""
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_designer.py -v`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/designer.py tests/layout/test_designer.py
+git commit -m "feat(layout): add designer response parsing, fallback, run_design"
+```
+
+---
+
+### Task 5: Designer worker + panel (GUI)
+
+**Files:**
+- Create: `gui/layout/designer_panel.py`
+- Test: `tests/layout/test_designer_panel.py`
+
+**Interfaces:**
+- Consumes: `designer.build_messages`/`run_design`/`run_completion`, `DialogStatusConsole`, `core.llm_models` provider helpers.
+- Produces:
+  - `designer_panel.DesignerWorker(messages, page_px, completion_fn, parent=None)` — `QThread`; signals `progress(str)`, `proposed(object)` (DesignerResult), `failed(str)`.
+  - `designer_panel.DesignerPanel(config, parent=None)` — `QWidget`; signal `layoutProposed(object)` (DesignerResult); method `content_kind() -> str`; method `start_design(user_text, page_px, current_regions=None, completion_fn=None)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/layout/test_designer_panel.py
+from core.layout.models import Region
+from gui.layout.designer_panel import DesignerPanel, DesignerWorker
+from core.layout import designer
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def test_worker_emits_proposed_with_injected_completion(qapp):
+    msgs = designer.build_messages("comic", (200, 200), "one panel")
+    fake = lambda m: '{"layout": {"regions": [{"id":"a","kind":"image","bbox":[0,0,100,100]}]}}'
+    w = DesignerWorker(msgs, (200, 200), fake)
+    got = []
+    w.proposed.connect(lambda res: got.append(res))
+    w.run()  # run synchronously in-test (no thread start)
+    assert got and [r.id for r in got[0].regions] == ["a"]
+
+
+def test_panel_builds_and_reports_content_kind(qapp):
+    p = DesignerPanel(FakeConfig())
+    assert isinstance(p.content_kind(), str) and p.content_kind()
+
+
+def test_panel_start_design_emits_layout_proposed(qapp):
+    p = DesignerPanel(FakeConfig())
+    got = []
+    p.layoutProposed.connect(lambda res: got.append(res))
+    fake = lambda m: '{"layout": {"regions": [{"id":"z","kind":"text","bbox":[0,0,50,50],"text":"hi"}]}}'
+    p.start_design("a title page", (300, 300), completion_fn=fake)
+    assert got and [r.id for r in got[0].regions] == ["z"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_designer_panel.py -v`
+Expected: FAIL (`ModuleNotFoundError: gui.layout.designer_panel`).
+
+- [ ] **Step 3: Create `gui/layout/designer_panel.py`**
+
+```python
+"""Designer panel: description/iterate input, status console, LLM worker."""
+import logging
+from typing import List, Dict, Optional, Callable
+
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QComboBox, QPlainTextEdit, QPushButton, QLabel,
+)
+from PySide6.QtCore import QThread, Signal
+
+from core.layout import designer
+from gui.llm_utils import DialogStatusConsole
+
+logger = logging.getLogger("imageai.layout.designer_panel")
+
+CONTENT_KINDS = ["children", "comic", "comic_strip", "magazine", "newspaper", "scientific", "custom"]
+
+
+class DesignerWorker(QThread):
+    progress = Signal(str)
+    proposed = Signal(object)  # DesignerResult
+    failed = Signal(str)
+
+    def __init__(self, messages: List[Dict], page_px, completion_fn: Callable[[List[Dict]], str], parent=None):
+        super().__init__(parent)
+        self._messages = messages
+        self._page_px = page_px
+        self._completion_fn = completion_fn
+
+    def run(self):
+        try:
+            self.progress.emit("Designing layout…")
+            result = designer.run_design(self._messages, self._page_px, self._completion_fn)
+            self.proposed.emit(result)
+        except Exception as e:  # noqa: BLE001 - surfaced to UI + log
+            logger.error("Designer worker failed: %s", e, exc_info=True)
+            self.failed.emit(str(e))
+
+
+class DesignerPanel(QWidget):
+    layoutProposed = Signal(object)  # DesignerResult
+
+    def __init__(self, config, parent=None):
+        super().__init__(parent)
+        self._config = config
+        self._worker: Optional[DesignerWorker] = None
+        self._build()
+
+    def _build(self):
+        lay = QVBoxLayout(self)
+
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Kind:"))
+        self.kind_combo = QComboBox()
+        self.kind_combo.addItems(CONTENT_KINDS)
+        row.addWidget(self.kind_combo)
+        row.addWidget(QLabel("Provider:"))
+        self.provider_combo = QComboBox()
+        self.model_combo = QComboBox()
+        self._populate_providers()
+        self.provider_combo.currentTextChanged.connect(self._on_provider_changed)
+        row.addWidget(self.provider_combo)
+        row.addWidget(self.model_combo)
+        lay.addLayout(row)
+
+        self.prompt_edit = QPlainTextEdit()
+        self.prompt_edit.setPlaceholderText(
+            "Describe the page, or type a change to the current layout…")
+        self.prompt_edit.setFixedHeight(70)
+        lay.addWidget(self.prompt_edit)
+
+        self.design_btn = QPushButton("Design / Iterate")
+        lay.addWidget(self.design_btn)
+
+        self.console = DialogStatusConsole("Designer")
+        lay.addWidget(self.console)
+
+    def _populate_providers(self):
+        from core.llm_models import get_all_provider_ids, get_provider_display_name
+        self.provider_combo.blockSignals(True)
+        self.provider_combo.clear()
+        self.provider_combo.addItems([get_provider_display_name(p) for p in get_all_provider_ids()])
+        saved = self._config.get_layout_llm_provider() if self._config else None
+        if saved:
+            idx = self.provider_combo.findText(saved, )
+            if idx < 0:
+                idx = self.provider_combo.findText(saved.capitalize())
+            if idx >= 0:
+                self.provider_combo.setCurrentIndex(idx)
+        self.provider_combo.blockSignals(False)
+        self._on_provider_changed(self.provider_combo.currentText())
+
+    def _on_provider_changed(self, provider: str):
+        from core.llm_models import get_provider_models
+        provider_map = {"claude": "anthropic", "google": "gemini", "lm studio": "lmstudio"}
+        pid = provider_map.get(provider.lower(), provider.lower())
+        self.model_combo.blockSignals(True)
+        self.model_combo.clear()
+        self.model_combo.addItems(get_provider_models(pid) or [])
+        self.model_combo.blockSignals(False)
+
+    def content_kind(self) -> str:
+        return self.kind_combo.currentText()
+
+    def start_design(self, user_text: str, page_px, current_regions=None,
+                     completion_fn: Optional[Callable[[List[Dict]], str]] = None):
+        kind = self.content_kind()
+        messages = designer.build_messages(kind, page_px, user_text, current_regions)
+        self.console.log(f"Designing ({kind}, {page_px[0]}x{page_px[1]}): {user_text}", "INFO")
+        if completion_fn is None:
+            provider = self.provider_combo.currentText()
+            model = self.model_combo.currentText()
+            cfg = self._config
+            completion_fn = lambda m: designer.run_completion(cfg, provider, model, m)
+        self._worker = DesignerWorker(messages, page_px, completion_fn)
+        self._worker.progress.connect(lambda msg: self.console.log(msg, "INFO"))
+        self._worker.proposed.connect(self._on_proposed)
+        self._worker.failed.connect(lambda err: self.console.log(err, "ERROR"))
+        if completion_fn is not None and self.sender() is None:
+            pass
+        self._worker.start()
+
+    def _on_proposed(self, result):
+        n = len(result.regions) if result.regions else 0
+        self.console.log(f"Proposed layout: {n} regions; {len(result.questions)} question(s).",
+                         "SUCCESS")
+        for q in result.questions:
+            self.console.log(f"Q: {q}", "WARNING")
+        self.layoutProposed.emit(result)
+```
+
+> Note for the implementer: `start_design` starts a `QThread` in real use. In the test `test_panel_start_design_emits_layout_proposed`, the injected `completion_fn` returns instantly and `proposed` is delivered via the worker; if the threaded delivery is flaky in headless CI, call `self._worker.wait(2000)` is NOT needed because the test connects before `start()` and the worker is trivial — but if `layoutProposed` is not received synchronously, change `start_design` to run the worker inline when a `completion_fn` is explicitly injected: replace `self._worker.start()` with:
+> ```python
+>         if completion_fn is not None:
+>             self._worker.run()      # synchronous for injected/test completions
+>         else:
+>             self._worker.start()
+> ```
+> Implement this inline-when-injected behavior (it is also correct for production, since production passes `completion_fn=None` and uses the thread). Remove the dead `if completion_fn is not None and self.sender() is None: pass` lines.
+
+- [ ] **Step 4: Apply the inline-when-injected fix and run tests**
+
+Edit `start_design` per the note: run the worker synchronously when `completion_fn` was explicitly provided, else `start()` the thread. Then:
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_designer_panel.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/layout/designer_panel.py tests/layout/test_designer_panel.py
+git commit -m "feat(layout): add designer panel + worker with status console"
+```
+
+---
+
+### Task 6: History window (GUI)
+
+**Files:**
+- Create: `gui/layout/history_window.py`
+- Test: `tests/layout/test_history_window.py`
+
+**Interfaces:**
+- Consumes: `core.layout.history.History`, `Snapshot`.
+- Produces:
+  - `history_window.HistoryWindow(history, parent=None)` — `QDialog`; signal `restoreRequested(str)` (snapshot id); method `set_history(history)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/layout/test_history_window.py
+from core.layout.models import DocumentSpec, PageSpec, Region
+from core.layout.history import History
+from gui.layout.history_window import HistoryWindow
+
+
+def _history_with(n):
+    doc = DocumentSpec(title="D", pages=[PageSpec(page_size_px=(100, 100),
+                       regions=[Region(id="r1", kind="text", text="v")])])
+    h = History(doc)
+    for i in range(n):
+        h.append(f"step {i}", snapshot_id=f"s{i}", timestamp=f"t{i}")
+    return h
+
+
+def test_window_lists_snapshots(qapp):
+    win = HistoryWindow(_history_with(3))
+    assert win.list_widget.count() == 3
+
+
+def test_restore_emits_snapshot_id(qapp):
+    win = HistoryWindow(_history_with(2))
+    got = []
+    win.restoreRequested.connect(lambda sid: got.append(sid))
+    win.list_widget.setCurrentRow(0)
+    win._on_restore()  # internal slot
+    assert got == ["s0"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_history_window.py -v`
+Expected: FAIL (`ModuleNotFoundError: gui.layout.history_window`).
+
+- [ ] **Step 3: Create `gui/layout/history_window.py`**
+
+```python
+"""Browsable iteration-history window for the layout designer."""
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QListWidget, QListWidgetItem, QPushButton, QLabel,
+)
+from PySide6.QtCore import Signal, Qt
+
+
+class HistoryWindow(QDialog):
+    restoreRequested = Signal(str)  # snapshot id
+
+    def __init__(self, history, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Layout History")
+        self.resize(420, 360)
+        self._history = history
+        self._build()
+        self.set_history(history)
+
+    def _build(self):
+        lay = QVBoxLayout(self)
+        lay.addWidget(QLabel("Iterations (newest last):"))
+        self.list_widget = QListWidget()
+        lay.addWidget(self.list_widget, 1)
+        row = QHBoxLayout()
+        self.restore_btn = QPushButton("Restore selected")
+        self.restore_btn.clicked.connect(self._on_restore)
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.reject)
+        row.addStretch(1)
+        row.addWidget(self.restore_btn)
+        row.addWidget(close_btn)
+        lay.addLayout(row)
+
+    def set_history(self, history):
+        self._history = history
+        self.list_widget.clear()
+        for s in history.snapshots():
+            label = f"[{s.timestamp}] {s.prompt[:60]}"
+            item = QListWidgetItem(label)
+            item.setData(Qt.UserRole, s.id)
+            self.list_widget.addItem(item)
+
+    def _on_restore(self):
+        item = self.list_widget.currentItem()
+        if item is None:
+            return
+        self.restoreRequested.emit(item.data(Qt.UserRole))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_history_window.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/layout/history_window.py tests/layout/test_history_window.py
+git commit -m "feat(layout): add browsable history window"
+```
+
+---
+
+### Task 7: Integrate designer + history into the Layout tab
+
+**Files:**
+- Modify: `gui/layout/layout_tab.py`
+- Test: `tests/layout/test_layout_tab_designer.py`
+
+**Interfaces:**
+- Consumes: `DesignerPanel` (`layoutProposed`), `History`, `HistoryWindow`, `designer.DesignerResult`.
+- Produces (on `LayoutTab`):
+  - `apply_designer_result(result, user_text="") -> None` — set current page regions from `result.regions`, re-render, append a history snapshot.
+  - `restore_snapshot(snapshot_id) -> None` — restore the document from history and re-render.
+  - attribute `self.history: History` (bound to `self.document`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/layout/test_layout_tab_designer.py
+from core.layout import designer
+from gui.layout.layout_tab import LayoutTab
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def test_apply_designer_result_sets_regions_and_snapshots(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    res = designer.DesignerResult(
+        questions=[], regions=[designer.Region(id="a", kind="image", bbox=(0, 0, 100, 100))],
+        raw="")
+    tab.apply_designer_result(res, user_text="one panel")
+    assert [r.id for r in tab.document.pages[0].regions] == ["a"]
+    assert len(tab.history.snapshots()) == 1
+    assert tab.history.snapshots()[0].prompt == "one panel"
+
+
+def test_restore_snapshot_reloads_document(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    # iteration 1
+    tab.apply_designer_result(
+        designer.DesignerResult(regions=[designer.Region(id="a", kind="image", bbox=(0, 0, 50, 50))]),
+        user_text="v1")
+    sid = tab.history.snapshots()[0].id
+    # iteration 2 (different regions)
+    tab.apply_designer_result(
+        designer.DesignerResult(regions=[designer.Region(id="b", kind="text", bbox=(0, 0, 50, 50), text="x")]),
+        user_text="v2")
+    assert [r.id for r in tab.document.pages[0].regions] == ["b"]
+    tab.restore_snapshot(sid)
+    assert [r.id for r in tab.document.pages[0].regions] == ["a"]  # back to v1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_layout_tab_designer.py -v`
+Expected: FAIL (`AttributeError`: `apply_designer_result`).
+
+- [ ] **Step 3: Wire designer + history into `gui/layout/layout_tab.py`**
+
+Add imports near the top (after the existing imports):
+
+```python
+from core.layout.history import History
+from gui.layout.designer_panel import DesignerPanel
+from gui.layout.history_window import HistoryWindow
+```
+
+In `_build`, add a "History…" toolbar button (extend the toolbar loop list) and embed the designer panel. Replace the toolbar loop list with:
+
+```python
+        for label, slot in [
+            ("New", self.new_document), ("Open…", self._open_dialog),
+            ("Save…", self._save_dialog), ("Export PDF…", self._export_dialog),
+            ("History…", self._open_history),
+        ]:
+```
+
+After `root.addWidget(self.page_setup)` add the designer panel:
+
+```python
+        self.designer = DesignerPanel(self.config)
+        self.designer.layoutProposed.connect(self._on_layout_proposed)
+        root.addWidget(self.designer)
+```
+
+In `new_document`, after building `self.document`, bind history:
+
+```python
+        self.history = History(self.document)
+```
+
+In `open_project_from` and after any place `self.document` is reassigned, rebind history. Update `open_project_from`:
+
+```python
+    def open_project_from(self, path: str):
+        self.document = project_io.load_project(path)
+        self.history = History(self.document)
+        self._refresh()
+```
+
+Add the new methods:
+
+```python
+    def _on_layout_proposed(self, result):
+        text = self.designer.prompt_edit.toPlainText().strip() if hasattr(self.designer, "prompt_edit") else ""
+        self.apply_designer_result(result, user_text=text)
+
+    def apply_designer_result(self, result, user_text: str = ""):
+        if not self.document or not self.document.pages:
+            return
+        self.document.content_kind = self.designer.content_kind() if hasattr(self, "designer") else self.document.content_kind
+        if result.regions:
+            self.document.pages[0].regions = list(result.regions)
+            self.history.append(user_text or "design")
+            self._refresh()
+
+    def restore_snapshot(self, snapshot_id: str):
+        restored = self.history.restore(snapshot_id)
+        self.document = restored
+        self.history = History(self.document)
+        self._refresh()
+
+    def _open_history(self):
+        win = HistoryWindow(self.history, self)
+        win.restoreRequested.connect(self.restore_snapshot)
+        win.exec()
+```
+
+Note: `new_document` must set `self.history` BEFORE `_refresh()` is first called, and `__init__` calls `new_document()` — so `self.history` exists after construction. Ensure the `self.history = History(self.document)` line is added inside `new_document` right after `self.document = DocumentSpec(...)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_layout_tab_designer.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Run the FULL suite + import smoke**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/ -q`
+Expected: all pass, no warnings.
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -c "from gui.layout import LayoutTab; print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gui/layout/layout_tab.py tests/layout/test_layout_tab_designer.py
+git commit -m "feat(layout): wire AI designer + history into the Layout tab"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 2):**
+- §5 AI designer: prompt (content_kind + page + current layout + JSON instruction) → Task 3; parse JSON/questions/regions with robust fences + fallback → Task 4; provider/model selection + status-console logging + QThread worker → Task 5; iterate loop (re-design with current regions, apply) → Tasks 5+7. ✓
+- §6 history: Snapshot model + persistence → Task 1; append/restore/branch manager → Task 2; browsable separate window → Task 6; wired (snapshot on each apply, restore) → Task 7. ✓
+- Cross-cutting LLM logging (console + file) → `DialogStatusConsole` in Task 5 + `logger` in Task 4. Model IDs via registry (`get_provider_models`/`get_provider_prefix`) → Task 4. ✓
+- Deferred (correctly, later phases): style system (Phase 3), content import (Phase 4), thumbnails in history (optional; `Snapshot.thumbnail` field exists, generation deferred).
+
+**Placeholder scan:** No TBD/TODO. The Task-5 note prescribes the exact `start_design` inline-when-injected change with code; Step 4 makes applying it explicit (not a vague "handle threading").
+
+**Type consistency:** `DesignerResult(questions, regions, raw)` used consistently in Tasks 4/5/7; `build_messages`/`run_design`/`parse_response` signatures match across Tasks 3/4/5; `History(document)` + `append`/`restore`/`snapshots` consistent across Tasks 2/6/7; `DesignerPanel.layoutProposed`/`content_kind`/`start_design` consistent across Tasks 5/7; `HistoryWindow(history)`/`restoreRequested`/`list_widget` consistent across Tasks 6/7. `Snapshot` fields consistent across Tasks 1/2.
+
+**Note for implementer:** the real LLM path (`run_completion`) is network and is intentionally NOT unit-tested; all designer logic is exercised through injected `completion_fn`. Do not add a live-network test.

--- a/Plans/2026-06-24-layout-ai-designer-phase3-completion.md
+++ b/Plans/2026-06-24-layout-ai-designer-phase3-completion.md
@@ -1,0 +1,64 @@
+# AI Layout Designer — Phase 3 (Style System + Templates) Completion Summary
+
+**Last Updated:** 2026-06-24 12:15
+**Branch:** `feat/layout-ai-designer-phase3` (stacked on Phase 2 branch / PR #19)
+**Status:** ✅ Phase 3 complete — all 5 tasks implemented, reviewed, and green.
+**Spec:** `Plans/2026-06-24-layout-ai-designer-design.md` (§7 style system, §8 templates)
+**Plan:** `Plans/2026-06-24-layout-ai-designer-phase3-style.md`
+
+---
+
+## What shipped
+
+A per-project **style system** and **shareable layout templates**:
+
+- **Project style** — named font **roles** (set varies by content kind: children → title/narration;
+  comic → logo_title/dialogue/sfx/caption; magazine → masthead/headline/body/caption/pull_quote;
+  scientific → title/heading/body/caption) plus a color palette, all seeded by content kind.
+- **Role-aware rendering** — a text region's `role` resolves to its `TextStyle` at render time
+  (explicit `text_style` overrides; unroled text falls back to the project's `default_text_role`).
+  One change to, e.g., the `dialogue` role re-renders every dialogue region.
+- **The AI designer now assigns roles** — the prompt lists the kind's role names and instructs the
+  model to set each text region's `role`, so AI-designed pages pick up the project fonts.
+- **Layout templates** (`.iailayout.json`) — export a document as a shareable template (structure +
+  shapes + styles + per-region prompt scaffolding, **content stripped**, history dropped) and import
+  it into a fresh, empty-content document.
+- **Style panel** — edit each role's font family / size / color.
+
+| Area | Module(s) |
+|---|---|
+| `ProjectStyle` + content-kind defaults + persistence | `core/layout/models.py`, `core/layout/styles.py`, `core/layout/schema.py` |
+| Role resolution at render (editor + PNG + PDF) | `core/layout/qt_renderer.py`, `gui/layout/canvas_widget.py` |
+| Designer emits `role` | `core/layout/designer.py` |
+| Template export/import | `core/layout/template_io.py` |
+| Style panel | `gui/layout/style_panel.py` |
+| Tab integration (seed, render, panel, templates) | `gui/layout/layout_tab.py` |
+
+## Tests
+
+19 new tests (75 total under `tests/layout/`), headless offscreen Qt: **75 passed, 0 warnings**.
+Backward compatible — Phase 1/2 project files (no `style` key) load and render unchanged.
+
+## Process
+
+Subagent-driven TDD (implementer + reviewer per task, fix loops) + a final whole-branch review
+(opus). The whole-branch review caught a real architectural gap — the style system was initially
+**dormant in the AI workflow** (the designer never emitted `role`, `default_text_role` was never
+read, and two document-mutation paths skipped style re-seeding). The consolidated fix made the
+system active: designer roles, render-time fallback, a centralized `_adopt_document` for every
+load path, and style re-seeding on content-kind change (guarded so user edits aren't clobbered).
+
+## Deferred / carry-forward (documented)
+
+- **Custom-role / palette editing UI** (spec §7 mentions user-added roles like "emphasis"): the
+  panel currently edits the *existing* role set's font; add/rename/remove roles + palette editing
+  is deferred.
+- **Region-level role picker** (an inspector to assign/override a region's role manually) — the AI
+  assigns roles now; manual per-region assignment is a later content-editing concern (Phase 4).
+- Minor polish in `.superpowers/sdd/progress.md` (e.g. promote the lazy `styles` import in
+  `designer.build_messages`; restore-snapshot resets the user-edit flag) — non-blocking.
+
+## Next
+
+Phase 4 — content MVP (import images + edit text into placeholders) — gets its own
+spec→plan→PR cycle, then Phase 5 (AI content + full bundles).

--- a/Plans/2026-06-24-layout-ai-designer-phase3-style.md
+++ b/Plans/2026-06-24-layout-ai-designer-phase3-style.md
@@ -1,0 +1,830 @@
+# AI Layout Designer — Phase 3 (Style System + Template Sharing) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-project **style system** — font roles (whose set varies by content kind) and a color palette — that text regions reference by role name, resolved at render time; plus **layout-template export/import** (`.iailayout.json`: structure + shapes + styles + prompt scaffolding, no content) so layouts can be shared.
+
+**Architecture:** A `ProjectStyle` (role-name → `TextStyle`, plus a color palette) lives on `DocumentSpec`. `core/layout/styles.py` seeds a sensible role set per content kind. The Qt renderer resolves a text region's `role` against the project style when the region has no explicit `text_style`. Template export strips content from a serialized document; import rebuilds an empty-content document with the same structure + style. A GUI `StylePanel` edits roles; the Layout tab seeds the style, renders with it, and gains template export/import.
+
+**Tech Stack:** Python 3.12, PySide6 (`QGraphicsScene`/`QFont`, widgets), dataclasses, `pytest` (headless offscreen Qt). Builds on Phase 1+2 (`core/layout/{models,schema,qt_renderer,project_io}.py`, `gui/layout/{layout_tab,canvas_widget}.py`).
+
+## Global Constraints
+
+- Spec: `Plans/2026-06-24-layout-ai-designer-design.md` (§7 style system, §8 sharing/templates). This plan implements **Phase 3**.
+- Python interpreter for all commands: `.venv_linux/bin/python` (never `.venv`). Run from repo root `/mnt/d/Documents/Code/GitHub/ImageAI`. **No `cd`.**
+- GUI tests run **headless** under `QT_QPA_PLATFORM=offscreen` (already in `tests/conftest.py`; session `qapp` fixture). No `pytest-qt`.
+- Fonts are referenced **by family name** (with fallbacks) — never embedded in templates (the spec defers font-file embedding to Phase 5 bundles).
+- Backward compatible: `ProjectStyle` is optional on `DocumentSpec`; documents without a style render exactly as before. Do not break the Phase 1+2 suite (56 tests must stay green).
+- Conventional Commits; commit subjects **≤72 chars**; commit after each task. Branch: `feat/layout-ai-designer-phase3`.
+- Extend Phase 1/2 modules in place; all new renderer/canvas params default to `None`.
+
+---
+
+## File Structure
+
+**Create:**
+- `core/layout/styles.py` — `default_style_for(content_kind) -> ProjectStyle`.
+- `core/layout/template_io.py` — `export_template` / `import_template`.
+- `gui/layout/style_panel.py` — `StylePanel(QWidget)`.
+- Tests: `tests/layout/test_styles.py`, `test_template_io.py`, `test_style_panel.py`, `test_layout_tab_style.py`; renderer-style assertions appended to `test_qt_renderer.py`.
+
+**Modify:**
+- `core/layout/models.py` — add `ProjectStyle`; add `style` field to `DocumentSpec`.
+- `core/layout/schema.py` — `project_style_to_dict`/`project_style_from_dict`; include `style` in `document_to_dict`/`document_from_dict`.
+- `core/layout/qt_renderer.py` — `build_scene`/`render_page_to_image`/`save_page_png` accept a `style`; `export_document_pdf` passes `doc.style`; `_add_text_region` resolves region `role` → project style.
+- `gui/layout/canvas_widget.py` — `load_page(page, style=None)`.
+- `gui/layout/layout_tab.py` — seed style on `new_document`; pass `self.document.style` when rendering; embed `StylePanel`; add Export/Import Template.
+
+---
+
+### Task 1: ProjectStyle model + content-kind defaults + persistence
+
+**Files:**
+- Modify: `core/layout/models.py`, `core/layout/schema.py`
+- Create: `core/layout/styles.py`
+- Test: `tests/layout/test_styles.py`
+
+**Interfaces:**
+- Consumes: Phase-1 `TextStyle`, `DocumentSpec`, `schema.document_to_dict`/`from_dict`.
+- Produces:
+  - `models.ProjectStyle(font_roles: dict[str, TextStyle] = {}, palette: dict[str, str] = {}, default_text_role: str = "body")`
+  - `DocumentSpec.style: ProjectStyle | None = None`
+  - `schema.project_style_to_dict(s)`/`project_style_from_dict(d)`; `document_to_dict`/`from_dict` round-trip `style`
+  - `styles.default_style_for(content_kind: str) -> ProjectStyle`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/layout/test_styles.py
+from core.layout.models import ProjectStyle, DocumentSpec, PageSpec, TextStyle
+from core.layout import schema, styles
+
+
+def test_default_style_for_comic_has_dialogue_role():
+    st = styles.default_style_for("comic")
+    assert "dialogue" in st.font_roles
+    assert isinstance(st.font_roles["dialogue"], TextStyle)
+    assert st.default_text_role == "dialogue"
+    assert st.palette.get("text")
+
+
+def test_default_style_for_children_has_title_and_narration():
+    st = styles.default_style_for("children")
+    assert set(["title", "narration"]).issubset(st.font_roles.keys())
+
+
+def test_default_style_for_unknown_kind_falls_back():
+    st = styles.default_style_for("totally-made-up")
+    assert "body" in st.font_roles and "title" in st.font_roles
+
+
+def test_project_style_roundtrip_via_schema():
+    doc = DocumentSpec(title="D", pages=[PageSpec(page_size_px=(100, 100))],
+                       style=styles.default_style_for("comic"))
+    again = schema.document_from_dict(schema.document_to_dict(doc))
+    assert again.style is not None
+    assert "dialogue" in again.style.font_roles
+    assert again.style.font_roles["dialogue"].size_px == doc.style.font_roles["dialogue"].size_px
+    assert again.style.default_text_role == "dialogue"
+
+
+def test_document_without_style_roundtrips_none():
+    doc = DocumentSpec(title="D", pages=[PageSpec(page_size_px=(100, 100))])
+    again = schema.document_from_dict(schema.document_to_dict(doc))
+    assert again.style is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_styles.py -v`
+Expected: FAIL (`ImportError`: cannot import `ProjectStyle`/`styles`).
+
+- [ ] **Step 3: Add `ProjectStyle` + `style` to `core/layout/models.py`**
+
+Add after `Snapshot` (before `migrate_legacy_blocks`, or near the other style dataclasses — anywhere after `TextStyle`):
+
+```python
+@dataclass
+class ProjectStyle:
+    """Per-project named font roles + color palette."""
+
+    font_roles: Dict[str, TextStyle] = field(default_factory=dict)
+    palette: Dict[str, str] = field(default_factory=dict)  # name -> hex
+    default_text_role: str = "body"
+```
+
+Extend `DocumentSpec` — add as the LAST field (after `history`):
+
+```python
+    style: Optional["ProjectStyle"] = None
+```
+
+- [ ] **Step 4: Create `core/layout/styles.py`**
+
+```python
+"""Default project style (font roles + palette) seeded by content kind."""
+from typing import Dict, List
+
+from core.layout.models import ProjectStyle, TextStyle
+
+
+def _role(family: List[str], size: int, weight: str = "regular", color: str = "#111111") -> TextStyle:
+    return TextStyle(family=list(family), size_px=size, weight=weight, color=color)
+
+
+_PALETTE = {"background": "#FFFFFF", "text": "#111111", "accent": "#2C7BE5"}
+
+_KIND_ROLES: Dict[str, Dict[str, TextStyle]] = {
+    "children": {
+        "title": _role(["Georgia", "DejaVu Serif"], 64, "bold"),
+        "narration": _role(["Georgia", "DejaVu Serif"], 36),
+    },
+    "comic": {
+        "logo_title": _role(["Impact", "DejaVu Sans"], 72, "black"),
+        "dialogue": _role(["Comic Sans MS", "DejaVu Sans"], 28),
+        "sfx": _role(["Impact", "DejaVu Sans"], 48, "black", "#D7263D"),
+        "caption": _role(["Arial", "DejaVu Sans"], 24),
+    },
+    "magazine": {
+        "masthead": _role(["Georgia", "DejaVu Serif"], 72, "bold"),
+        "headline": _role(["Georgia", "DejaVu Serif"], 48, "bold"),
+        "body": _role(["Arial", "DejaVu Sans"], 28),
+        "caption": _role(["Arial", "DejaVu Sans"], 22),
+        "pull_quote": _role(["Georgia", "DejaVu Serif"], 36, "semibold", "#2C7BE5"),
+    },
+    "scientific": {
+        "title": _role(["Times New Roman", "DejaVu Serif"], 56, "bold"),
+        "heading": _role(["Times New Roman", "DejaVu Serif"], 36, "bold"),
+        "body": _role(["Times New Roman", "DejaVu Serif"], 28),
+        "caption": _role(["Arial", "DejaVu Sans"], 22),
+    },
+}
+# aliases
+_KIND_ROLES["comic_strip"] = _KIND_ROLES["comic"]
+_KIND_ROLES["newspaper"] = _KIND_ROLES["magazine"]
+
+_DEFAULT_ROLE = {
+    "children": "narration", "comic": "dialogue", "comic_strip": "dialogue",
+    "magazine": "body", "newspaper": "body", "scientific": "body",
+}
+
+_FALLBACK_ROLES = {
+    "title": _role(["Arial", "DejaVu Sans"], 56, "bold"),
+    "body": _role(["Arial", "DejaVu Sans"], 28),
+}
+
+
+def default_style_for(content_kind: str) -> ProjectStyle:
+    roles = _KIND_ROLES.get(content_kind, _FALLBACK_ROLES)
+    return ProjectStyle(
+        font_roles={name: _role(ts.family, ts.size_px, ts.weight, ts.color)
+                    for name, ts in roles.items()},
+        palette=dict(_PALETTE),
+        default_text_role=_DEFAULT_ROLE.get(content_kind, "body"),
+    )
+```
+
+- [ ] **Step 5: Add style serialization to `core/layout/schema.py`**
+
+Add `ProjectStyle` and `TextStyle` to the `from core.layout.models import (...)` line if not already present. Add:
+
+```python
+def project_style_to_dict(s: "ProjectStyle") -> Dict:
+    return {
+        "font_roles": {name: asdict(ts) for name, ts in s.font_roles.items()},
+        "palette": dict(s.palette),
+        "default_text_role": s.default_text_role,
+    }
+
+
+def project_style_from_dict(d: Dict) -> "ProjectStyle":
+    from core.layout.models import ProjectStyle
+    return ProjectStyle(
+        font_roles={name: TextStyle(**ts) for name, ts in d.get("font_roles", {}).items()},
+        palette=dict(d.get("palette", {})),
+        default_text_role=d.get("default_text_role", "body"),
+    )
+```
+
+In `document_to_dict`, add:
+
+```python
+        "style": project_style_to_dict(doc.style) if doc.style else None,
+```
+
+In `document_from_dict`, add to the `DocumentSpec(...)` construction:
+
+```python
+        style=project_style_from_dict(d["style"]) if d.get("style") else None,
+```
+
+- [ ] **Step 6: Run tests + full suite**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_styles.py -v`
+Expected: PASS (5 passed).
+Run: `.venv_linux/bin/python -m pytest tests/layout/ -q`
+Expected: all pass (61 now), 0 warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/layout/models.py core/layout/styles.py core/layout/schema.py tests/layout/test_styles.py
+git commit -m "feat(layout): add ProjectStyle model, content-kind defaults, persistence"
+```
+
+---
+
+### Task 2: Renderer + canvas resolve font roles
+
+**Files:**
+- Modify: `core/layout/qt_renderer.py`, `gui/layout/canvas_widget.py`
+- Test: `tests/layout/test_qt_renderer.py` (append)
+
+**Interfaces:**
+- Consumes: `ProjectStyle`, Phase-1 `build_scene`/render/export, `Region.role`/`text_style`.
+- Produces:
+  - `qt_renderer.build_scene(page, *, selectable=False, style=None)`
+  - `qt_renderer.render_page_to_image(page, *, style=None)`; `save_page_png(page, path, *, style=None)`
+  - `export_document_pdf(doc, path, dpi=300)` resolves `doc.style`
+  - text regions with a `role` and no `text_style` render using `style.font_roles[role]`
+  - `canvas_widget.CanvasWidget.load_page(page, style=None)`
+
+- [ ] **Step 1: Write the failing test (append to `tests/layout/test_qt_renderer.py`)**
+
+```python
+def test_text_region_resolves_font_role_from_style(qapp):
+    from core.layout.models import Region, PageSpec, ProjectStyle, TextStyle
+    from core.layout import qt_renderer
+    from PySide6.QtWidgets import QGraphicsSimpleTextItem
+    style = ProjectStyle(font_roles={"title": TextStyle(family=["Georgia"], size_px=64, weight="bold")})
+    page = PageSpec(page_size_px=(400, 200), regions=[
+        Region(id="t", kind="text", bbox=(0, 0, 400, 100), text="Hi", role="title")])
+    scene = qt_renderer.build_scene(page, style=style)
+    texts = [it for it in scene.items() if isinstance(it, QGraphicsSimpleTextItem)]
+    assert texts, "expected a text item"
+    f = texts[0].font()
+    assert f.pixelSize() == 64
+    assert f.bold() is True
+
+
+def test_explicit_text_style_overrides_role(qapp):
+    from core.layout.models import Region, PageSpec, ProjectStyle, TextStyle
+    from core.layout import qt_renderer
+    from PySide6.QtWidgets import QGraphicsSimpleTextItem
+    style = ProjectStyle(font_roles={"title": TextStyle(family=["Georgia"], size_px=64)})
+    page = PageSpec(page_size_px=(400, 200), regions=[
+        Region(id="t", kind="text", bbox=(0, 0, 400, 100), text="Hi", role="title",
+               text_style=TextStyle(family=["Arial"], size_px=20))])
+    scene = qt_renderer.build_scene(page, style=style)
+    texts = [it for it in scene.items() if isinstance(it, QGraphicsSimpleTextItem)]
+    assert texts[0].font().pixelSize() == 20  # explicit style wins
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_qt_renderer.py -k font_role -v`
+Expected: FAIL (`build_scene() got an unexpected keyword argument 'style'`).
+
+- [ ] **Step 3: Update `core/layout/qt_renderer.py`**
+
+Replace `_add_text_region` with (rename the local style var to `ts`; add a `project_style` param; resolve role):
+
+```python
+def _add_text_region(scene: QGraphicsScene, r: Region, selectable: bool, project_style=None) -> None:
+    x, y, w, h = r.bbox
+    box = QGraphicsRectItem(QRectF(x, y, w, h))
+    box.setBrush(QBrush(Qt.transparent))
+    box.setPen(QPen(QColor("#CED4DA"), 1, Qt.DashLine))
+    _apply_flags(box, selectable, r.id)
+    scene.addItem(box)
+
+    text = QGraphicsSimpleTextItem(r.text or "")
+    ts = r.text_style
+    if ts is None and project_style is not None and r.role:
+        ts = project_style.font_roles.get(r.role)
+    font = QFont()
+    if ts:
+        if ts.family:
+            font.setFamily(ts.family[0])
+        if ts.size_px:
+            font.setPixelSize(ts.size_px)
+        font.setBold(ts.weight in ("bold", "black", "semibold"))
+        font.setItalic(ts.italic)
+        text.setBrush(QBrush(QColor(ts.color)))
+    text.setFont(font)
+    text.setPos(x + 2, y + 2)
+    scene.addItem(text)
+```
+
+Update `build_scene` signature + the text-region call:
+
+```python
+def build_scene(page: PageSpec, *, selectable: bool = False, style=None) -> QGraphicsScene:
+    pw, ph = page.page_size_px
+    scene = QGraphicsScene(0, 0, pw, ph)
+    scene.setBackgroundBrush(QBrush(QColor(_resolve_bg(page))))
+    for r in sorted(page.regions, key=lambda rr: rr.z):
+        if r.kind == "image":
+            _add_image_region(scene, r, selectable)
+        else:
+            _add_text_region(scene, r, selectable, project_style=style)
+    return scene
+```
+
+Update `render_page_to_image` and `save_page_png`:
+
+```python
+def render_page_to_image(page: PageSpec, *, style=None) -> QImage:
+    pw, ph = page.page_size_px
+    scene = build_scene(page, style=style)
+    img = QImage(pw, ph, QImage.Format_ARGB32)
+    img.fill(QColor(_resolve_bg(page)))
+    painter = QPainter(img)
+    painter.setRenderHint(QPainter.Antialiasing, True)
+    scene.render(painter, QRectF(0, 0, pw, ph), QRectF(0, 0, pw, ph))
+    painter.end()
+    return img
+
+
+def save_page_png(page: PageSpec, path: str, *, style=None) -> None:
+    render_page_to_image(page, style=style).save(path, "PNG")
+```
+
+In `export_document_pdf`, change the scene build inside the loop to pass the document style:
+
+```python
+        scene = build_scene(page, style=doc.style)
+```
+
+- [ ] **Step 4: Update `gui/layout/canvas_widget.py` `load_page`**
+
+Change the signature and the `build_scene` call:
+
+```python
+    def load_page(self, page: PageSpec, style=None) -> None:
+        old = self._scene
+        if old is not None:
+            try:
+                old.selectionChanged.disconnect(self._on_selection_changed)
+            except (RuntimeError, TypeError):
+                pass
+        self._page = page
+        scene = qt_renderer.build_scene(page, selectable=True, style=style)
+        scene.setParent(self)
+        scene.selectionChanged.connect(self._on_selection_changed)
+        self.setScene(scene)
+        self._scene = scene
+        self.fitInView(scene.sceneRect(), Qt.KeepAspectRatio)
+```
+
+- [ ] **Step 5: Run tests + full suite**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_qt_renderer.py -v`
+Expected: PASS (all, incl. 2 new).
+Run: `.venv_linux/bin/python -m pytest tests/layout/ -q`
+Expected: all pass, 0 warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/layout/qt_renderer.py gui/layout/canvas_widget.py tests/layout/test_qt_renderer.py
+git commit -m "feat(layout): resolve text-region font roles from project style"
+```
+
+---
+
+### Task 3: Template export / import
+
+**Files:**
+- Create: `core/layout/template_io.py`
+- Test: `tests/layout/test_template_io.py`
+
+**Interfaces:**
+- Consumes: `schema.document_to_dict`/`document_from_dict`.
+- Produces:
+  - `template_io.export_template(doc: DocumentSpec, path: str) -> None` (strips content, keeps geometry/shape/style/prompt/role + ProjectStyle; drops history)
+  - `template_io.import_template(path: str) -> DocumentSpec` (structure + style, empty content)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/layout/test_template_io.py
+from core.layout.models import Region, PageSpec, DocumentSpec
+from core.layout import template_io, styles
+
+
+def _doc():
+    page = PageSpec(page_size_px=(500, 500), regions=[
+        Region(id="img", kind="image", bbox=(0, 0, 200, 200), image_ref="/a.png",
+               prompt="a red car"),
+        Region(id="txt", kind="text", bbox=(0, 220, 500, 60), text="My Title", role="title"),
+    ])
+    doc = DocumentSpec(title="Proj", content_kind="comic", pages=[page],
+                       style=styles.default_style_for("comic"))
+    return doc
+
+
+def test_export_strips_content_keeps_structure(tmp_path):
+    p = tmp_path / "t.iailayout.json"
+    template_io.export_template(_doc(), str(p))
+    loaded = template_io.import_template(str(p))
+    regions = loaded.pages[0].regions
+    # geometry + shape + role + prompt preserved
+    assert [r.id for r in regions] == ["img", "txt"]
+    assert regions[0].bbox == (0, 0, 200, 200)
+    assert regions[0].prompt == "a red car"
+    assert regions[1].role == "title"
+    # content stripped
+    assert regions[0].image_ref is None
+    assert regions[1].text == ""
+    # style preserved
+    assert loaded.style is not None and "dialogue" in loaded.style.font_roles
+    # content_kind preserved, history dropped
+    assert loaded.content_kind == "comic"
+    assert loaded.history == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_template_io.py -v`
+Expected: FAIL (`ModuleNotFoundError: core.layout.template_io`).
+
+- [ ] **Step 3: Create `core/layout/template_io.py`**
+
+```python
+"""Layout-template export/import: shareable structure + style, no content."""
+import json
+from pathlib import Path
+
+from core.layout.models import DocumentSpec
+from core.layout import schema
+
+
+def export_template(doc: DocumentSpec, path: str) -> None:
+    data = schema.document_to_dict(doc)
+    data["history"] = []  # templates carry no iteration history
+    for page in data.get("pages", []):
+        for region in page.get("regions", []):
+            region["text"] = ""        # strip text content
+            region["image_ref"] = None  # strip image content
+            # keep: id, kind, shape, bbox, points, z, role, prompt, styles
+    Path(path).write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def import_template(path: str) -> DocumentSpec:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return schema.document_from_dict(data)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_template_io.py -v`
+Expected: PASS (1 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/template_io.py tests/layout/test_template_io.py
+git commit -m "feat(layout): add layout-template export/import (.iailayout.json)"
+```
+
+---
+
+### Task 4: Style panel (GUI)
+
+**Files:**
+- Create: `gui/layout/style_panel.py`
+- Test: `tests/layout/test_style_panel.py`
+
+**Interfaces:**
+- Consumes: `ProjectStyle`, `TextStyle`.
+- Produces:
+  - `style_panel.StylePanel(parent=None)` — `QWidget`; signal `styleChanged(object)` (ProjectStyle); methods `set_style(style)`, `style() -> ProjectStyle`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/layout/test_style_panel.py
+from core.layout.models import ProjectStyle, TextStyle
+from gui.layout.style_panel import StylePanel
+
+
+def _style():
+    return ProjectStyle(font_roles={
+        "title": TextStyle(family=["Georgia"], size_px=64, weight="bold"),
+        "body": TextStyle(family=["Arial"], size_px=28)},
+        palette={"text": "#111111"}, default_text_role="body")
+
+
+def test_panel_lists_roles(qapp):
+    p = StylePanel()
+    p.set_style(_style())
+    assert p.role_combo.count() == 2
+
+
+def test_editing_family_updates_style_and_emits(qapp):
+    p = StylePanel()
+    p.set_style(_style())
+    got = []
+    p.styleChanged.connect(lambda s: got.append(s))
+    p.role_combo.setCurrentText("title")
+    p.family_edit.setText("Impact")
+    p._on_field_changed()  # internal slot
+    assert p.style().font_roles["title"].family[0] == "Impact"
+    assert got and got[-1].font_roles["title"].family[0] == "Impact"
+
+
+def test_editing_size(qapp):
+    p = StylePanel()
+    p.set_style(_style())
+    p.role_combo.setCurrentText("body")
+    p.size_spin.setValue(40)
+    p._on_field_changed()
+    assert p.style().font_roles["body"].size_px == 40
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_style_panel.py -v`
+Expected: FAIL (`ModuleNotFoundError: gui.layout.style_panel`).
+
+- [ ] **Step 3: Create `gui/layout/style_panel.py`**
+
+```python
+"""Project style editor: per-role font family/size/color + palette."""
+from PySide6.QtWidgets import (
+    QWidget, QFormLayout, QComboBox, QLineEdit, QSpinBox, QLabel,
+)
+from PySide6.QtCore import Signal
+
+from core.layout.models import ProjectStyle, TextStyle
+
+
+class StylePanel(QWidget):
+    styleChanged = Signal(object)  # ProjectStyle
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._style = ProjectStyle()
+        self._build()
+
+    def _build(self):
+        form = QFormLayout(self)
+        self.role_combo = QComboBox()
+        self.role_combo.currentTextChanged.connect(self._on_role_selected)
+        form.addRow(QLabel("Role:"), self.role_combo)
+        self.family_edit = QLineEdit()
+        self.family_edit.editingFinished.connect(self._on_field_changed)
+        form.addRow(QLabel("Font family:"), self.family_edit)
+        self.size_spin = QSpinBox()
+        self.size_spin.setRange(1, 2000)
+        self.size_spin.valueChanged.connect(self._on_field_changed)
+        form.addRow(QLabel("Size (px):"), self.size_spin)
+        self.color_edit = QLineEdit()
+        self.color_edit.editingFinished.connect(self._on_field_changed)
+        form.addRow(QLabel("Color (hex):"), self.color_edit)
+
+    def set_style(self, style: ProjectStyle):
+        self._style = style
+        self.role_combo.blockSignals(True)
+        self.role_combo.clear()
+        self.role_combo.addItems(sorted(style.font_roles.keys()))
+        self.role_combo.blockSignals(False)
+        if self.role_combo.count():
+            self.role_combo.setCurrentIndex(0)
+            self._load_role(self.role_combo.currentText())
+
+    def style(self) -> ProjectStyle:
+        return self._style
+
+    def _load_role(self, role: str):
+        ts = self._style.font_roles.get(role)
+        if ts is None:
+            return
+        for w in (self.family_edit, self.size_spin, self.color_edit):
+            w.blockSignals(True)
+        self.family_edit.setText(ts.family[0] if ts.family else "")
+        self.size_spin.setValue(ts.size_px)
+        self.color_edit.setText(ts.color)
+        for w in (self.family_edit, self.size_spin, self.color_edit):
+            w.blockSignals(False)
+
+    def _on_role_selected(self, role: str):
+        if role:
+            self._load_role(role)
+
+    def _on_field_changed(self):
+        role = self.role_combo.currentText()
+        if not role or role not in self._style.font_roles:
+            return
+        old = self._style.font_roles[role]
+        self._style.font_roles[role] = TextStyle(
+            family=[self.family_edit.text() or "Arial"],
+            weight=old.weight, italic=old.italic,
+            size_px=self.size_spin.value(),
+            line_height=old.line_height,
+            color=self.color_edit.text() or "#111111",
+            align=old.align, wrap=old.wrap, letter_spacing=old.letter_spacing,
+        )
+        self.styleChanged.emit(self._style)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_style_panel.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/layout/style_panel.py tests/layout/test_style_panel.py
+git commit -m "feat(layout): add project style panel (font roles editor)"
+```
+
+---
+
+### Task 5: Integrate style + templates into the Layout tab
+
+**Files:**
+- Modify: `gui/layout/layout_tab.py`
+- Test: `tests/layout/test_layout_tab_style.py`
+
+**Interfaces:**
+- Consumes: `styles.default_style_for`, `StylePanel`, `template_io`, `qt_renderer` (style-aware).
+- Produces (on `LayoutTab`):
+  - `new_document` seeds `self.document.style = styles.default_style_for(content_kind)`
+  - `_refresh` renders with `self.document.style`
+  - `apply_style(style) -> None` (set + re-render)
+  - `export_template_to(path)` / `import_template_from(path)`
+  - a `StylePanel` (`self.style_panel`) wired so its `styleChanged` calls `apply_style`
+  - toolbar "Export Template…" / "Import Template…" entries
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/layout/test_layout_tab_style.py
+from gui.layout.layout_tab import LayoutTab
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def test_new_document_has_style(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    assert tab.document.style is not None
+    assert tab.document.style.font_roles  # non-empty role set
+
+
+def test_apply_style_updates_document(qapp):
+    from core.layout import styles
+    tab = LayoutTab(config=FakeConfig())
+    st = styles.default_style_for("comic")
+    tab.apply_style(st)
+    assert "dialogue" in tab.document.style.font_roles
+
+
+def test_export_then_import_template_roundtrip(qapp, tmp_path):
+    from core.layout import designer
+    tab = LayoutTab(config=FakeConfig())
+    tab.apply_designer_result(
+        designer.DesignerResult(regions=[designer.Region(id="a", kind="text",
+                                bbox=(0, 0, 100, 30), text="Hi", role="title")]),
+        user_text="v1")
+    p = tmp_path / "t.iailayout.json"
+    tab.export_template_to(str(p))
+    tab2 = LayoutTab(config=FakeConfig())
+    tab2.import_template_from(str(p))
+    regions = tab2.document.pages[0].regions
+    assert [r.id for r in regions] == ["a"]
+    assert regions[0].text == ""          # content stripped
+    assert regions[0].role == "title"     # structure kept
+    assert tab2.document.style is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_layout_tab_style.py -v`
+Expected: FAIL (`AttributeError`: `apply_style`/`export_template_to`, or `style is None`).
+
+- [ ] **Step 3: Wire style + templates into `gui/layout/layout_tab.py`**
+
+Add imports near the others:
+
+```python
+from core.layout import styles, template_io
+from gui.layout.style_panel import StylePanel
+```
+
+Extend the toolbar loop list (add two entries):
+
+```python
+            ("Export Template…", self._export_template_dialog),
+            ("Import Template…", self._import_template_dialog),
+```
+
+After embedding the designer panel in `_build`, add the style panel:
+
+```python
+        self.style_panel = StylePanel()
+        self.style_panel.styleChanged.connect(self.apply_style)
+        root.addWidget(self.style_panel)
+```
+
+In `new_document`, after building `self.document` and binding history, seed + load the style:
+
+```python
+        self.document.style = styles.default_style_for(self.document.content_kind)
+        if hasattr(self, "style_panel"):
+            self.style_panel.set_style(self.document.style)
+```
+
+(Place this BEFORE `self._refresh()`.)
+
+Update `_refresh` to render with the style:
+
+```python
+    def _refresh(self):
+        if self.document and self.document.pages:
+            self.canvas.load_page(self.document.pages[0], self.document.style)
+            self.status.setText(f"{self.document.title} — {self.document.pages[0].page_size_px}")
+        self.documentChanged.emit()
+```
+
+In `open_project_from` and `import_template_from`, after setting `self.document`, refresh the style panel. Add the new methods:
+
+```python
+    def apply_style(self, style):
+        if self.document is None:
+            return
+        self.document.style = style
+        self._refresh()
+
+    def export_template_to(self, path: str):
+        template_io.export_template(self.document, path)
+        self.status.setText(f"Exported template {path}")
+
+    def import_template_from(self, path: str):
+        self.document = template_io.import_template(path)
+        from core.layout.history import History
+        self.history = History(self.document)
+        if self.document.style is None:
+            self.document.style = styles.default_style_for(self.document.content_kind)
+        if hasattr(self, "style_panel") and self.document.style:
+            self.style_panel.set_style(self.document.style)
+        self._refresh()
+
+    def _export_template_dialog(self):
+        from PySide6.QtWidgets import QFileDialog
+        path, _ = QFileDialog.getSaveFileName(self, "Export Template", "",
+                                              "ImageAI Layout Template (*.iailayout.json)")
+        if path:
+            self.export_template_to(path)
+
+    def _import_template_dialog(self):
+        from PySide6.QtWidgets import QFileDialog
+        path, _ = QFileDialog.getOpenFileName(self, "Import Template", "",
+                                              "ImageAI Layout Template (*.iailayout.json)")
+        if path:
+            self.import_template_from(path)
+```
+
+Also update `open_project_from` to refresh the style panel (add after `self.history = History(self.document)`):
+
+```python
+        if hasattr(self, "style_panel") and self.document.style:
+            self.style_panel.set_style(self.document.style)
+```
+
+- [ ] **Step 4: Run tests + full suite + import smoke**
+
+Run: `.venv_linux/bin/python -m pytest tests/layout/test_layout_tab_style.py -v`
+Expected: PASS (3 passed).
+Run: `.venv_linux/bin/python -m pytest tests/layout/ -q`
+Expected: all pass, 0 warnings.
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -c "from gui.layout import LayoutTab; print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/layout/layout_tab.py tests/layout/test_layout_tab_style.py
+git commit -m "feat(layout): wire style panel + template export/import into tab"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 3):**
+- §7 style system: `ProjectStyle` (roles + palette) + per-kind defaults → Task 1; role resolution at render → Task 2; editable roles → Task 4; project-wide application + seeding → Task 5. Font roles whose set varies by kind → `styles.default_style_for`. ✓
+- §8 template sharing: `.iailayout.json` structure+style, no content → Task 3; tab export/import → Task 5. ✓
+- Fonts by family name (no embedding) — `TextStyle.family` lists; templates carry names only. ✓
+- Deferred (later phases): full bundles with embedded fonts (Phase 5); AI font/color suggestions (the designer could propose a `style` — deferred); palette editing UI beyond the per-role color (Phase 3 ships role font + color; palette-name editing is minimal).
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code. The `_doc()` helper's `history.append.__self__` line in Task 3 is explicitly flagged as removable.
+
+**Type consistency:** `ProjectStyle(font_roles, palette, default_text_role)` used identically across Tasks 1/2/4/5; `default_style_for(kind)` consistent 1/5; `build_scene(..., style=)` / `load_page(page, style)` consistent 2/5; `export_template`/`import_template` consistent 3/5; `StylePanel.set_style`/`style`/`styleChanged`/`role_combo`/`family_edit`/`size_spin` consistent 4/5; `apply_style`/`export_template_to`/`import_template_from` consistent in Task 5 test + impl.

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -125,11 +125,14 @@ def run_completion(config, provider: str, model: str, messages: List[Dict],
         raise RuntimeError(f"No models available for provider {provider!r}")
     prefix = get_provider_prefix(pid)
     full_model = f"{prefix}{model_name}" if prefix else model_name
-    logger.info("Designer LLM call: model=%s temp=%s", full_model, temperature)
+    logger.info("Designer LLM request: provider=%s model=%s temperature=%s\nmessages=%s",
+                provider, full_model, temperature, messages)
     kwargs = {"model": full_model, "messages": messages, "temperature": temperature}
     if api_key:
         kwargs["api_key"] = api_key
     resp = litellm.completion(**kwargs)
     if not resp or not resp.choices:
         raise RuntimeError("Empty LLM response")
-    return resp.choices[0].message.content or ""
+    content = resp.choices[0].message.content or ""
+    logger.info("Designer LLM response:\n%s", content)
+    return content

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -1,0 +1,48 @@
+"""AI layout designer: prompt building, response parsing, and the LLM call."""
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional, Tuple, Callable
+
+from core.layout.models import Region
+from core.layout import schema
+
+logger = logging.getLogger("imageai.layout.designer")
+
+_SYSTEM = (
+    "You are a page-layout designer. You design the GEOMETRY of a single page as "
+    "regions (image or text placeholders). You never write the actual content. "
+    "Respond with a SINGLE JSON object and nothing else."
+)
+
+
+def build_messages(content_kind: str, page_px: Tuple[int, int], user_text: str,
+                   current_regions: Optional[List[Region]] = None) -> List[Dict[str, str]]:
+    pw, ph = page_px
+    current = ""
+    if current_regions:
+        current = (
+            "<current_layout>\n"
+            + json.dumps([schema.region_to_dict(r) for r in current_regions], indent=0)
+            + "\n</current_layout>\n"
+        )
+    user = (
+        f"<context>\n"
+        f"content_kind: {content_kind}\n"
+        f"page_pixels: {pw} x {ph} (x,y origin top-left; all coordinates in pixels)\n"
+        f"</context>\n"
+        f"{current}"
+        f"<request>\n{user_text}\n</request>\n"
+        f"<instructions>\n"
+        f"Return a JSON object with optional keys:\n"
+        f'  "questions": [strings]   // ask for missing detail if needed\n'
+        f'  "layout": {{ "regions": [ {{\n'
+        f'      "id": string, "kind": "image"|"text", "shape": "rect"|"polygon",\n'
+        f'      "bbox": [x,y,w,h], "points": [[x,y],...] (polygon only),\n'
+        f'      "z": int, "text": string (text only) }} ] }}\n'
+        f"All coordinates MUST be within the page ({pw} x {ph}). Prefer 'rect' unless the\n"
+        f"request implies panels that flow into each other (then use 'polygon'). You may\n"
+        f"return questions, a layout, or both.\n"
+        f"</instructions>"
+    )
+    return [{"role": "system", "content": _SYSTEM}, {"role": "user", "content": user}]

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -46,3 +46,87 @@ def build_messages(content_kind: str, page_px: Tuple[int, int], user_text: str,
         f"</instructions>"
     )
     return [{"role": "system", "content": _SYSTEM}, {"role": "user", "content": user}]
+
+
+@dataclass
+class DesignerResult:
+    questions: List[str] = field(default_factory=list)
+    regions: Optional[List[Region]] = None
+    raw: str = ""
+
+
+def fallback_result(page_px: Tuple[int, int]) -> DesignerResult:
+    pw, ph = page_px
+    region = Region(id="region1", kind="image", shape="rect",
+                    bbox=(0, 0, pw, ph), name="full page")
+    return DesignerResult(
+        questions=["I couldn't parse a layout — here's a single full-page frame. "
+                   "Tell me how to divide it."],
+        regions=[region], raw="")
+
+
+def parse_response(content: str, page_px: Tuple[int, int]) -> DesignerResult:
+    from gui.llm_utils import LLMResponseParser
+    data = LLMResponseParser.parse_json_response(content, expected_type=dict)
+    if not isinstance(data, dict):
+        logger.warning("Designer: unparseable response, using fallback")
+        return fallback_result(page_px)
+    questions = [str(q) for q in data.get("questions", []) if str(q).strip()]
+    regions = None
+    layout = data.get("layout")
+    if isinstance(layout, dict) and isinstance(layout.get("regions"), list):
+        regions = []
+        for i, rd in enumerate(layout["regions"]):
+            if not isinstance(rd, dict):
+                continue
+            rd.setdefault("id", f"region{i + 1}")
+            rd.setdefault("kind", "image")
+            region = schema.region_from_dict(rd)
+            regions.append(schema.normalize_region(region, page_px))
+        if not regions:
+            regions = None
+    if regions is None and not questions:
+        return fallback_result(page_px)
+    return DesignerResult(questions=questions, regions=regions, raw=content)
+
+
+def run_design(messages: List[Dict], page_px: Tuple[int, int],
+               completion_fn: Callable[[List[Dict]], str]) -> DesignerResult:
+    content = completion_fn(messages)
+    return parse_response(content or "", page_px)
+
+
+def run_completion(config, provider: str, model: str, messages: List[Dict],
+                   temperature: float = 0.4) -> str:
+    """Real LLM call (mirrors TextGenerationWorker). Not unit-tested (network)."""
+    from gui.llm_utils import LiteLLMHandler
+    from core.llm_models import get_provider_models, get_provider_prefix
+    ok, litellm = LiteLLMHandler.setup_litellm(enable_console_logging=True)
+    if not ok or litellm is None:
+        raise RuntimeError("Failed to initialize LiteLLM")
+    provider = provider or (config.get_layout_llm_provider() if config else "google")
+    provider_map = {"google": "google", "anthropic": "anthropic", "openai": "openai",
+                    "ollama": "ollama", "lm studio": "lmstudio"}
+    pid_api = provider_map.get(provider.lower(), provider.lower())
+    pid = "gemini" if pid_api == "google" else pid_api
+    api_key = None
+    auth_mode = "api-key"
+    if pid_api == "google" and config is not None:
+        am = config.get("auth_mode", "api-key")
+        auth_mode = "gcloud" if am in ("gcloud", "Google Cloud Account") else "api-key"
+    if auth_mode == "api-key" and config is not None:
+        api_key = config.get_api_key(pid_api)
+    models = get_provider_models(pid)
+    model_name = model or (models[0] if models else None)
+    if not model_name:
+        raise RuntimeError(f"No models available for provider {provider!r}")
+    prefix = get_provider_prefix(pid)
+    full_model = f"{prefix}{model_name}" if prefix else model_name
+    logger.info("Designer LLM call: model=%s temp=%s", full_model, temperature)
+    kwargs = {"model": full_model, "messages": messages, "temperature": temperature}
+    if api_key:
+        kwargs["api_key"] = api_key
+    resp = litellm.completion(**kwargs)
+    if not resp or not resp.choices:
+        raise RuntimeError("Empty LLM response")
+    return resp.choices[0].message.content or ""

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -71,7 +71,9 @@ def parse_response(content: str, page_px: Tuple[int, int]) -> DesignerResult:
     if not isinstance(data, dict):
         logger.warning("Designer: unparseable response, using fallback")
         return fallback_result(page_px)
-    questions = [str(q) for q in data.get("questions", []) if str(q).strip()]
+    raw_questions = data.get("questions", [])
+    questions = ([str(q) for q in raw_questions if str(q).strip()]
+                 if isinstance(raw_questions, list) else [])
     regions = None
     layout = data.get("layout")
     if isinstance(layout, dict) and isinstance(layout.get("regions"), list):
@@ -79,6 +81,7 @@ def parse_response(content: str, page_px: Tuple[int, int]) -> DesignerResult:
         for i, rd in enumerate(layout["regions"]):
             if not isinstance(rd, dict):
                 continue
+            rd = dict(rd)  # don't mutate the parsed dict
             rd.setdefault("id", f"region{i + 1}")
             rd.setdefault("kind", "image")
             region = schema.region_from_dict(rd)

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -19,6 +19,9 @@ _SYSTEM = (
 def build_messages(content_kind: str, page_px: Tuple[int, int], user_text: str,
                    current_regions: Optional[List[Region]] = None) -> List[Dict[str, str]]:
     pw, ph = page_px
+    from core.layout import styles
+    role_names = sorted(styles.default_style_for(content_kind).font_roles.keys())
+    roles = ", ".join(role_names)
     current = ""
     if current_regions:
         current = (
@@ -39,8 +42,9 @@ def build_messages(content_kind: str, page_px: Tuple[int, int], user_text: str,
         f'  "layout": {{ "regions": [ {{\n'
         f'      "id": string, "kind": "image"|"text", "shape": "rect"|"polygon",\n'
         f'      "bbox": [x,y,w,h], "points": [[x,y],...] (polygon only),\n'
-        f'      "z": int, "text": string (text only) }} ] }}\n'
+        f'      "z": int, "role": string, "text": string (text only) }} ] }}\n'
         f"All coordinates MUST be within the page ({pw} x {ph}). Prefer 'rect' unless the\n"
+        f"Each text region MUST set \"role\" to one of: {roles}.\n"
         f"request implies panels that flow into each other (then use 'polygon'). You may\n"
         f"return questions, a layout, or both.\n"
         f"</instructions>"

--- a/core/layout/history.py
+++ b/core/layout/history.py
@@ -1,0 +1,47 @@
+"""Iteration-history manager for the layout designer."""
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from core.layout.models import DocumentSpec, Snapshot
+from core.layout import schema
+
+
+class History:
+    """Append/browse/restore layout snapshots stored on a DocumentSpec."""
+
+    def __init__(self, document: DocumentSpec):
+        self.document = document
+
+    def snapshots(self) -> List[Snapshot]:
+        return self.document.history
+
+    def get(self, snapshot_id: str) -> Optional[Snapshot]:
+        for s in self.document.history:
+            if s.id == snapshot_id:
+                return s
+        return None
+
+    def append(self, prompt: str, *, snapshot_id: Optional[str] = None,
+               timestamp: Optional[str] = None, parent_id: Optional[str] = None) -> Snapshot:
+        doc_dict = schema.document_to_dict(self.document)
+        doc_dict.pop("history", None)  # never nest history inside a snapshot
+        if parent_id is None and self.document.history:
+            parent_id = self.document.history[-1].id
+        snap = Snapshot(
+            id=snapshot_id or uuid.uuid4().hex[:8],
+            parent_id=parent_id,
+            timestamp=timestamp or datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            prompt=prompt,
+            document=doc_dict,
+        )
+        self.document.history.append(snap)
+        return snap
+
+    def restore(self, snapshot_id: str) -> DocumentSpec:
+        snap = self.get(snapshot_id)
+        if snap is None:
+            raise KeyError(f"No snapshot {snapshot_id!r}")
+        restored = schema.document_from_dict(snap.document)
+        restored.history = list(self.document.history)  # keep the timeline
+        return restored

--- a/core/layout/models.py
+++ b/core/layout/models.py
@@ -114,6 +114,18 @@ class Region:
 
 
 @dataclass
+class Snapshot:
+    """One iteration of the layout designer (browsable in history)."""
+
+    id: str
+    parent_id: Optional[str]
+    timestamp: str
+    prompt: str
+    document: Dict  # serialized DocumentSpec (without its own history)
+    thumbnail: Optional[str] = None
+
+
+@dataclass
 class PageSpec:
     """Specification for a single page layout."""
 
@@ -138,6 +150,7 @@ class DocumentSpec:
     metadata: Dict[str, str] = field(default_factory=dict)  # Custom metadata
     content_kind: str = "custom"
     schema_version: str = "2.0"
+    history: List["Snapshot"] = field(default_factory=list)
 
 
 def migrate_legacy_blocks(blocks: List[Union[TextBlock, ImageBlock]]) -> List[Region]:

--- a/core/layout/models.py
+++ b/core/layout/models.py
@@ -126,6 +126,15 @@ class Snapshot:
 
 
 @dataclass
+class ProjectStyle:
+    """Per-project named font roles + color palette."""
+
+    font_roles: Dict[str, TextStyle] = field(default_factory=dict)
+    palette: Dict[str, str] = field(default_factory=dict)  # name -> hex
+    default_text_role: str = "body"
+
+
+@dataclass
 class PageSpec:
     """Specification for a single page layout."""
 
@@ -151,6 +160,7 @@ class DocumentSpec:
     content_kind: str = "custom"
     schema_version: str = "2.0"
     history: List["Snapshot"] = field(default_factory=list)
+    style: Optional["ProjectStyle"] = None
 
 
 def migrate_legacy_blocks(blocks: List[Union[TextBlock, ImageBlock]]) -> List[Region]:

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -62,7 +62,7 @@ def _add_image_region(scene: QGraphicsScene, r: Region, selectable: bool) -> Non
     scene.addItem(label)
 
 
-def _add_text_region(scene: QGraphicsScene, r: Region, selectable: bool) -> None:
+def _add_text_region(scene: QGraphicsScene, r: Region, selectable: bool, project_style=None) -> None:
     x, y, w, h = r.bbox
     box = QGraphicsRectItem(QRectF(x, y, w, h))
     box.setBrush(QBrush(Qt.transparent))
@@ -71,40 +71,40 @@ def _add_text_region(scene: QGraphicsScene, r: Region, selectable: bool) -> None
     scene.addItem(box)
 
     text = QGraphicsSimpleTextItem(r.text or "")
-    style = r.text_style
+    ts = r.text_style
+    if ts is None and project_style is not None and r.role:
+        ts = project_style.font_roles.get(r.role)
     font = QFont()
-    if style:
-        if style.family:
-            font.setFamily(style.family[0])
-        if style.size_px:
-            font.setPixelSize(style.size_px)
-        font.setBold(style.weight in ("bold", "black", "semibold"))
-        font.setItalic(style.italic)
-        text.setBrush(QBrush(QColor(style.color)))
+    if ts:
+        if ts.family:
+            font.setFamily(ts.family[0])
+        if ts.size_px:
+            font.setPixelSize(ts.size_px)
+        font.setBold(ts.weight in ("bold", "black", "semibold"))
+        font.setItalic(ts.italic)
+        text.setBrush(QBrush(QColor(ts.color)))
     text.setFont(font)
     text.setPos(x + 2, y + 2)
     scene.addItem(text)
 
 
-def build_scene(page: PageSpec, *, selectable: bool = False) -> QGraphicsScene:
+def build_scene(page: PageSpec, *, selectable: bool = False, style=None) -> QGraphicsScene:
     pw, ph = page.page_size_px
     scene = QGraphicsScene(0, 0, pw, ph)
-    bg = _resolve_bg(page)
-    scene.setBackgroundBrush(QBrush(QColor(bg)))
+    scene.setBackgroundBrush(QBrush(QColor(_resolve_bg(page))))
     for r in sorted(page.regions, key=lambda rr: rr.z):
         if r.kind == "image":
             _add_image_region(scene, r, selectable)
         else:
-            _add_text_region(scene, r, selectable)
+            _add_text_region(scene, r, selectable, project_style=style)
     return scene
 
 
-def render_page_to_image(page: PageSpec) -> QImage:
+def render_page_to_image(page: PageSpec, *, style=None) -> QImage:
     pw, ph = page.page_size_px
-    scene = build_scene(page)
+    scene = build_scene(page, style=style)
     img = QImage(pw, ph, QImage.Format_ARGB32)
-    bg = _resolve_bg(page)
-    img.fill(QColor(bg))
+    img.fill(QColor(_resolve_bg(page)))
     painter = QPainter(img)
     painter.setRenderHint(QPainter.Antialiasing, True)
     scene.render(painter, QRectF(0, 0, pw, ph), QRectF(0, 0, pw, ph))
@@ -112,8 +112,8 @@ def render_page_to_image(page: PageSpec) -> QImage:
     return img
 
 
-def save_page_png(page: PageSpec, path: str) -> None:
-    render_page_to_image(page).save(path, "PNG")
+def save_page_png(page: PageSpec, path: str, *, style=None) -> None:
+    render_page_to_image(page, style=style).save(path, "PNG")
 
 
 def export_document_pdf(doc: DocumentSpec, path: str, dpi: int = 300) -> None:
@@ -132,7 +132,7 @@ def export_document_pdf(doc: DocumentSpec, path: str, dpi: int = 300) -> None:
             started = True
         else:
             writer.newPage()
-        scene = build_scene(page)
+        scene = build_scene(page, style=doc.style)
         target = painter.viewport()
         scene.render(painter, QRectF(target), QRectF(0, 0, pw, ph))
     if started:

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -72,8 +72,9 @@ def _add_text_region(scene: QGraphicsScene, r: Region, selectable: bool, project
 
     text = QGraphicsSimpleTextItem(r.text or "")
     ts = r.text_style
-    if ts is None and project_style is not None and r.role:
-        ts = project_style.font_roles.get(r.role)
+    if ts is None and project_style is not None:
+        role = r.role or project_style.default_text_role
+        ts = project_style.font_roles.get(role)
     font = QFont()
     if ts:
         if ts.family:

--- a/core/layout/schema.py
+++ b/core/layout/schema.py
@@ -3,7 +3,7 @@ from dataclasses import asdict, replace
 from typing import Dict, List, Tuple
 
 from core.layout.models import (
-    Region, PageSpec, DocumentSpec, PageSize, TextStyle, ImageStyle, Snapshot,
+    Region, PageSpec, DocumentSpec, PageSize, TextStyle, ImageStyle, Snapshot, ProjectStyle,
     migrate_legacy_blocks, TextBlock, ImageBlock,
 )
 
@@ -71,6 +71,23 @@ def snapshot_from_dict(d: Dict) -> "Snapshot":
     )
 
 
+def project_style_to_dict(s: "ProjectStyle") -> Dict:
+    return {
+        "font_roles": {name: asdict(ts) for name, ts in s.font_roles.items()},
+        "palette": dict(s.palette),
+        "default_text_role": s.default_text_role,
+    }
+
+
+def project_style_from_dict(d: Dict) -> "ProjectStyle":
+    from core.layout.models import ProjectStyle
+    return ProjectStyle(
+        font_roles={name: TextStyle(**ts) for name, ts in d.get("font_roles", {}).items()},
+        palette=dict(d.get("palette", {})),
+        default_text_role=d.get("default_text_role", "body"),
+    )
+
+
 def _page_size_from_dict(d):
     return PageSize(**d) if d else None
 
@@ -113,6 +130,7 @@ def document_to_dict(doc: DocumentSpec) -> Dict:
         "content_kind": doc.content_kind, "theme": dict(doc.theme),
         "metadata": dict(doc.metadata), "pages": [page_to_dict(p) for p in doc.pages],
         "history": [snapshot_to_dict(s) for s in doc.history],
+        "style": project_style_to_dict(doc.style) if doc.style else None,
     }
 
 
@@ -124,6 +142,7 @@ def document_from_dict(d: Dict) -> DocumentSpec:
         content_kind=d.get("content_kind", "custom"),
         schema_version=d.get("schema_version", "2.0"),
         history=[snapshot_from_dict(s) for s in d.get("history", [])],
+        style=project_style_from_dict(d["style"]) if d.get("style") else None,
     )
 
 

--- a/core/layout/schema.py
+++ b/core/layout/schema.py
@@ -3,7 +3,7 @@ from dataclasses import asdict, replace
 from typing import Dict, List, Tuple
 
 from core.layout.models import (
-    Region, PageSpec, DocumentSpec, PageSize, TextStyle, ImageStyle,
+    Region, PageSpec, DocumentSpec, PageSize, TextStyle, ImageStyle, Snapshot,
     migrate_legacy_blocks, TextBlock, ImageBlock,
 )
 
@@ -56,6 +56,22 @@ def region_from_dict(d: Dict) -> Region:
     )
 
 
+def snapshot_to_dict(s: "Snapshot") -> Dict:
+    return {
+        "id": s.id, "parent_id": s.parent_id, "timestamp": s.timestamp,
+        "prompt": s.prompt, "document": s.document, "thumbnail": s.thumbnail,
+    }
+
+
+def snapshot_from_dict(d: Dict) -> "Snapshot":
+    from core.layout.models import Snapshot
+    return Snapshot(
+        id=d["id"], parent_id=d.get("parent_id"), timestamp=d.get("timestamp", ""),
+        prompt=d.get("prompt", ""), document=d.get("document", {}),
+        thumbnail=d.get("thumbnail"),
+    )
+
+
 def _page_size_from_dict(d):
     return PageSize(**d) if d else None
 
@@ -97,6 +113,7 @@ def document_to_dict(doc: DocumentSpec) -> Dict:
         "schema_version": doc.schema_version, "title": doc.title, "author": doc.author,
         "content_kind": doc.content_kind, "theme": dict(doc.theme),
         "metadata": dict(doc.metadata), "pages": [page_to_dict(p) for p in doc.pages],
+        "history": [snapshot_to_dict(s) for s in doc.history],
     }
 
 
@@ -107,6 +124,7 @@ def document_from_dict(d: Dict) -> DocumentSpec:
         theme=dict(d.get("theme", {})), metadata=dict(d.get("metadata", {})),
         content_kind=d.get("content_kind", "custom"),
         schema_version=d.get("schema_version", "2.0"),
+        history=[snapshot_from_dict(s) for s in d.get("history", [])],
     )
 
 

--- a/core/layout/schema.py
+++ b/core/layout/schema.py
@@ -64,7 +64,6 @@ def snapshot_to_dict(s: "Snapshot") -> Dict:
 
 
 def snapshot_from_dict(d: Dict) -> "Snapshot":
-    from core.layout.models import Snapshot
     return Snapshot(
         id=d["id"], parent_id=d.get("parent_id"), timestamp=d.get("timestamp", ""),
         prompt=d.get("prompt", ""), document=d.get("document", {}),

--- a/core/layout/schema.py
+++ b/core/layout/schema.py
@@ -80,7 +80,6 @@ def project_style_to_dict(s: "ProjectStyle") -> Dict:
 
 
 def project_style_from_dict(d: Dict) -> "ProjectStyle":
-    from core.layout.models import ProjectStyle
     return ProjectStyle(
         font_roles={name: TextStyle(**ts) for name, ts in d.get("font_roles", {}).items()},
         palette=dict(d.get("palette", {})),

--- a/core/layout/styles.py
+++ b/core/layout/styles.py
@@ -1,0 +1,60 @@
+"""Default project style (font roles + palette) seeded by content kind."""
+from typing import Dict, List
+
+from core.layout.models import ProjectStyle, TextStyle
+
+
+def _role(family: List[str], size: int, weight: str = "regular", color: str = "#111111") -> TextStyle:
+    return TextStyle(family=list(family), size_px=size, weight=weight, color=color)
+
+
+_PALETTE = {"background": "#FFFFFF", "text": "#111111", "accent": "#2C7BE5"}
+
+_KIND_ROLES: Dict[str, Dict[str, TextStyle]] = {
+    "children": {
+        "title": _role(["Georgia", "DejaVu Serif"], 64, "bold"),
+        "narration": _role(["Georgia", "DejaVu Serif"], 36),
+    },
+    "comic": {
+        "logo_title": _role(["Impact", "DejaVu Sans"], 72, "black"),
+        "dialogue": _role(["Comic Sans MS", "DejaVu Sans"], 28),
+        "sfx": _role(["Impact", "DejaVu Sans"], 48, "black", "#D7263D"),
+        "caption": _role(["Arial", "DejaVu Sans"], 24),
+    },
+    "magazine": {
+        "masthead": _role(["Georgia", "DejaVu Serif"], 72, "bold"),
+        "headline": _role(["Georgia", "DejaVu Serif"], 48, "bold"),
+        "body": _role(["Arial", "DejaVu Sans"], 28),
+        "caption": _role(["Arial", "DejaVu Sans"], 22),
+        "pull_quote": _role(["Georgia", "DejaVu Serif"], 36, "semibold", "#2C7BE5"),
+    },
+    "scientific": {
+        "title": _role(["Times New Roman", "DejaVu Serif"], 56, "bold"),
+        "heading": _role(["Times New Roman", "DejaVu Serif"], 36, "bold"),
+        "body": _role(["Times New Roman", "DejaVu Serif"], 28),
+        "caption": _role(["Arial", "DejaVu Sans"], 22),
+    },
+}
+# aliases
+_KIND_ROLES["comic_strip"] = _KIND_ROLES["comic"]
+_KIND_ROLES["newspaper"] = _KIND_ROLES["magazine"]
+
+_DEFAULT_ROLE = {
+    "children": "narration", "comic": "dialogue", "comic_strip": "dialogue",
+    "magazine": "body", "newspaper": "body", "scientific": "body",
+}
+
+_FALLBACK_ROLES = {
+    "title": _role(["Arial", "DejaVu Sans"], 56, "bold"),
+    "body": _role(["Arial", "DejaVu Sans"], 28),
+}
+
+
+def default_style_for(content_kind: str) -> ProjectStyle:
+    roles = _KIND_ROLES.get(content_kind, _FALLBACK_ROLES)
+    return ProjectStyle(
+        font_roles={name: _role(ts.family, ts.size_px, ts.weight, ts.color)
+                    for name, ts in roles.items()},
+        palette=dict(_PALETTE),
+        default_text_role=_DEFAULT_ROLE.get(content_kind, "body"),
+    )

--- a/core/layout/styles.py
+++ b/core/layout/styles.py
@@ -1,10 +1,12 @@
 """Default project style (font roles + palette) seeded by content kind."""
-from typing import Dict, List
+from typing import Dict, List, Literal
 
 from core.layout.models import ProjectStyle, TextStyle
 
 
-def _role(family: List[str], size: int, weight: str = "regular", color: str = "#111111") -> TextStyle:
+def _role(family: List[str], size: int,
+          weight: Literal["regular", "medium", "semibold", "bold", "black"] = "regular",
+          color: str = "#111111") -> TextStyle:
     return TextStyle(family=list(family), size_px=size, weight=weight, color=color)
 
 
@@ -36,8 +38,8 @@ _KIND_ROLES: Dict[str, Dict[str, TextStyle]] = {
     },
 }
 # aliases
-_KIND_ROLES["comic_strip"] = _KIND_ROLES["comic"]
-_KIND_ROLES["newspaper"] = _KIND_ROLES["magazine"]
+_KIND_ROLES["comic_strip"] = dict(_KIND_ROLES["comic"])
+_KIND_ROLES["newspaper"] = dict(_KIND_ROLES["magazine"])
 
 _DEFAULT_ROLE = {
     "children": "narration", "comic": "dialogue", "comic_strip": "dialogue",

--- a/core/layout/template_io.py
+++ b/core/layout/template_io.py
@@ -1,0 +1,22 @@
+"""Layout-template export/import: shareable structure + style, no content."""
+import json
+from pathlib import Path
+
+from core.layout.models import DocumentSpec
+from core.layout import schema
+
+
+def export_template(doc: DocumentSpec, path: str) -> None:
+    data = schema.document_to_dict(doc)
+    data["history"] = []  # templates carry no iteration history
+    for page in data.get("pages", []):
+        for region in page.get("regions", []):
+            region["text"] = ""        # strip text content
+            region["image_ref"] = None  # strip image content
+            # keep: id, kind, shape, bbox, points, z, role, prompt, styles
+    Path(path).write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def import_template(path: str) -> DocumentSpec:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return schema.document_from_dict(data)

--- a/gui/layout/canvas_widget.py
+++ b/gui/layout/canvas_widget.py
@@ -20,15 +20,15 @@ class CanvasWidget(QGraphicsView):
         self._scene: Optional[QGraphicsScene] = None
         self.setScene(QGraphicsScene(self))
 
-    def load_page(self, page: PageSpec) -> None:
+    def load_page(self, page: PageSpec, style=None) -> None:
         old = self._scene
         if old is not None:
             try:
                 old.selectionChanged.disconnect(self._on_selection_changed)
             except (RuntimeError, TypeError):
-                pass  # old scene's signal was not connected
+                pass
         self._page = page
-        scene = qt_renderer.build_scene(page, selectable=True)
+        scene = qt_renderer.build_scene(page, selectable=True, style=style)
         scene.setParent(self)
         scene.selectionChanged.connect(self._on_selection_changed)
         self.setScene(scene)

--- a/gui/layout/designer_panel.py
+++ b/gui/layout/designer_panel.py
@@ -105,7 +105,8 @@ class DesignerPanel(QWidget):
                      completion_fn: Optional[Callable[[List[Dict]], str]] = None):
         kind = self.content_kind()
         messages = designer.build_messages(kind, page_px, user_text, current_regions)
-        self.console.log(f"Designing ({kind}, {page_px[0]}x{page_px[1]}): {user_text}", "INFO")
+        self.console.log(f"Designing ({kind}, {page_px[0]}x{page_px[1]})", "INFO")
+        self.console.log("Prompt sent to LLM:\n" + messages[-1]["content"], "INFO")
         # Capture whether a completion_fn was injected BEFORE we build the production one.
         injected = completion_fn is not None
         if completion_fn is None:
@@ -123,6 +124,8 @@ class DesignerPanel(QWidget):
             self._worker.start()
 
     def _on_proposed(self, result):
+        if result.raw:
+            self.console.log("LLM response:\n" + result.raw, "INFO")
         n = len(result.regions) if result.regions else 0
         self.console.log(f"Proposed layout: {n} regions; {len(result.questions)} question(s).",
                          "SUCCESS")

--- a/gui/layout/designer_panel.py
+++ b/gui/layout/designer_panel.py
@@ -1,0 +1,131 @@
+"""Designer panel: description/iterate input, status console, LLM worker."""
+import logging
+from typing import List, Dict, Optional, Callable
+
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QComboBox, QPlainTextEdit, QPushButton, QLabel,
+)
+from PySide6.QtCore import QThread, Signal
+
+from core.layout import designer
+from gui.llm_utils import DialogStatusConsole
+
+logger = logging.getLogger("imageai.layout.designer_panel")
+
+CONTENT_KINDS = ["children", "comic", "comic_strip", "magazine", "newspaper", "scientific", "custom"]
+
+
+class DesignerWorker(QThread):
+    progress = Signal(str)
+    proposed = Signal(object)  # DesignerResult
+    failed = Signal(str)
+
+    def __init__(self, messages: List[Dict], page_px, completion_fn: Callable[[List[Dict]], str], parent=None):
+        super().__init__(parent)
+        self._messages = messages
+        self._page_px = page_px
+        self._completion_fn = completion_fn
+
+    def run(self):
+        try:
+            self.progress.emit("Designing layout…")
+            result = designer.run_design(self._messages, self._page_px, self._completion_fn)
+            self.proposed.emit(result)
+        except Exception as e:  # noqa: BLE001 - surfaced to UI + log
+            logger.error("Designer worker failed: %s", e, exc_info=True)
+            self.failed.emit(str(e))
+
+
+class DesignerPanel(QWidget):
+    layoutProposed = Signal(object)  # DesignerResult
+
+    def __init__(self, config, parent=None):
+        super().__init__(parent)
+        self._config = config
+        self._worker: Optional[DesignerWorker] = None
+        self._build()
+
+    def _build(self):
+        lay = QVBoxLayout(self)
+
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Kind:"))
+        self.kind_combo = QComboBox()
+        self.kind_combo.addItems(CONTENT_KINDS)
+        row.addWidget(self.kind_combo)
+        row.addWidget(QLabel("Provider:"))
+        self.provider_combo = QComboBox()
+        self.model_combo = QComboBox()
+        self._populate_providers()
+        self.provider_combo.currentTextChanged.connect(self._on_provider_changed)
+        row.addWidget(self.provider_combo)
+        row.addWidget(self.model_combo)
+        lay.addLayout(row)
+
+        self.prompt_edit = QPlainTextEdit()
+        self.prompt_edit.setPlaceholderText(
+            "Describe the page, or type a change to the current layout…")
+        self.prompt_edit.setFixedHeight(70)
+        lay.addWidget(self.prompt_edit)
+
+        self.design_btn = QPushButton("Design / Iterate")
+        lay.addWidget(self.design_btn)
+
+        self.console = DialogStatusConsole("Designer")
+        lay.addWidget(self.console)
+
+    def _populate_providers(self):
+        from core.llm_models import get_all_provider_ids, get_provider_display_name
+        self.provider_combo.blockSignals(True)
+        self.provider_combo.clear()
+        self.provider_combo.addItems([get_provider_display_name(p) for p in get_all_provider_ids()])
+        saved = self._config.get_layout_llm_provider() if self._config else None
+        if saved:
+            idx = self.provider_combo.findText(saved, )
+            if idx < 0:
+                idx = self.provider_combo.findText(saved.capitalize())
+            if idx >= 0:
+                self.provider_combo.setCurrentIndex(idx)
+        self.provider_combo.blockSignals(False)
+        self._on_provider_changed(self.provider_combo.currentText())
+
+    def _on_provider_changed(self, provider: str):
+        from core.llm_models import get_provider_models
+        provider_map = {"claude": "anthropic", "google": "gemini", "lm studio": "lmstudio"}
+        pid = provider_map.get(provider.lower(), provider.lower())
+        self.model_combo.blockSignals(True)
+        self.model_combo.clear()
+        self.model_combo.addItems(get_provider_models(pid) or [])
+        self.model_combo.blockSignals(False)
+
+    def content_kind(self) -> str:
+        return self.kind_combo.currentText()
+
+    def start_design(self, user_text: str, page_px, current_regions=None,
+                     completion_fn: Optional[Callable[[List[Dict]], str]] = None):
+        kind = self.content_kind()
+        messages = designer.build_messages(kind, page_px, user_text, current_regions)
+        self.console.log(f"Designing ({kind}, {page_px[0]}x{page_px[1]}): {user_text}", "INFO")
+        # Capture whether a completion_fn was injected BEFORE we build the production one.
+        injected = completion_fn is not None
+        if completion_fn is None:
+            provider = self.provider_combo.currentText()
+            model = self.model_combo.currentText()
+            cfg = self._config
+            completion_fn = lambda m: designer.run_completion(cfg, provider, model, m)
+        self._worker = DesignerWorker(messages, page_px, completion_fn)
+        self._worker.progress.connect(lambda msg: self.console.log(msg, "INFO"))
+        self._worker.proposed.connect(self._on_proposed)
+        self._worker.failed.connect(lambda err: self.console.log(err, "ERROR"))
+        if injected:
+            self._worker.run()      # synchronous for injected/test completions
+        else:
+            self._worker.start()
+
+    def _on_proposed(self, result):
+        n = len(result.regions) if result.regions else 0
+        self.console.log(f"Proposed layout: {n} regions; {len(result.questions)} question(s).",
+                         "SUCCESS")
+        for q in result.questions:
+            self.console.log(f"Q: {q}", "WARNING")
+        self.layoutProposed.emit(result)

--- a/gui/layout/history_window.py
+++ b/gui/layout/history_window.py
@@ -1,0 +1,47 @@
+"""Browsable iteration-history window for the layout designer."""
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QListWidget, QListWidgetItem, QPushButton, QLabel,
+)
+from PySide6.QtCore import Signal, Qt
+
+
+class HistoryWindow(QDialog):
+    restoreRequested = Signal(str)  # snapshot id
+
+    def __init__(self, history, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Layout History")
+        self.resize(420, 360)
+        self._history = history
+        self._build()
+        self.set_history(history)
+
+    def _build(self):
+        lay = QVBoxLayout(self)
+        lay.addWidget(QLabel("Iterations (newest last):"))
+        self.list_widget = QListWidget()
+        lay.addWidget(self.list_widget, 1)
+        row = QHBoxLayout()
+        self.restore_btn = QPushButton("Restore selected")
+        self.restore_btn.clicked.connect(self._on_restore)
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.reject)
+        row.addStretch(1)
+        row.addWidget(self.restore_btn)
+        row.addWidget(close_btn)
+        lay.addLayout(row)
+
+    def set_history(self, history):
+        self._history = history
+        self.list_widget.clear()
+        for s in history.snapshots():
+            label = f"[{s.timestamp}] {s.prompt[:60]}"
+            item = QListWidgetItem(label)
+            item.setData(Qt.UserRole, s.id)
+            self.list_widget.addItem(item)
+
+    def _on_restore(self):
+        item = self.list_widget.currentItem()
+        if item is None:
+            return
+        self.restoreRequested.emit(item.data(Qt.UserRole))

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -108,17 +108,20 @@ class LayoutTab(QWidget):
                                    current_regions=page.regions or None)
 
     def _on_layout_proposed(self, result):
-        text = self.designer.prompt_edit.toPlainText().strip() if hasattr(self.designer, "prompt_edit") else ""
+        text = self.designer.prompt_edit.toPlainText().strip()
         self.apply_designer_result(result, user_text=text)
 
     def apply_designer_result(self, result, user_text: str = ""):
         if not self.document or not self.document.pages:
             return
-        self.document.content_kind = self.designer.content_kind() if hasattr(self, "designer") else self.document.content_kind
+        self.document.content_kind = self.designer.content_kind()
         if result.regions:
             self.document.pages[0].regions = list(result.regions)
             self.history.append(user_text or "design")
             self._refresh()
+        elif result.questions:
+            self.status.setText(
+                f"Designer asked {len(result.questions)} question(s) — see the Designer console.")
 
     def restore_snapshot(self, snapshot_id: str):
         restored = self.history.restore(snapshot_id)

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -1,4 +1,4 @@
-"""Layout tab — Phase 2: AI designer + history integration."""
+"""Layout tab — Phase 3: style panel + template export/import integration."""
 import logging
 from typing import Optional
 
@@ -9,11 +9,13 @@ from PySide6.QtCore import Signal
 
 from core.layout.models import DocumentSpec, PageSpec, PageSize
 from core.layout import project_io, qt_renderer
+from core.layout import styles, template_io
 from core.layout.history import History
 from gui.layout.page_setup_widget import PageSetupWidget
 from gui.layout.canvas_widget import CanvasWidget
 from gui.layout.designer_panel import DesignerPanel
 from gui.layout.history_window import HistoryWindow
+from gui.layout.style_panel import StylePanel
 
 logger = logging.getLogger("imageai.layout.tab")
 
@@ -37,6 +39,8 @@ class LayoutTab(QWidget):
             ("New", self.new_document), ("Open…", self._open_dialog),
             ("Save…", self._save_dialog), ("Export PDF…", self._export_dialog),
             ("History…", self._open_history),
+            ("Export Template…", self._export_template_dialog),
+            ("Import Template…", self._import_template_dialog),
         ]:
             btn = QPushButton(label)
             btn.clicked.connect(slot)
@@ -53,6 +57,10 @@ class LayoutTab(QWidget):
         self.designer.design_btn.clicked.connect(self._on_design_clicked)
         root.addWidget(self.designer)
 
+        self.style_panel = StylePanel()
+        self.style_panel.styleChanged.connect(self.apply_style)
+        root.addWidget(self.style_panel)
+
         self.canvas = CanvasWidget()
         root.addWidget(self.canvas, 1)
 
@@ -66,6 +74,9 @@ class LayoutTab(QWidget):
         page = PageSpec(page_size_px=(pw, ph), page_size=ps, background="#FFFFFF")
         self.document = DocumentSpec(title="Untitled", pages=[page])
         self.history = History(self.document)
+        self.document.style = styles.default_style_for(self.document.content_kind)
+        if hasattr(self, "style_panel"):
+            self.style_panel.set_style(self.document.style)
         self._refresh()
 
     def _on_page_size_changed(self, ps: PageSize):
@@ -78,7 +89,7 @@ class LayoutTab(QWidget):
 
     def _refresh(self):
         if self.document and self.document.pages:
-            self.canvas.load_page(self.document.pages[0])
+            self.canvas.load_page(self.document.pages[0], self.document.style)
             self.status.setText(f"{self.document.title} — {self.document.pages[0].page_size_px}")
         self.documentChanged.emit()
 
@@ -90,6 +101,8 @@ class LayoutTab(QWidget):
     def open_project_from(self, path: str):
         self.document = project_io.load_project(path)
         self.history = History(self.document)
+        if hasattr(self, "style_panel") and self.document.style:
+            self.style_panel.set_style(self.document.style)
         self._refresh()
 
     def export_pdf_to(self, path: str):
@@ -133,6 +146,40 @@ class LayoutTab(QWidget):
         win = HistoryWindow(self.history, self)
         win.restoreRequested.connect(self.restore_snapshot)
         win.exec()
+
+    def apply_style(self, style):
+        if self.document is None:
+            return
+        self.document.style = style
+        self._refresh()
+
+    def export_template_to(self, path: str):
+        template_io.export_template(self.document, path)
+        self.status.setText(f"Exported template {path}")
+
+    def import_template_from(self, path: str):
+        self.document = template_io.import_template(path)
+        from core.layout.history import History
+        self.history = History(self.document)
+        if self.document.style is None:
+            self.document.style = styles.default_style_for(self.document.content_kind)
+        if hasattr(self, "style_panel") and self.document.style:
+            self.style_panel.set_style(self.document.style)
+        self._refresh()
+
+    def _export_template_dialog(self):
+        from PySide6.QtWidgets import QFileDialog
+        path, _ = QFileDialog.getSaveFileName(self, "Export Template", "",
+                                              "ImageAI Layout Template (*.iailayout.json)")
+        if path:
+            self.export_template_to(path)
+
+    def _import_template_dialog(self):
+        from PySide6.QtWidgets import QFileDialog
+        path, _ = QFileDialog.getOpenFileName(self, "Import Template", "",
+                                              "ImageAI Layout Template (*.iailayout.json)")
+        if path:
+            self.import_template_from(path)
 
     # --- dialogs ---
     def _save_dialog(self):

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -68,15 +68,20 @@ class LayoutTab(QWidget):
         root.addWidget(self.status)
 
     # --- document lifecycle ---
+    def _adopt_document(self, doc):
+        self.document = doc
+        self.history = History(self.document)
+        if self.document.style is None:
+            self.document.style = styles.default_style_for(self.document.content_kind)
+        self._style_user_modified = False
+        if hasattr(self, "style_panel") and self.document.style:
+            self.style_panel.set_style(self.document.style)
+
     def new_document(self):
         ps = self.page_setup.page_size() if hasattr(self, "page_setup") else PageSize(8.5, 11, "in")
         pw, ph = ps.to_pixels()
         page = PageSpec(page_size_px=(pw, ph), page_size=ps, background="#FFFFFF")
-        self.document = DocumentSpec(title="Untitled", pages=[page])
-        self.history = History(self.document)
-        self.document.style = styles.default_style_for(self.document.content_kind)
-        if hasattr(self, "style_panel"):
-            self.style_panel.set_style(self.document.style)
+        self._adopt_document(DocumentSpec(title="Untitled", pages=[page]))
         self._refresh()
 
     def _on_page_size_changed(self, ps: PageSize):
@@ -99,12 +104,7 @@ class LayoutTab(QWidget):
         self.status.setText(f"Saved {path}")
 
     def open_project_from(self, path: str):
-        self.document = project_io.load_project(path)
-        self.history = History(self.document)
-        if self.document.style is None:
-            self.document.style = styles.default_style_for(self.document.content_kind)
-        if hasattr(self, "style_panel") and self.document.style:
-            self.style_panel.set_style(self.document.style)
+        self._adopt_document(project_io.load_project(path))
         self._refresh()
 
     def export_pdf_to(self, path: str):
@@ -129,7 +129,13 @@ class LayoutTab(QWidget):
     def apply_designer_result(self, result, user_text: str = ""):
         if not self.document or not self.document.pages:
             return
-        self.document.content_kind = self.designer.content_kind()
+        kind = self.designer.content_kind()
+        if kind != self.document.content_kind:
+            self.document.content_kind = kind
+            if not getattr(self, "_style_user_modified", False):
+                self.document.style = styles.default_style_for(kind)
+                if hasattr(self, "style_panel"):
+                    self.style_panel.set_style(self.document.style)
         if result.regions:
             self.document.pages[0].regions = list(result.regions)
             self.history.append(user_text or "design")
@@ -140,8 +146,7 @@ class LayoutTab(QWidget):
 
     def restore_snapshot(self, snapshot_id: str):
         restored = self.history.restore(snapshot_id)
-        self.document = restored
-        self.history = History(self.document)
+        self._adopt_document(restored)
         self._refresh()
 
     def _open_history(self):
@@ -153,6 +158,7 @@ class LayoutTab(QWidget):
         if self.document is None:
             return
         self.document.style = style
+        self._style_user_modified = True
         self._refresh()
 
     def export_template_to(self, path: str):
@@ -162,12 +168,7 @@ class LayoutTab(QWidget):
         self.status.setText(f"Exported template {path}")
 
     def import_template_from(self, path: str):
-        self.document = template_io.import_template(path)
-        self.history = History(self.document)
-        if self.document.style is None:
-            self.document.style = styles.default_style_for(self.document.content_kind)
-        if hasattr(self, "style_panel") and self.document.style:
-            self.style_panel.set_style(self.document.style)
+        self._adopt_document(template_io.import_template(path))
         self._refresh()
 
     def _export_template_dialog(self):

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -101,6 +101,8 @@ class LayoutTab(QWidget):
     def open_project_from(self, path: str):
         self.document = project_io.load_project(path)
         self.history = History(self.document)
+        if self.document.style is None:
+            self.document.style = styles.default_style_for(self.document.content_kind)
         if hasattr(self, "style_panel") and self.document.style:
             self.style_panel.set_style(self.document.style)
         self._refresh()
@@ -154,12 +156,13 @@ class LayoutTab(QWidget):
         self._refresh()
 
     def export_template_to(self, path: str):
+        if self.document is None:
+            return
         template_io.export_template(self.document, path)
         self.status.setText(f"Exported template {path}")
 
     def import_template_from(self, path: str):
         self.document = template_io.import_template(path)
-        from core.layout.history import History
         self.history = History(self.document)
         if self.document.style is None:
             self.document.style = styles.default_style_for(self.document.content_kind)

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -1,4 +1,4 @@
-"""Layout tab — Phase 1 foundation: page setup + canvas + New/Open/Save/Export."""
+"""Layout tab — Phase 2: AI designer + history integration."""
 import logging
 from typing import Optional
 
@@ -9,8 +9,11 @@ from PySide6.QtCore import Signal
 
 from core.layout.models import DocumentSpec, PageSpec, PageSize
 from core.layout import project_io, qt_renderer
+from core.layout.history import History
 from gui.layout.page_setup_widget import PageSetupWidget
 from gui.layout.canvas_widget import CanvasWidget
+from gui.layout.designer_panel import DesignerPanel
+from gui.layout.history_window import HistoryWindow
 
 logger = logging.getLogger("imageai.layout.tab")
 
@@ -22,6 +25,7 @@ class LayoutTab(QWidget):
         super().__init__(parent)
         self.config = config
         self.document: Optional[DocumentSpec] = None
+        self.history: Optional[History] = None
         self._build()
         self.new_document()
 
@@ -32,6 +36,7 @@ class LayoutTab(QWidget):
         for label, slot in [
             ("New", self.new_document), ("Open…", self._open_dialog),
             ("Save…", self._save_dialog), ("Export PDF…", self._export_dialog),
+            ("History…", self._open_history),
         ]:
             btn = QPushButton(label)
             btn.clicked.connect(slot)
@@ -42,6 +47,11 @@ class LayoutTab(QWidget):
         self.page_setup = PageSetupWidget(self.config)
         self.page_setup.pageSizeChanged.connect(self._on_page_size_changed)
         root.addWidget(self.page_setup)
+
+        self.designer = DesignerPanel(self.config)
+        self.designer.layoutProposed.connect(self._on_layout_proposed)
+        self.designer.design_btn.clicked.connect(self._on_design_clicked)
+        root.addWidget(self.designer)
 
         self.canvas = CanvasWidget()
         root.addWidget(self.canvas, 1)
@@ -55,6 +65,7 @@ class LayoutTab(QWidget):
         pw, ph = ps.to_pixels()
         page = PageSpec(page_size_px=(pw, ph), page_size=ps, background="#FFFFFF")
         self.document = DocumentSpec(title="Untitled", pages=[page])
+        self.history = History(self.document)
         self._refresh()
 
     def _on_page_size_changed(self, ps: PageSize):
@@ -78,11 +89,47 @@ class LayoutTab(QWidget):
 
     def open_project_from(self, path: str):
         self.document = project_io.load_project(path)
+        self.history = History(self.document)
         self._refresh()
 
     def export_pdf_to(self, path: str):
         qt_renderer.export_document_pdf(self.document, path)
         self.status.setText(f"Exported {path}")
+
+    # --- designer + history methods ---
+    def _on_design_clicked(self):
+        if not self.document or not self.document.pages:
+            return
+        text = self.designer.prompt_edit.toPlainText().strip()
+        if not text:
+            return
+        page = self.document.pages[0]
+        self.designer.start_design(text, page.page_size_px,
+                                   current_regions=page.regions or None)
+
+    def _on_layout_proposed(self, result):
+        text = self.designer.prompt_edit.toPlainText().strip() if hasattr(self.designer, "prompt_edit") else ""
+        self.apply_designer_result(result, user_text=text)
+
+    def apply_designer_result(self, result, user_text: str = ""):
+        if not self.document or not self.document.pages:
+            return
+        self.document.content_kind = self.designer.content_kind() if hasattr(self, "designer") else self.document.content_kind
+        if result.regions:
+            self.document.pages[0].regions = list(result.regions)
+            self.history.append(user_text or "design")
+            self._refresh()
+
+    def restore_snapshot(self, snapshot_id: str):
+        restored = self.history.restore(snapshot_id)
+        self.document = restored
+        self.history = History(self.document)
+        self._refresh()
+
+    def _open_history(self):
+        win = HistoryWindow(self.history, self)
+        win.restoreRequested.connect(self.restore_snapshot)
+        win.exec()
 
     # --- dialogs ---
     def _save_dialog(self):

--- a/gui/layout/style_panel.py
+++ b/gui/layout/style_panel.py
@@ -1,0 +1,76 @@
+"""Project style editor: per-role font family/size/color + palette."""
+from PySide6.QtWidgets import (
+    QWidget, QFormLayout, QComboBox, QLineEdit, QSpinBox, QLabel,
+)
+from PySide6.QtCore import Signal
+
+from core.layout.models import ProjectStyle, TextStyle
+
+
+class StylePanel(QWidget):
+    styleChanged = Signal(object)  # ProjectStyle
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._style = ProjectStyle()
+        self._build()
+
+    def _build(self):
+        form = QFormLayout(self)
+        self.role_combo = QComboBox()
+        self.role_combo.currentTextChanged.connect(self._on_role_selected)
+        form.addRow(QLabel("Role:"), self.role_combo)
+        self.family_edit = QLineEdit()
+        self.family_edit.editingFinished.connect(self._on_field_changed)
+        form.addRow(QLabel("Font family:"), self.family_edit)
+        self.size_spin = QSpinBox()
+        self.size_spin.setRange(1, 2000)
+        self.size_spin.valueChanged.connect(self._on_field_changed)
+        form.addRow(QLabel("Size (px):"), self.size_spin)
+        self.color_edit = QLineEdit()
+        self.color_edit.editingFinished.connect(self._on_field_changed)
+        form.addRow(QLabel("Color (hex):"), self.color_edit)
+
+    def set_style(self, style: ProjectStyle):
+        self._style = style
+        self.role_combo.blockSignals(True)
+        self.role_combo.clear()
+        self.role_combo.addItems(sorted(style.font_roles.keys()))
+        self.role_combo.blockSignals(False)
+        if self.role_combo.count():
+            self.role_combo.setCurrentIndex(0)
+            self._load_role(self.role_combo.currentText())
+
+    def style(self) -> ProjectStyle:
+        return self._style
+
+    def _load_role(self, role: str):
+        ts = self._style.font_roles.get(role)
+        if ts is None:
+            return
+        for w in (self.family_edit, self.size_spin, self.color_edit):
+            w.blockSignals(True)
+        self.family_edit.setText(ts.family[0] if ts.family else "")
+        self.size_spin.setValue(ts.size_px)
+        self.color_edit.setText(ts.color)
+        for w in (self.family_edit, self.size_spin, self.color_edit):
+            w.blockSignals(False)
+
+    def _on_role_selected(self, role: str):
+        if role:
+            self._load_role(role)
+
+    def _on_field_changed(self):
+        role = self.role_combo.currentText()
+        if not role or role not in self._style.font_roles:
+            return
+        old = self._style.font_roles[role]
+        self._style.font_roles[role] = TextStyle(
+            family=[self.family_edit.text() or "Arial"],
+            weight=old.weight, italic=old.italic,
+            size_px=self.size_spin.value(),
+            line_height=old.line_height,
+            color=self.color_edit.text() or "#111111",
+            align=old.align, wrap=old.wrap, letter_spacing=old.letter_spacing,
+        )
+        self.styleChanged.emit(self._style)

--- a/gui/layout/style_panel.py
+++ b/gui/layout/style_panel.py
@@ -25,7 +25,7 @@ class StylePanel(QWidget):
         form.addRow(QLabel("Font family:"), self.family_edit)
         self.size_spin = QSpinBox()
         self.size_spin.setRange(1, 2000)
-        self.size_spin.valueChanged.connect(self._on_field_changed)
+        self.size_spin.editingFinished.connect(self._on_field_changed)
         form.addRow(QLabel("Size (px):"), self.size_spin)
         self.color_edit = QLineEdit()
         self.color_edit.editingFinished.connect(self._on_field_changed)
@@ -38,7 +38,6 @@ class StylePanel(QWidget):
         self.role_combo.addItems(sorted(style.font_roles.keys()))
         self.role_combo.blockSignals(False)
         if self.role_combo.count():
-            self.role_combo.setCurrentIndex(0)
             self._load_role(self.role_combo.currentText())
 
     def style(self) -> ProjectStyle:

--- a/tests/layout/test_designer.py
+++ b/tests/layout/test_designer.py
@@ -1,0 +1,20 @@
+from core.layout.models import Region
+from core.layout import designer
+
+
+def test_build_messages_includes_context_and_json_instruction():
+    msgs = designer.build_messages("comic", (1000, 800), "9 panels that flow into each other")
+    assert isinstance(msgs, list) and msgs[0]["role"] == "system"
+    joined = " ".join(m["content"] for m in msgs)
+    assert "comic" in joined
+    assert "1000" in joined and "800" in joined
+    assert "9 panels that flow into each other" in joined
+    assert "JSON" in joined or "json" in joined
+    assert "regions" in joined  # tells the model our schema key
+
+
+def test_build_messages_includes_current_layout_when_iterating():
+    regions = [Region(id="r1", kind="image", bbox=(0, 0, 500, 500))]
+    msgs = designer.build_messages("comic", (1000, 800), "make the top panel bigger", regions)
+    joined = " ".join(m["content"] for m in msgs)
+    assert "r1" in joined  # current layout passed back for modification

--- a/tests/layout/test_designer.py
+++ b/tests/layout/test_designer.py
@@ -67,3 +67,10 @@ def test_parse_response_non_list_questions_does_not_split():
     res = designer.parse_response('{"questions": "why"}', (100, 100))
     assert "w" not in res.questions          # not iterated char-by-char
     assert res.regions is not None and len(res.regions) >= 1  # falls back to a layout
+
+
+def test_build_messages_instructs_role_with_kind_roles():
+    msgs = designer.build_messages("comic", (1000, 800), "a page")
+    joined = " ".join(m["content"] for m in msgs)
+    assert '"role"' in joined
+    assert "dialogue" in joined  # a comic role name is offered to the model

--- a/tests/layout/test_designer.py
+++ b/tests/layout/test_designer.py
@@ -61,3 +61,9 @@ def test_run_design_uses_injected_completion():
     res = designer.run_design(msgs, (200, 200), fake_completion)
     assert captured["msgs"] == msgs
     assert [r.id for r in res.regions] == ["a"]
+
+
+def test_parse_response_non_list_questions_does_not_split():
+    res = designer.parse_response('{"questions": "why"}', (100, 100))
+    assert "w" not in res.questions          # not iterated char-by-char
+    assert res.regions is not None and len(res.regions) >= 1  # falls back to a layout

--- a/tests/layout/test_designer.py
+++ b/tests/layout/test_designer.py
@@ -18,3 +18,46 @@ def test_build_messages_includes_current_layout_when_iterating():
     msgs = designer.build_messages("comic", (1000, 800), "make the top panel bigger", regions)
     joined = " ".join(m["content"] for m in msgs)
     assert "r1" in joined  # current layout passed back for modification
+
+
+def test_parse_response_with_regions_and_questions():
+    content = (
+        "```json\n"
+        '{"questions": ["What palette?"],'
+        ' "layout": {"regions": [{"id": "p1", "kind": "image", "shape": "rect",'
+        ' "bbox": [0,0,500,400]}, {"id": "t1", "kind": "text", "bbox": [0,420,500,80],'
+        ' "text": "Title"}]}}'
+        "\n```"
+    )
+    res = designer.parse_response(content, (1000, 800))
+    assert res.questions == ["What palette?"]
+    assert [r.id for r in res.regions] == ["p1", "t1"]
+    assert res.regions[0].kind == "image"
+    # out-of-nothing clamp safety: bbox stays within page
+    x, y, w, h = res.regions[1].bbox
+    assert x + w <= 1000 and y + h <= 800
+
+
+def test_parse_response_questions_only():
+    res = designer.parse_response('{"questions": ["how many pages?"]}', (1000, 800))
+    assert res.questions == ["how many pages?"]
+    assert res.regions is None
+
+
+def test_parse_response_garbage_falls_back():
+    res = designer.parse_response("the model rambled with no json", (1000, 800))
+    assert res.regions is not None and len(res.regions) >= 1  # fallback layout
+    assert res.regions[0].bbox[2] > 0
+
+
+def test_run_design_uses_injected_completion():
+    captured = {}
+
+    def fake_completion(messages):
+        captured["msgs"] = messages
+        return '{"layout": {"regions": [{"id":"a","kind":"image","bbox":[0,0,100,100]}]}}'
+
+    msgs = designer.build_messages("comic", (200, 200), "one panel")
+    res = designer.run_design(msgs, (200, 200), fake_completion)
+    assert captured["msgs"] == msgs
+    assert [r.id for r in res.regions] == ["a"]

--- a/tests/layout/test_designer_panel.py
+++ b/tests/layout/test_designer_panel.py
@@ -1,0 +1,35 @@
+# tests/layout/test_designer_panel.py
+from core.layout.models import Region
+from gui.layout.designer_panel import DesignerPanel, DesignerWorker
+from core.layout import designer
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def test_worker_emits_proposed_with_injected_completion(qapp):
+    msgs = designer.build_messages("comic", (200, 200), "one panel")
+    fake = lambda m: '{"layout": {"regions": [{"id":"a","kind":"image","bbox":[0,0,100,100]}]}}'
+    w = DesignerWorker(msgs, (200, 200), fake)
+    got = []
+    w.proposed.connect(lambda res: got.append(res))
+    w.run()  # run synchronously in-test (no thread start)
+    assert got and [r.id for r in got[0].regions] == ["a"]
+
+
+def test_panel_builds_and_reports_content_kind(qapp):
+    p = DesignerPanel(FakeConfig())
+    assert isinstance(p.content_kind(), str) and p.content_kind()
+
+
+def test_panel_start_design_emits_layout_proposed(qapp):
+    p = DesignerPanel(FakeConfig())
+    got = []
+    p.layoutProposed.connect(lambda res: got.append(res))
+    fake = lambda m: '{"layout": {"regions": [{"id":"z","kind":"text","bbox":[0,0,50,50],"text":"hi"}]}}'
+    p.start_design("a title page", (300, 300), completion_fn=fake)
+    assert got and [r.id for r in got[0].regions] == ["z"]

--- a/tests/layout/test_history.py
+++ b/tests/layout/test_history.py
@@ -23,3 +23,41 @@ def test_document_history_roundtrip():
     assert again.history[0].document == {"k": "v"}
     # content still intact
     assert again.pages[0].regions[0].text == "hi"
+
+
+def _doc_with_text(t):
+    from core.layout.models import DocumentSpec, PageSpec, Region
+    return DocumentSpec(title="D", pages=[PageSpec(page_size_px=(100, 100),
+                        regions=[Region(id="r1", kind="text", text=t)])])
+
+
+def test_history_append_snapshots_current_doc():
+    from core.layout.history import History
+    doc = _doc_with_text("v1")
+    h = History(doc)
+    s1 = h.append("first", snapshot_id="s1", timestamp="t1")
+    assert s1.id == "s1" and s1.parent_id is None
+    # snapshot captured the doc WITHOUT nesting history inside it
+    assert "history" not in s1.document
+    assert s1.document["pages"][0]["regions"][0]["text"] == "v1"
+    assert len(h.snapshots()) == 1
+
+
+def test_history_parent_chain_and_restore():
+    from core.layout.history import History
+    doc = _doc_with_text("v1")
+    h = History(doc)
+    h.append("first", snapshot_id="s1", timestamp="t1")
+    # mutate the live doc, snapshot again
+    doc.pages[0].regions[0].text = "v2"
+    s2 = h.append("second", snapshot_id="s2", timestamp="t2")
+    assert s2.parent_id == "s1"  # auto-parents to previous snapshot
+    restored = h.restore("s1")
+    assert restored.pages[0].regions[0].text == "v1"  # got s1 content
+    assert len(restored.history) == 2  # timeline preserved on the restored doc
+
+
+def test_history_get_missing_returns_none():
+    from core.layout.history import History
+    h = History(_doc_with_text("v1"))
+    assert h.get("nope") is None

--- a/tests/layout/test_history.py
+++ b/tests/layout/test_history.py
@@ -1,0 +1,25 @@
+from core.layout.models import Snapshot, DocumentSpec, PageSpec, Region
+from core.layout import schema
+
+
+def test_snapshot_roundtrip_via_schema():
+    snap = Snapshot(id="s1", parent_id=None, timestamp="2026-06-24 12:00",
+                    prompt="a 9-panel comic", document={"title": "X", "pages": []})
+    d = schema.snapshot_to_dict(snap)
+    again = schema.snapshot_from_dict(d)
+    assert again.id == "s1"
+    assert again.prompt == "a 9-panel comic"
+    assert again.document == {"title": "X", "pages": []}
+
+
+def test_document_history_roundtrip():
+    doc = DocumentSpec(title="Doc", pages=[PageSpec(page_size_px=(100, 100),
+                       regions=[Region(id="r1", kind="text", text="hi")])])
+    doc.history.append(Snapshot(id="s1", parent_id=None, timestamp="t",
+                                prompt="p", document={"k": "v"}))
+    again = schema.document_from_dict(schema.document_to_dict(doc))
+    assert len(again.history) == 1
+    assert again.history[0].id == "s1"
+    assert again.history[0].document == {"k": "v"}
+    # content still intact
+    assert again.pages[0].regions[0].text == "hi"

--- a/tests/layout/test_history_window.py
+++ b/tests/layout/test_history_window.py
@@ -1,0 +1,26 @@
+from core.layout.models import DocumentSpec, PageSpec, Region
+from core.layout.history import History
+from gui.layout.history_window import HistoryWindow
+
+
+def _history_with(n):
+    doc = DocumentSpec(title="D", pages=[PageSpec(page_size_px=(100, 100),
+                       regions=[Region(id="r1", kind="text", text="v")])])
+    h = History(doc)
+    for i in range(n):
+        h.append(f"step {i}", snapshot_id=f"s{i}", timestamp=f"t{i}")
+    return h
+
+
+def test_window_lists_snapshots(qapp):
+    win = HistoryWindow(_history_with(3))
+    assert win.list_widget.count() == 3
+
+
+def test_restore_emits_snapshot_id(qapp):
+    win = HistoryWindow(_history_with(2))
+    got = []
+    win.restoreRequested.connect(lambda sid: got.append(sid))
+    win.list_widget.setCurrentRow(0)
+    win._on_restore()  # internal slot
+    assert got == ["s0"]

--- a/tests/layout/test_layout_tab.py
+++ b/tests/layout/test_layout_tab.py
@@ -11,6 +11,8 @@ class FakeConfig:
         self.store["layout"] = cfg
     def save(self):
         pass
+    def get_layout_llm_provider(self):
+        return "google"
 
 
 def test_new_document_creates_one_page(qapp):

--- a/tests/layout/test_layout_tab_designer.py
+++ b/tests/layout/test_layout_tab_designer.py
@@ -1,0 +1,48 @@
+# tests/layout/test_layout_tab_designer.py
+from core.layout import designer
+from gui.layout.layout_tab import LayoutTab
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def test_apply_designer_result_sets_regions_and_snapshots(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    res = designer.DesignerResult(
+        questions=[], regions=[designer.Region(id="a", kind="image", bbox=(0, 0, 100, 100))],
+        raw="")
+    tab.apply_designer_result(res, user_text="one panel")
+    assert [r.id for r in tab.document.pages[0].regions] == ["a"]
+    assert len(tab.history.snapshots()) == 1
+    assert tab.history.snapshots()[0].prompt == "one panel"
+
+
+def test_restore_snapshot_reloads_document(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    # iteration 1
+    tab.apply_designer_result(
+        designer.DesignerResult(regions=[designer.Region(id="a", kind="image", bbox=(0, 0, 50, 50))]),
+        user_text="v1")
+    sid = tab.history.snapshots()[0].id
+    # iteration 2 (different regions)
+    tab.apply_designer_result(
+        designer.DesignerResult(regions=[designer.Region(id="b", kind="text", bbox=(0, 0, 50, 50), text="x")]),
+        user_text="v2")
+    assert [r.id for r in tab.document.pages[0].regions] == ["b"]
+    tab.restore_snapshot(sid)
+    assert [r.id for r in tab.document.pages[0].regions] == ["a"]  # back to v1
+
+
+def test_design_button_calls_start_design_with_page_size(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    captured = {}
+    tab.designer.start_design = lambda *a, **k: captured.setdefault("call", (a, k))
+    tab.designer.prompt_edit.setPlainText("a comic cover")
+    tab._on_design_clicked()
+    a, k = captured["call"]
+    assert a[0] == "a comic cover"                       # prompt text passed
+    assert a[1] == tab.document.pages[0].page_size_px    # current page size supplied

--- a/tests/layout/test_layout_tab_designer.py
+++ b/tests/layout/test_layout_tab_designer.py
@@ -46,3 +46,10 @@ def test_design_button_calls_start_design_with_page_size(qapp):
     a, k = captured["call"]
     assert a[0] == "a comic cover"                       # prompt text passed
     assert a[1] == tab.document.pages[0].page_size_px    # current page size supplied
+
+
+def test_apply_designer_result_questions_only_sets_status(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    res = designer.DesignerResult(questions=["how many panels?"], regions=None, raw="")
+    tab.apply_designer_result(res, user_text="a comic")
+    assert "question" in tab.status.text().lower()

--- a/tests/layout/test_layout_tab_style.py
+++ b/tests/layout/test_layout_tab_style.py
@@ -49,3 +49,26 @@ def test_open_legacy_project_seeds_style(qapp, tmp_path):
     tab = LayoutTab(config=FakeConfig())
     tab.open_project_from(str(p))
     assert tab.document.style is not None  # a default style is seeded for legacy projects
+
+
+def test_design_reseeds_style_on_kind_change(qapp):
+    from core.layout import designer
+    tab = LayoutTab(config=FakeConfig())
+    tab.designer.kind_combo.setCurrentText("comic")
+    tab.apply_designer_result(
+        designer.DesignerResult(regions=[designer.Region(id="a", kind="text",
+                                bbox=(0, 0, 50, 20), text="hi", role="dialogue")]),
+        user_text="v1")
+    assert tab.document.content_kind == "comic"
+    assert "dialogue" in tab.document.style.font_roles
+
+
+def test_user_style_edit_not_clobbered_by_design(qapp):
+    from core.layout import designer, styles
+    tab = LayoutTab(config=FakeConfig())
+    tab.apply_style(styles.default_style_for("scientific"))  # user picks a style
+    tab.designer.kind_combo.setCurrentText("comic")
+    tab.apply_designer_result(
+        designer.DesignerResult(regions=[designer.Region(id="a", kind="text", bbox=(0, 0, 50, 20))]),
+        user_text="v1")
+    assert "heading" in tab.document.style.font_roles  # scientific roles preserved, not reseeded

--- a/tests/layout/test_layout_tab_style.py
+++ b/tests/layout/test_layout_tab_style.py
@@ -39,3 +39,13 @@ def test_export_then_import_template_roundtrip(qapp, tmp_path):
     assert regions[0].text == ""          # content stripped
     assert regions[0].role == "title"     # structure kept
     assert tab2.document.style is not None
+
+
+def test_open_legacy_project_seeds_style(qapp, tmp_path):
+    import json
+    legacy = {"title": "Old", "pages": [{"page_size_px": [400, 400], "regions": []}]}
+    p = tmp_path / "old.iaiproj.json"
+    p.write_text(json.dumps(legacy), encoding="utf-8")
+    tab = LayoutTab(config=FakeConfig())
+    tab.open_project_from(str(p))
+    assert tab.document.style is not None  # a default style is seeded for legacy projects

--- a/tests/layout/test_layout_tab_style.py
+++ b/tests/layout/test_layout_tab_style.py
@@ -1,0 +1,41 @@
+# tests/layout/test_layout_tab_style.py
+from gui.layout.layout_tab import LayoutTab
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def test_new_document_has_style(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    assert tab.document.style is not None
+    assert tab.document.style.font_roles  # non-empty role set
+
+
+def test_apply_style_updates_document(qapp):
+    from core.layout import styles
+    tab = LayoutTab(config=FakeConfig())
+    st = styles.default_style_for("comic")
+    tab.apply_style(st)
+    assert "dialogue" in tab.document.style.font_roles
+
+
+def test_export_then_import_template_roundtrip(qapp, tmp_path):
+    from core.layout import designer
+    tab = LayoutTab(config=FakeConfig())
+    tab.apply_designer_result(
+        designer.DesignerResult(regions=[designer.Region(id="a", kind="text",
+                                bbox=(0, 0, 100, 30), text="Hi", role="title")]),
+        user_text="v1")
+    p = tmp_path / "t.iailayout.json"
+    tab.export_template_to(str(p))
+    tab2 = LayoutTab(config=FakeConfig())
+    tab2.import_template_from(str(p))
+    regions = tab2.document.pages[0].regions
+    assert [r.id for r in regions] == ["a"]
+    assert regions[0].text == ""          # content stripped
+    assert regions[0].role == "title"     # structure kept
+    assert tab2.document.style is not None

--- a/tests/layout/test_qt_renderer.py
+++ b/tests/layout/test_qt_renderer.py
@@ -47,3 +47,31 @@ def test_export_pdf(qapp, tmp_path):
     qt_renderer.export_document_pdf(doc, str(out))
     assert out.exists() and out.stat().st_size > 500
     assert out.read_bytes()[:4] == b"%PDF"
+
+
+def test_text_region_resolves_font_role_from_style(qapp):
+    from core.layout.models import Region, PageSpec, ProjectStyle, TextStyle
+    from core.layout import qt_renderer
+    from PySide6.QtWidgets import QGraphicsSimpleTextItem
+    style = ProjectStyle(font_roles={"title": TextStyle(family=["Georgia"], size_px=64, weight="bold")})
+    page = PageSpec(page_size_px=(400, 200), regions=[
+        Region(id="t", kind="text", bbox=(0, 0, 400, 100), text="Hi", role="title")])
+    scene = qt_renderer.build_scene(page, style=style)
+    texts = [it for it in scene.items() if isinstance(it, QGraphicsSimpleTextItem)]
+    assert texts, "expected a text item"
+    f = texts[0].font()
+    assert f.pixelSize() == 64
+    assert f.bold() is True
+
+
+def test_explicit_text_style_overrides_role(qapp):
+    from core.layout.models import Region, PageSpec, ProjectStyle, TextStyle
+    from core.layout import qt_renderer
+    from PySide6.QtWidgets import QGraphicsSimpleTextItem
+    style = ProjectStyle(font_roles={"title": TextStyle(family=["Georgia"], size_px=64)})
+    page = PageSpec(page_size_px=(400, 200), regions=[
+        Region(id="t", kind="text", bbox=(0, 0, 400, 100), text="Hi", role="title",
+               text_style=TextStyle(family=["Arial"], size_px=20))])
+    scene = qt_renderer.build_scene(page, style=style)
+    texts = [it for it in scene.items() if isinstance(it, QGraphicsSimpleTextItem)]
+    assert texts[0].font().pixelSize() == 20  # explicit style wins

--- a/tests/layout/test_qt_renderer.py
+++ b/tests/layout/test_qt_renderer.py
@@ -75,3 +75,16 @@ def test_explicit_text_style_overrides_role(qapp):
     scene = qt_renderer.build_scene(page, style=style)
     texts = [it for it in scene.items() if isinstance(it, QGraphicsSimpleTextItem)]
     assert texts[0].font().pixelSize() == 20  # explicit style wins
+
+
+def test_unroled_text_uses_default_text_role(qapp):
+    from core.layout.models import Region, PageSpec, ProjectStyle, TextStyle
+    from core.layout import qt_renderer
+    from PySide6.QtWidgets import QGraphicsSimpleTextItem
+    style = ProjectStyle(font_roles={"body": TextStyle(family=["Arial"], size_px=33)},
+                         default_text_role="body")
+    page = PageSpec(page_size_px=(400, 200), regions=[
+        Region(id="t", kind="text", bbox=(0, 0, 400, 100), text="Hi", role="")])
+    scene = qt_renderer.build_scene(page, style=style)
+    texts = [it for it in scene.items() if isinstance(it, QGraphicsSimpleTextItem)]
+    assert texts[0].font().pixelSize() == 33  # fell back to default_text_role

--- a/tests/layout/test_style_panel.py
+++ b/tests/layout/test_style_panel.py
@@ -1,0 +1,36 @@
+from core.layout.models import ProjectStyle, TextStyle
+from gui.layout.style_panel import StylePanel
+
+
+def _style():
+    return ProjectStyle(font_roles={
+        "title": TextStyle(family=["Georgia"], size_px=64, weight="bold"),
+        "body": TextStyle(family=["Arial"], size_px=28)},
+        palette={"text": "#111111"}, default_text_role="body")
+
+
+def test_panel_lists_roles(qapp):
+    p = StylePanel()
+    p.set_style(_style())
+    assert p.role_combo.count() == 2
+
+
+def test_editing_family_updates_style_and_emits(qapp):
+    p = StylePanel()
+    p.set_style(_style())
+    got = []
+    p.styleChanged.connect(lambda s: got.append(s))
+    p.role_combo.setCurrentText("title")
+    p.family_edit.setText("Impact")
+    p._on_field_changed()  # internal slot
+    assert p.style().font_roles["title"].family[0] == "Impact"
+    assert got and got[-1].font_roles["title"].family[0] == "Impact"
+
+
+def test_editing_size(qapp):
+    p = StylePanel()
+    p.set_style(_style())
+    p.role_combo.setCurrentText("body")
+    p.size_spin.setValue(40)
+    p._on_field_changed()
+    assert p.style().font_roles["body"].size_px == 40

--- a/tests/layout/test_style_panel.py
+++ b/tests/layout/test_style_panel.py
@@ -30,7 +30,10 @@ def test_editing_family_updates_style_and_emits(qapp):
 def test_editing_size(qapp):
     p = StylePanel()
     p.set_style(_style())
+    got = []
+    p.styleChanged.connect(lambda s: got.append(s))
     p.role_combo.setCurrentText("body")
     p.size_spin.setValue(40)
     p._on_field_changed()
     assert p.style().font_roles["body"].size_px == 40
+    assert got and got[-1].font_roles["body"].size_px == 40

--- a/tests/layout/test_styles.py
+++ b/tests/layout/test_styles.py
@@ -1,0 +1,36 @@
+from core.layout.models import ProjectStyle, DocumentSpec, PageSpec, TextStyle
+from core.layout import schema, styles
+
+
+def test_default_style_for_comic_has_dialogue_role():
+    st = styles.default_style_for("comic")
+    assert "dialogue" in st.font_roles
+    assert isinstance(st.font_roles["dialogue"], TextStyle)
+    assert st.default_text_role == "dialogue"
+    assert st.palette.get("text")
+
+
+def test_default_style_for_children_has_title_and_narration():
+    st = styles.default_style_for("children")
+    assert set(["title", "narration"]).issubset(st.font_roles.keys())
+
+
+def test_default_style_for_unknown_kind_falls_back():
+    st = styles.default_style_for("totally-made-up")
+    assert "body" in st.font_roles and "title" in st.font_roles
+
+
+def test_project_style_roundtrip_via_schema():
+    doc = DocumentSpec(title="D", pages=[PageSpec(page_size_px=(100, 100))],
+                       style=styles.default_style_for("comic"))
+    again = schema.document_from_dict(schema.document_to_dict(doc))
+    assert again.style is not None
+    assert "dialogue" in again.style.font_roles
+    assert again.style.font_roles["dialogue"].size_px == doc.style.font_roles["dialogue"].size_px
+    assert again.style.default_text_role == "dialogue"
+
+
+def test_document_without_style_roundtrips_none():
+    doc = DocumentSpec(title="D", pages=[PageSpec(page_size_px=(100, 100))])
+    again = schema.document_from_dict(schema.document_to_dict(doc))
+    assert again.style is None

--- a/tests/layout/test_template_io.py
+++ b/tests/layout/test_template_io.py
@@ -1,0 +1,33 @@
+from core.layout.models import Region, PageSpec, DocumentSpec
+from core.layout import template_io, styles
+
+
+def _doc():
+    page = PageSpec(page_size_px=(500, 500), regions=[
+        Region(id="img", kind="image", bbox=(0, 0, 200, 200), image_ref="/a.png",
+               prompt="a red car"),
+        Region(id="txt", kind="text", bbox=(0, 220, 500, 60), text="My Title", role="title"),
+    ])
+    doc = DocumentSpec(title="Proj", content_kind="comic", pages=[page],
+                       style=styles.default_style_for("comic"))
+    return doc
+
+
+def test_export_strips_content_keeps_structure(tmp_path):
+    p = tmp_path / "t.iailayout.json"
+    template_io.export_template(_doc(), str(p))
+    loaded = template_io.import_template(str(p))
+    regions = loaded.pages[0].regions
+    # geometry + shape + role + prompt preserved
+    assert [r.id for r in regions] == ["img", "txt"]
+    assert regions[0].bbox == (0, 0, 200, 200)
+    assert regions[0].prompt == "a red car"
+    assert regions[1].role == "title"
+    # content stripped
+    assert regions[0].image_ref is None
+    assert regions[1].text == ""
+    # style preserved
+    assert loaded.style is not None and "dialogue" in loaded.style.font_roles
+    # content_kind preserved, history dropped
+    assert loaded.content_kind == "comic"
+    assert loaded.history == []


### PR DESCRIPTION
## Summary

Phase 2 of the **AI Layout Designer**, on top of merged Phase 1 (#18). The Layout tab can now **design itself with AI**: describe a page (or type a change) → the text LLM proposes a structured layout and/or clarifying questions, rendered on the canvas → iterate in a loop, with a browsable **history** of every iteration (snapshot / restore / branch) persisted with the project.

- **Spec:** `Plans/2026-06-24-layout-ai-designer-design.md` (§5 designer, §6 history)
- **Plan:** `Plans/2026-06-24-layout-ai-designer-phase2-designer.md`
- **Summary:** `Plans/2026-06-24-layout-ai-designer-phase2-completion.md`

## What's included

| Area | Module(s) |
|---|---|
| Snapshot model + history persistence | `core/layout/models.py`, `core/layout/schema.py` |
| History manager (append/restore/branch) | `core/layout/history.py` |
| Designer: prompt build + parse + fallback + LLM call | `core/layout/designer.py` |
| Designer panel + QThread worker + status console | `gui/layout/designer_panel.py` |
| Browsable history window | `gui/layout/history_window.py` |
| Tab integration (design button, apply+snapshot, restore, History…) | `gui/layout/layout_tab.py` |

## Architecture

**Network isolation:** the only LLM network call is `designer.run_completion`; every other layer takes an injectable `completion_fn`, so all designer logic is unit-tested **headless without a network**. Production runs on a `QThread`; the injected/test path runs inline.

**Robust + graceful:** markdown-fenced JSON via the shared `LLMResponseParser`; non-list `questions` guarded; LLM geometry clamped into the page via `normalize_region`; empty/garbage → fallback layout (spec §5), never crashes.

**History hygiene:** snapshots never nest their own timeline (no unbounded growth); restore re-attaches the live timeline so branching works; persists in the project JSON, backward-compatible with Phase-1 files.

**§8 logging:** full request (provider/model/temperature/messages) + full response logged to the file logger and surfaced in the designer status console.

## Testing

- **21 new tests** (56 total under `tests/layout/`), headless offscreen Qt: **56 passed, 0 warnings**.
- No new runtime deps (reuses `LiteLLMHandler`/`LLMResponseParser`/`DialogStatusConsole` + the model registry). Model IDs resolved via the registry (`get_provider_models`/`get_provider_prefix`), never hardcoded.
- Backward compatible: `LayoutTab(config=...)` signature unchanged; package import chain verified.

## Process

Subagent-driven TDD (implementer + reviewer per task, fix loops) + a final whole-branch review (opus). Review-loop catches: non-list-`questions` parsing, parsed-dict mutation, the design-button wiring, and the §8 full-prompt/response logging gap.

## Deferred (documented decision)

**Provider display-name→id threading** (`designer_panel` + `run_completion`) is correct for all five registered providers and mirrors the proven `text_gen_dialog` two-map pattern. NOT refactored here because the naive "pass the registry id" fix would **break Google gcloud/key auth** (the app stores Google's key under `"google"` while the registry id is `"gemini"`). A proper fix is a repo-wide provider-id refactor (touching `text_gen_dialog` too), out of Phase-2 scope.

## Notes

- Phase 2 renders proposed regions as the same gray placeholders as Phase 1 — actual content filling (image import, text editing) is Phase 4, by design.
- Next: Phase 3 (project style system + template sharing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117xE9FzFFp3mZfgW3SNuD8