### PR TITLE
feat(layout): Phase 4 — Content MVP (fill image/text, export PDF)

### DIFF
--- a/Plans/2026-06-24-layout-ai-designer-phase4-completion.md
+++ b/Plans/2026-06-24-layout-ai-designer-phase4-completion.md
@@ -1,0 +1,71 @@
+# Phase 4 — Content MVP — Completion Summary ✅
+**Last Updated:** 2026-06-24 17:25
+
+Part of the AI Layout Designer redesign. Implements **F-MVP** (spec §9 Subsystem
+F): fill the placeholders the designer/canvas produce, yielding a finished,
+exportable page — with **no** AI content features.
+
+Branch: `feat/layout-ai-designer-phase4` (stacked on
+`feat/layout-ai-designer-phase3`). Plan:
+`Plans/2026-06-24-layout-ai-designer-phase4-content.md`.
+
+## What shipped
+1. **Renderer fix** (`core/layout/qt_renderer.py`): a *filled* image region's
+   pixmap is drawn on top of the placeholder rect; it now receives the same
+   selectable flags (`_apply_flags`) instead of bare `setData`, so clicking a
+   filled image re-selects its region (prerequisite for changing an existing
+   image).
+2. **`ContentInspector`** (`gui/layout/content_inspector.py`, NEW): a compact
+   per-region editor.
+   - Image region → **Import image…** (`QFileDialog`) and **From history…**
+     (reuses the existing `ImageHistoryDialog`) + a current-ref label.
+   - Text region → `QPlainTextEdit` + **Apply text**.
+   - Emits `regionContentChanged(region_id, value)`; the inspector only
+     *displays* the region — it never mutates the document.
+3. **LayoutTab wiring** (`gui/layout/layout_tab.py`): `canvas.regionSelected` →
+   `inspector.set_region`; `regionContentChanged` → `set_region_content(id,
+   value)` which sets `image_ref`/`text` on the region and re-renders. The
+   inspector resets on every `_adopt_document`. `set_region_content` is the
+   programmatic hook Phase 5 will reuse to place images by region id.
+
+## Design decisions
+- **Single-mutator pattern**: `LayoutTab` owns all document mutation (mirrors
+  `apply_style` / `apply_designer_result`). The inspector is display-only +
+  signals.
+- **Reused** `ImageHistoryDialog` (clean API: `(config, parent)` →
+  `get_selected_image()`); did **not** revive the retired template-era
+  `inspector_widget.py` (legacy block model, zero live references).
+
+## Tests
+- `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q`
+  → **88 passed, 0 warnings** (75 before Phase 4 → +13).
+- New: `test_qt_renderer.py::test_filled_image_region_is_selectable`;
+  `test_content_inspector.py` (5: editor switching, import emit, cancel no-op,
+  from-history emit, apply-text emit); `test_layout_tab_content.py` (7: selection
+  routing, **real canvas-selection→inspector wiring**, image/text content change,
+  unknown-id no-op, reset-on-new-document, and the **F-MVP E2E acceptance** —
+  design → fill image+text → export valid PDF).
+
+## Whole-branch review
+opus structured review over `feat/layout-ai-designer-phase3..HEAD`.
+**Verdict: APPROVE** — no Critical or Important issues. It confirmed the key
+design point (the single-mutator path re-fetches the region by id in
+`set_region_content`, so the inspector's held reference can never cause a
+wrong-region edit after `_refresh` rebuilds the scene) and that the renderer's
+two same-id selectable items are unambiguous for `selected_region_id()`.
+
+One consolidated fix wave applied the optional Minor items (`ad40a27`):
+- pixmap overlay is selectable but **not** movable (`_apply_flags(..., movable=
+  False)`) — can't drag a filled image off its placeholder.
+- `ContentInspector._set_image_ref` guards a null region.
+- `set_region_content` skips the re-render when the value is unchanged.
+- `_find_region` documents the single-page (pages[0]) MVP assumption.
+- added a test that a real scene selection drives the inspector.
+
+## Out of scope (Phase 5 / later)
+- Per-region AI prompt help, "Send to Image tab", batch placement,
+  layout-complete mode, `.iaibundle` (F-AI / bundles).
+- Multi-page content editing (only page 0 is wired — matches the rest of the tab,
+  which operates on `pages[0]`).
+- PNG transparency / image-path page backgrounds (renderer deferrals).
+- Per-region role picker / custom-role editor (Phase 3 deferral).

--- a/Plans/2026-06-24-layout-ai-designer-phase4-content.md
+++ b/Plans/2026-06-24-layout-ai-designer-phase4-content.md
@@ -1,0 +1,465 @@
+# Phase 4 — Content MVP (F-MVP) ⏳ 0%
+**Last Updated:** 2026-06-24 17:05
+
+Part of the AI Layout Designer redesign (whole-vision spec:
+`Plans/2026-06-24-layout-ai-designer-design.md`, §9 Subsystem F). Phases 1–3 are
+done and PR'd (#18 merged, #19/#20 open). This branch
+(`feat/layout-ai-designer-phase4`, stacked on `feat/layout-ai-designer-phase3`)
+implements **F-MVP**: fill the placeholders the designer/canvas already produce.
+
+## Goal (spec §9 F-MVP)
+> Select an image region → **import an image file** *or* pick from the existing
+> generated-image history (`ImageHistoryDialog`) → fills the placeholder. Select a
+> text region → **edit text**. This alone yields a finished, exportable page.
+
+**Acceptance:** a user fills every region of an AI-designed page with imported
+images and typed text and exports a correct PDF — **no** AI content features
+required.
+
+## Design decisions (from exploration)
+- **Reuse `gui/layout/image_history_dialog.py`** as-is: `ImageHistoryDialog(config,
+  parent)` browses generated images via sidecar metadata; `get_selected_image()`
+  returns the chosen path. API fits the "From history…" picker exactly.
+- **Build a NEW `gui/layout/content_inspector.py`**; do **not** revive the retired
+  `gui/layout/inspector_widget.py` (template-era, uses the legacy `TextBlock`/
+  `ImageBlock` model; confirmed: zero live references).
+- **Single-mutator pattern:** the inspector never mutates the document. It displays
+  the selected `Region` and emits `regionContentChanged(region_id, value)`.
+  `LayoutTab` owns all document mutation (consistent with `apply_style` /
+  `apply_designer_result`): it looks up the region by id and sets `image_ref`
+  (image kind) or `text` (text kind), then `_refresh()`. The renderer already draws
+  `image_ref` scaled-to-fit and resolves text styles, so a content change is just
+  "set attribute → re-render".
+
+## Architecture touch-points (already built)
+- `core/layout/qt_renderer.py::_add_image_region` draws a placeholder rect (with
+  selectable flags) then, if `image_ref` loads, a pixmap on top. **Bug:** the
+  pixmap gets `setData(0, r.id)` but **not** the selectable flags, so a *filled*
+  image region can't be re-selected by clicking it (the non-selectable pixmap on
+  top swallows the click). Fixed in Task 1.
+- `gui/layout/canvas_widget.py` emits `regionSelected(str)` ("" on deselect);
+  `selected_region_id()` reads `item.data(0)`.
+- `gui/layout/layout_tab.py`: `_adopt_document` centralizes load paths; `_refresh`
+  → `canvas.load_page(page, style)`. Add inspector here.
+
+---
+
+## Task 1 — Renderer: filled image regions are selectable ⏳
+**File:** `core/layout/qt_renderer.py` · **Test:** `tests/layout/test_qt_renderer.py`
+
+Apply the selectable flags to the loaded-image pixmap so clicking a filled image
+selects its region (prerequisite for editing already-filled regions).
+
+### Test (add to `tests/layout/test_qt_renderer.py`)
+```python
+def test_filled_image_region_is_selectable(qapp, tmp_path):
+    from PySide6.QtWidgets import QGraphicsItem
+    from PySide6.QtGui import QImage
+    from PySide6.QtCore import Qt
+    img_path = tmp_path / "ref.png"
+    im = QImage(20, 20, QImage.Format_RGB32)
+    im.fill(Qt.white)
+    assert im.save(str(img_path))
+    page = PageSpec(page_size_px=(200, 150), background="#FFFFFF", regions=[
+        Region(id="img1", kind="image", bbox=(10, 10, 80, 80), image_ref=str(img_path))])
+    scene = qt_renderer.build_scene(page, selectable=True)
+    sel = [it for it in scene.items()
+           if (it.flags() & QGraphicsItem.ItemIsSelectable) and it.data(0) == "img1"]
+    assert sel, "a filled image region must expose a selectable item carrying its id"
+```
+
+### Change (`_add_image_region`)
+Replace the pixmap's `pi.setData(0, r.id)` with `_apply_flags(pi, selectable, r.id)`:
+```python
+    if r.image_ref:
+        pix = QPixmap(r.image_ref)
+        if not pix.isNull():
+            scaled = pix.scaled(int(w), int(h), Qt.KeepAspectRatio, Qt.SmoothTransformation)
+            pi = QGraphicsPixmapItem(scaled)
+            pi.setPos(x, y)
+            _apply_flags(pi, selectable, r.id)
+            scene.addItem(pi)
+            return
+```
+
+---
+
+## Task 2 — `ContentInspector` widget ⏳
+**File:** `gui/layout/content_inspector.py` (new) ·
+**Test:** `tests/layout/test_content_inspector.py` (new)
+
+A compact editor for the selected region. Image kind → "Import image…" /
+"From history…" buttons + a ref label. Text kind → `QPlainTextEdit` + "Apply text".
+Emits `regionContentChanged(region_id, value)`. No-selection → empty page.
+
+### Implementation (`gui/layout/content_inspector.py`)
+```python
+"""Content inspector: edit the selected region's content (image ref or text)."""
+from typing import Optional
+
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QStackedWidget, QLabel, QPushButton,
+    QPlainTextEdit, QFileDialog,
+)
+from PySide6.QtCore import Signal
+
+from core.layout.models import Region
+
+
+class ContentInspector(QWidget):
+    """Edits the content of the currently selected region.
+
+    Emits ``regionContentChanged(region_id, value)``:
+      - image region -> ``value`` is the chosen image path (becomes ``image_ref``)
+      - text region  -> ``value`` is the new text
+    The inspector only *displays* the region; ``LayoutTab`` owns the mutation.
+    """
+
+    regionContentChanged = Signal(str, str)  # (region_id, new_value)
+
+    def __init__(self, config=None, parent=None):
+        super().__init__(parent)
+        self._config = config
+        self._region: Optional[Region] = None
+        self._build()
+        self.set_region(None)
+
+    def _build(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        self.header = QLabel("No region selected")
+        self.header.setStyleSheet("font-weight: bold;")
+        root.addWidget(self.header)
+
+        self.stack = QStackedWidget()
+        root.addWidget(self.stack, 1)
+
+        # page 0 — nothing selected
+        self.stack.addWidget(QWidget())
+
+        # page 1 — image controls
+        img_page = QWidget()
+        img_lay = QVBoxLayout(img_page)
+        img_lay.setContentsMargins(0, 0, 0, 0)
+        btn_row = QHBoxLayout()
+        self.import_btn = QPushButton("Import image…")
+        self.import_btn.clicked.connect(self._on_import_image)
+        self.history_btn = QPushButton("From history…")
+        self.history_btn.clicked.connect(self._on_from_history)
+        btn_row.addWidget(self.import_btn)
+        btn_row.addWidget(self.history_btn)
+        btn_row.addStretch(1)
+        img_lay.addLayout(btn_row)
+        self.image_ref_label = QLabel("(no image)")
+        self.image_ref_label.setWordWrap(True)
+        self.image_ref_label.setStyleSheet("color: #666; font-size: 11px;")
+        img_lay.addWidget(self.image_ref_label)
+        img_lay.addStretch(1)
+        self.stack.addWidget(img_page)
+
+        # page 2 — text editor
+        txt_page = QWidget()
+        txt_lay = QVBoxLayout(txt_page)
+        txt_lay.setContentsMargins(0, 0, 0, 0)
+        self.text_edit = QPlainTextEdit()
+        self.text_edit.setPlaceholderText("Type the text for this region…")
+        self.text_edit.setFixedHeight(90)
+        txt_lay.addWidget(self.text_edit)
+        self.apply_text_btn = QPushButton("Apply text")
+        self.apply_text_btn.clicked.connect(self._on_apply_text)
+        txt_lay.addWidget(self.apply_text_btn)
+        self.stack.addWidget(txt_page)
+
+    def set_region(self, region: Optional[Region]):
+        """Show the editor for ``region`` (or the empty page when None)."""
+        self._region = region
+        if region is None:
+            self.header.setText("No region selected")
+            self.stack.setCurrentIndex(0)
+            return
+        label = region.name or region.id
+        if region.kind == "image":
+            self.header.setText(f"Image region: {label}")
+            self.image_ref_label.setText(region.image_ref or "(no image)")
+            self.stack.setCurrentIndex(1)
+        else:
+            self.header.setText(f"Text region: {label}")
+            self.text_edit.blockSignals(True)
+            self.text_edit.setPlainText(region.text or "")
+            self.text_edit.blockSignals(False)
+            self.stack.setCurrentIndex(2)
+
+    # --- image ---
+    def _on_import_image(self):
+        if self._region is None:
+            return
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Import Image", "",
+            "Images (*.png *.jpg *.jpeg *.webp *.bmp *.gif)")
+        if path:
+            self._set_image_ref(path)
+
+    def _on_from_history(self):
+        if self._region is None:
+            return
+        from gui.layout.image_history_dialog import ImageHistoryDialog
+        dlg = ImageHistoryDialog(self._config, self)
+        if dlg.exec():
+            path = dlg.get_selected_image()
+            if path:
+                self._set_image_ref(path)
+
+    def _set_image_ref(self, path: str):
+        self.image_ref_label.setText(path)
+        self.regionContentChanged.emit(self._region.id, path)
+
+    # --- text ---
+    def _on_apply_text(self):
+        if self._region is None:
+            return
+        self.regionContentChanged.emit(self._region.id, self.text_edit.toPlainText())
+```
+
+### Tests (`tests/layout/test_content_inspector.py`)
+```python
+# tests/layout/test_content_inspector.py
+from core.layout.models import Region
+from gui.layout.content_inspector import ContentInspector
+
+
+def _img(rid="i", ref=None):
+    return Region(id=rid, kind="image", bbox=(0, 0, 10, 10), image_ref=ref)
+
+
+def _txt(rid="t", text=""):
+    return Region(id=rid, kind="text", bbox=(0, 0, 10, 10), text=text)
+
+
+def test_set_region_switches_editor(qapp):
+    insp = ContentInspector()
+    insp.set_region(_img(ref="/p.png"))
+    assert insp.stack.currentIndex() == 1
+    assert "/p.png" in insp.image_ref_label.text()
+    insp.set_region(_txt(text="hello"))
+    assert insp.stack.currentIndex() == 2
+    assert insp.text_edit.toPlainText() == "hello"
+    insp.set_region(None)
+    assert insp.stack.currentIndex() == 0
+
+
+def test_import_image_emits(qapp, monkeypatch):
+    from gui.layout import content_inspector as ci
+    insp = ContentInspector()
+    insp.set_region(_img(rid="i1"))
+    monkeypatch.setattr(ci.QFileDialog, "getOpenFileName",
+                        staticmethod(lambda *a, **k: ("/tmp/x.png", "")))
+    got = []
+    insp.regionContentChanged.connect(lambda rid, v: got.append((rid, v)))
+    insp.import_btn.click()
+    assert got == [("i1", "/tmp/x.png")]
+
+
+def test_import_cancelled_emits_nothing(qapp, monkeypatch):
+    from gui.layout import content_inspector as ci
+    insp = ContentInspector()
+    insp.set_region(_img(rid="i1"))
+    monkeypatch.setattr(ci.QFileDialog, "getOpenFileName",
+                        staticmethod(lambda *a, **k: ("", "")))
+    got = []
+    insp.regionContentChanged.connect(lambda rid, v: got.append((rid, v)))
+    insp.import_btn.click()
+    assert got == []
+
+
+def test_from_history_emits(qapp, monkeypatch):
+    import gui.layout.image_history_dialog as ihd
+
+    class FakeDlg:
+        def __init__(self, config, parent=None):
+            pass
+
+        def exec(self):
+            return True
+
+        def get_selected_image(self):
+            return "/hist/a.png"
+
+    monkeypatch.setattr(ihd, "ImageHistoryDialog", FakeDlg)
+    insp = ContentInspector(config=object())
+    insp.set_region(_img(rid="i2"))
+    got = []
+    insp.regionContentChanged.connect(lambda rid, v: got.append((rid, v)))
+    insp.history_btn.click()
+    assert got == [("i2", "/hist/a.png")]
+
+
+def test_apply_text_emits(qapp):
+    insp = ContentInspector()
+    insp.set_region(_txt(rid="t1", text="old"))
+    got = []
+    insp.regionContentChanged.connect(lambda rid, v: got.append((rid, v)))
+    insp.text_edit.setPlainText("new text")
+    insp.apply_text_btn.click()
+    assert got == [("t1", "new text")]
+```
+
+---
+
+## Task 3 — Wire `ContentInspector` into `LayoutTab` ⏳
+**File:** `gui/layout/layout_tab.py` ·
+**Test:** `tests/layout/test_layout_tab_content.py` (new)
+
+Selection drives the inspector; content edits mutate the document and re-render.
+Expose a programmatic `set_region_content(region_id, value)` (used by tests and
+re-used by Phase 5's place-by-id). Reset the inspector on every document adopt.
+
+### Changes (`gui/layout/layout_tab.py`)
+1. Import: `from gui.layout.content_inspector import ContentInspector`.
+2. In `_build()`, after `self.canvas` is added:
+```python
+        self.inspector = ContentInspector(self.config)
+        self.inspector.regionContentChanged.connect(self._on_region_content_changed)
+        root.addWidget(self.inspector)
+        self.canvas.regionSelected.connect(self._on_region_selected)
+```
+3. In `_adopt_document()`, after the style-panel reset, reset the inspector too:
+```python
+        if hasattr(self, "inspector"):
+            self.inspector.set_region(None)
+```
+4. New methods (place after `_refresh`):
+```python
+    # --- content inspector ---
+    def _find_region(self, region_id: str):
+        if not region_id or not self.document or not self.document.pages:
+            return None
+        for r in self.document.pages[0].regions:
+            if r.id == region_id:
+                return r
+        return None
+
+    def _on_region_selected(self, region_id: str):
+        self.inspector.set_region(self._find_region(region_id))
+
+    def _on_region_content_changed(self, region_id: str, value: str):
+        self.set_region_content(region_id, value)
+
+    def set_region_content(self, region_id: str, value: str):
+        """Apply edited content to a region and re-render (programmatic API)."""
+        region = self._find_region(region_id)
+        if region is None:
+            return
+        if region.kind == "image":
+            region.image_ref = value
+        else:
+            region.text = value
+        self._refresh()
+```
+
+### Tests (`tests/layout/test_layout_tab_content.py`)
+```python
+# tests/layout/test_layout_tab_content.py
+from core.layout import designer
+from gui.layout.layout_tab import LayoutTab
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tab_with_regions():
+    tab = LayoutTab(config=FakeConfig())
+    tab.apply_designer_result(designer.DesignerResult(regions=[
+        designer.Region(id="img", kind="image", bbox=(0, 0, 100, 100)),
+        designer.Region(id="txt", kind="text", bbox=(0, 110, 100, 40), text="", role="title"),
+    ]), user_text="page")
+    return tab
+
+
+def test_selecting_region_populates_inspector(qapp):
+    tab = _tab_with_regions()
+    tab._on_region_selected("img")
+    assert tab.inspector.stack.currentIndex() == 1   # image editor
+    tab._on_region_selected("txt")
+    assert tab.inspector.stack.currentIndex() == 2   # text editor
+    tab._on_region_selected("")                      # deselect
+    assert tab.inspector.stack.currentIndex() == 0
+
+
+def test_image_content_change_sets_image_ref(qapp):
+    tab = _tab_with_regions()
+    tab._on_region_content_changed("img", "/path/to/pic.png")
+    assert tab.document.pages[0].regions[0].image_ref == "/path/to/pic.png"
+
+
+def test_text_content_change_sets_text(qapp):
+    tab = _tab_with_regions()
+    tab._on_region_content_changed("txt", "Once upon a time")
+    assert tab.document.pages[0].regions[1].text == "Once upon a time"
+
+
+def test_set_region_content_unknown_id_is_noop(qapp):
+    tab = _tab_with_regions()
+    tab.set_region_content("nope", "x")  # must not raise
+    assert tab.document.pages[0].regions[0].image_ref is None
+
+
+def test_inspector_resets_on_new_document(qapp):
+    tab = _tab_with_regions()
+    tab._on_region_selected("img")
+    assert tab.inspector.stack.currentIndex() == 1
+    tab.new_document()
+    assert tab.inspector.stack.currentIndex() == 0
+```
+
+---
+
+## Task 4 — End-to-end acceptance ⏳
+**File:** `tests/layout/test_layout_tab_content.py` (extend)
+
+Prove the F-MVP acceptance: design a page, fill an image region (real file) and a
+text region, export a valid PDF.
+
+```python
+def test_fill_image_and_text_then_export_pdf(qapp, tmp_path):
+    from PySide6.QtGui import QImage
+    from PySide6.QtCore import Qt
+    tab = _tab_with_regions()
+
+    img_path = tmp_path / "pic.png"
+    im = QImage(40, 40, QImage.Format_RGB32)
+    im.fill(Qt.blue)
+    assert im.save(str(img_path))
+
+    tab.set_region_content("img", str(img_path))
+    tab.set_region_content("txt", "The Title")
+
+    page = tab.document.pages[0]
+    assert page.regions[0].image_ref == str(img_path)
+    assert page.regions[1].text == "The Title"
+
+    out = tmp_path / "out.pdf"
+    tab.export_pdf_to(str(out))
+    assert out.exists() and out.read_bytes()[:4] == b"%PDF"
+```
+
+---
+
+## Process
+- TDD per task: write/extend the test, watch it fail, implement, `QT_QPA_PLATFORM=
+  offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` → green, 0 warnings.
+- After all 4 tasks: **whole-branch review on opus** over `merge-base..HEAD`, one
+  consolidated fix wave, completion summary, push, **stacked PR** (base =
+  `feat/layout-ai-designer-phase3`).
+- Python: `.venv_linux/bin/python` only. No `cd`. Commit subjects ≤72 chars with the
+  Co-Authored-By / Claude-Session trailers.
+
+## Out of scope (deferred to Phase 5 / later)
+- Per-region AI prompt help, "Send to Image tab", batch placement, layout-complete
+  mode, `.iaibundle` (all F-AI / bundles — Phase 5).
+- PNG transparency and image-path page backgrounds (renderer deferrals noted in the
+  Phase 1/3 summaries); not required for the F-MVP PDF acceptance.
+- Per-region role picker / custom-role editor (Phase 3 deferral).

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -52,6 +52,29 @@ def build_messages(content_kind: str, page_px: Tuple[int, int], user_text: str,
     return [{"role": "system", "content": _SYSTEM}, {"role": "user", "content": user}]
 
 
+def resolve_provider_ids(provider: str) -> Tuple[str, str]:
+    """Map a provider *display name* (or id/alias) to ``(api_key_id, registry_id)``.
+
+    ``api_key_id`` is the id the app stores the key under (Google's key lives
+    under ``"google"``); ``registry_id`` is the id ``core.llm_models`` knows
+    (Google → ``"gemini"``). They intentionally differ only for Google. This is
+    the single source of truth shared by the designer panel (model listing) and
+    ``run_completion`` (the production call) so the two can't drift apart.
+    """
+    p = (provider or "").strip().lower()
+    table = {
+        "openai": ("openai", "openai"),
+        "anthropic": ("anthropic", "anthropic"),
+        "claude": ("anthropic", "anthropic"),   # defensive: display name is "Anthropic"
+        "google": ("google", "gemini"),
+        "gemini": ("google", "gemini"),
+        "ollama": ("ollama", "ollama"),
+        "lm studio": ("lmstudio", "lmstudio"),
+        "lmstudio": ("lmstudio", "lmstudio"),
+    }
+    return table.get(p, (p, p))
+
+
 @dataclass
 class DesignerResult:
     questions: List[str] = field(default_factory=list)
@@ -112,10 +135,7 @@ def run_completion(config, provider: str, model: str, messages: List[Dict],
     if not ok or litellm is None:
         raise RuntimeError("Failed to initialize LiteLLM")
     provider = provider or (config.get_layout_llm_provider() if config else "google")
-    provider_map = {"google": "google", "anthropic": "anthropic", "openai": "openai",
-                    "ollama": "ollama", "lm studio": "lmstudio"}
-    pid_api = provider_map.get(provider.lower(), provider.lower())
-    pid = "gemini" if pid_api == "google" else pid_api
+    pid_api, pid = resolve_provider_ids(provider)
     api_key = None
     auth_mode = "api-key"
     if pid_api == "google" and config is not None:

--- a/core/layout/history.py
+++ b/core/layout/history.py
@@ -12,6 +12,11 @@ class History:
 
     def __init__(self, document: DocumentSpec):
         self.document = document
+        # The snapshot the next append should parent to. None → fall back to the
+        # latest snapshot (linear history). Set by branch_from() after a restore
+        # so a design that continues from a restored point records the real
+        # branch topology rather than re-parenting to the timeline's tail.
+        self._current_id: Optional[str] = None
 
     def snapshots(self) -> List[Snapshot]:
         return self.document.history
@@ -26,8 +31,11 @@ class History:
                timestamp: Optional[str] = None, parent_id: Optional[str] = None) -> Snapshot:
         doc_dict = schema.document_to_dict(self.document)
         doc_dict.pop("history", None)  # never nest history inside a snapshot
-        if parent_id is None and self.document.history:
-            parent_id = self.document.history[-1].id
+        if parent_id is None:
+            if self._current_id is not None:
+                parent_id = self._current_id
+            elif self.document.history:
+                parent_id = self.document.history[-1].id
         snap = Snapshot(
             id=snapshot_id or uuid.uuid4().hex[:8],
             parent_id=parent_id,
@@ -36,7 +44,13 @@ class History:
             document=doc_dict,
         )
         self.document.history.append(snap)
+        self._current_id = snap.id  # subsequent appends chain from this snapshot
         return snap
+
+    def branch_from(self, snapshot_id: str) -> None:
+        """Record the snapshot a restore branched from, so the next append
+        parents to it (faithful branch topology, not the timeline's tail)."""
+        self._current_id = snapshot_id
 
     def restore(self, snapshot_id: str) -> DocumentSpec:
         snap = self.get(snapshot_id)

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -27,11 +27,13 @@ def _resolve_bg(page: PageSpec) -> str:
     return "#FFFFFF"
 
 
-def _apply_flags(item: QGraphicsItem, selectable: bool, region_id: str) -> None:
+def _apply_flags(item: QGraphicsItem, selectable: bool, region_id: str,
+                 *, movable: bool = True) -> None:
     item.setData(0, region_id)
     if selectable:
         item.setFlag(QGraphicsItem.ItemIsSelectable, True)
-        item.setFlag(QGraphicsItem.ItemIsMovable, True)
+        if movable:
+            item.setFlag(QGraphicsItem.ItemIsMovable, True)
 
 
 def _add_image_region(scene: QGraphicsScene, r: Region, selectable: bool) -> None:
@@ -52,7 +54,10 @@ def _add_image_region(scene: QGraphicsScene, r: Region, selectable: bool) -> Non
             scaled = pix.scaled(int(w), int(h), Qt.KeepAspectRatio, Qt.SmoothTransformation)
             pi = QGraphicsPixmapItem(scaled)
             pi.setPos(x, y)
-            _apply_flags(pi, selectable, r.id)
+            # Selectable so a filled image can be re-picked, but not movable —
+            # it sits on top of the (movable) placeholder rect and shouldn't be
+            # dragged off it.
+            _apply_flags(pi, selectable, r.id, movable=False)
             scene.addItem(pi)
             return
 

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -52,7 +52,7 @@ def _add_image_region(scene: QGraphicsScene, r: Region, selectable: bool) -> Non
             scaled = pix.scaled(int(w), int(h), Qt.KeepAspectRatio, Qt.SmoothTransformation)
             pi = QGraphicsPixmapItem(scaled)
             pi.setPos(x, y)
-            pi.setData(0, r.id)
+            _apply_flags(pi, selectable, r.id)
             scene.addItem(pi)
             return
 

--- a/core/layout/schema.py
+++ b/core/layout/schema.py
@@ -1,11 +1,21 @@
 """Serialization, normalization, and validation for layout documents."""
-from dataclasses import asdict, replace
+from dataclasses import asdict, replace, fields
 from typing import Dict, List, Tuple
 
 from core.layout.models import (
     Region, PageSpec, DocumentSpec, PageSize, TextStyle, ImageStyle, Snapshot, ProjectStyle,
     migrate_legacy_blocks, TextBlock, ImageBlock,
 )
+
+
+def _filtered(cls, d: Dict) -> Dict:
+    """Keep only keys that are real fields of dataclass ``cls``.
+
+    Lets a hand-edited or forward-version file carrying extra/renamed keys load
+    instead of crashing with ``TypeError: unexpected keyword argument``.
+    """
+    valid = {f.name for f in fields(cls)}
+    return {k: v for k, v in d.items() if k in valid}
 
 REGION_JSON_SCHEMA: Dict = {
     "type": "object",
@@ -44,15 +54,15 @@ def region_from_dict(d: Dict) -> Region:
     ts = d.get("text_style")
     is_ = d.get("image_style")
     return Region(
-        id=d["id"], kind=d["kind"], shape=d.get("shape", "rect"),
+        id=d.get("id", ""), kind=d.get("kind", "image"), shape=d.get("shape", "rect"),
         bbox=tuple(d.get("bbox", (0, 0, 100, 100))),
         points=[tuple(p) for p in d.get("points", [])],
         z=int(d.get("z", 0)), name=d.get("name", ""),
         text=d.get("text", ""), role=d.get("role", ""),
         image_ref=d.get("image_ref"), prompt=d.get("prompt", ""),
         gen_settings=dict(d.get("gen_settings", {})),
-        text_style=TextStyle(**ts) if ts else None,
-        image_style=ImageStyle(**is_) if is_ else None,
+        text_style=TextStyle(**_filtered(TextStyle, ts)) if ts else None,
+        image_style=ImageStyle(**_filtered(ImageStyle, is_)) if is_ else None,
     )
 
 
@@ -81,14 +91,15 @@ def project_style_to_dict(s: "ProjectStyle") -> Dict:
 
 def project_style_from_dict(d: Dict) -> "ProjectStyle":
     return ProjectStyle(
-        font_roles={name: TextStyle(**ts) for name, ts in d.get("font_roles", {}).items()},
+        font_roles={name: TextStyle(**_filtered(TextStyle, ts))
+                    for name, ts in d.get("font_roles", {}).items()},
         palette=dict(d.get("palette", {})),
         default_text_role=d.get("default_text_role", "body"),
     )
 
 
 def _page_size_from_dict(d):
-    return PageSize(**d) if d else None
+    return PageSize(**_filtered(PageSize, d)) if d else None
 
 
 def page_to_dict(p: PageSpec) -> Dict:
@@ -107,11 +118,12 @@ def page_from_dict(d: Dict) -> PageSpec:
     else:  # legacy: migrate blocks -> regions
         legacy = []
         for b in d.get("blocks", []):
+            rect = tuple(b.get("rect", (0, 0, 100, 100)))
             if b.get("type") == "image":
-                legacy.append(ImageBlock(id=b["id"], rect=tuple(b["rect"]),
+                legacy.append(ImageBlock(id=b.get("id", ""), rect=rect,
                                          image_path=b.get("image_path")))
             else:
-                legacy.append(TextBlock(id=b["id"], rect=tuple(b["rect"]),
+                legacy.append(TextBlock(id=b.get("id", ""), rect=rect,
                                         text=b.get("text", "")))
         regions = migrate_legacy_blocks(legacy)
     return PageSpec(

--- a/gui/layout/canvas_widget.py
+++ b/gui/layout/canvas_widget.py
@@ -27,6 +27,7 @@ class CanvasWidget(QGraphicsView):
                 old.selectionChanged.disconnect(self._on_selection_changed)
             except (RuntimeError, TypeError):
                 pass
+            old.deleteLater()  # don't let replaced scenes accumulate as children
         self._page = page
         scene = qt_renderer.build_scene(page, selectable=True, style=style)
         scene.setParent(self)

--- a/gui/layout/content_inspector.py
+++ b/gui/layout/content_inspector.py
@@ -115,6 +115,8 @@ class ContentInspector(QWidget):
                 self._set_image_ref(path)
 
     def _set_image_ref(self, path: str):
+        if self._region is None:
+            return
         self.image_ref_label.setText(path)
         self.regionContentChanged.emit(self._region.id, path)
 

--- a/gui/layout/content_inspector.py
+++ b/gui/layout/content_inspector.py
@@ -1,0 +1,125 @@
+"""Content inspector: edit the selected region's content (image ref or text)."""
+from typing import Optional
+
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QStackedWidget, QLabel, QPushButton,
+    QPlainTextEdit, QFileDialog,
+)
+from PySide6.QtCore import Signal
+
+from core.layout.models import Region
+
+
+class ContentInspector(QWidget):
+    """Edits the content of the currently selected region.
+
+    Emits ``regionContentChanged(region_id, value)``:
+      - image region -> ``value`` is the chosen image path (becomes ``image_ref``)
+      - text region  -> ``value`` is the new text
+
+    The inspector only *displays* the region; ``LayoutTab`` owns the mutation.
+    """
+
+    regionContentChanged = Signal(str, str)  # (region_id, new_value)
+
+    def __init__(self, config=None, parent=None):
+        super().__init__(parent)
+        self._config = config
+        self._region: Optional[Region] = None
+        self._build()
+        self.set_region(None)
+
+    def _build(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        self.header = QLabel("No region selected")
+        self.header.setStyleSheet("font-weight: bold;")
+        root.addWidget(self.header)
+
+        self.stack = QStackedWidget()
+        root.addWidget(self.stack, 1)
+
+        # page 0 — nothing selected
+        self.stack.addWidget(QWidget())
+
+        # page 1 — image controls
+        img_page = QWidget()
+        img_lay = QVBoxLayout(img_page)
+        img_lay.setContentsMargins(0, 0, 0, 0)
+        btn_row = QHBoxLayout()
+        self.import_btn = QPushButton("Import image…")
+        self.import_btn.clicked.connect(self._on_import_image)
+        self.history_btn = QPushButton("From history…")
+        self.history_btn.clicked.connect(self._on_from_history)
+        btn_row.addWidget(self.import_btn)
+        btn_row.addWidget(self.history_btn)
+        btn_row.addStretch(1)
+        img_lay.addLayout(btn_row)
+        self.image_ref_label = QLabel("(no image)")
+        self.image_ref_label.setWordWrap(True)
+        self.image_ref_label.setStyleSheet("color: #666; font-size: 11px;")
+        img_lay.addWidget(self.image_ref_label)
+        img_lay.addStretch(1)
+        self.stack.addWidget(img_page)
+
+        # page 2 — text editor
+        txt_page = QWidget()
+        txt_lay = QVBoxLayout(txt_page)
+        txt_lay.setContentsMargins(0, 0, 0, 0)
+        self.text_edit = QPlainTextEdit()
+        self.text_edit.setPlaceholderText("Type the text for this region…")
+        self.text_edit.setFixedHeight(90)
+        txt_lay.addWidget(self.text_edit)
+        self.apply_text_btn = QPushButton("Apply text")
+        self.apply_text_btn.clicked.connect(self._on_apply_text)
+        txt_lay.addWidget(self.apply_text_btn)
+        self.stack.addWidget(txt_page)
+
+    def set_region(self, region: Optional[Region]):
+        """Show the editor for ``region`` (or the empty page when None)."""
+        self._region = region
+        if region is None:
+            self.header.setText("No region selected")
+            self.stack.setCurrentIndex(0)
+            return
+        label = region.name or region.id
+        if region.kind == "image":
+            self.header.setText(f"Image region: {label}")
+            self.image_ref_label.setText(region.image_ref or "(no image)")
+            self.stack.setCurrentIndex(1)
+        else:
+            self.header.setText(f"Text region: {label}")
+            self.text_edit.blockSignals(True)
+            self.text_edit.setPlainText(region.text or "")
+            self.text_edit.blockSignals(False)
+            self.stack.setCurrentIndex(2)
+
+    # --- image ---
+    def _on_import_image(self):
+        if self._region is None:
+            return
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Import Image", "",
+            "Images (*.png *.jpg *.jpeg *.webp *.bmp *.gif)")
+        if path:
+            self._set_image_ref(path)
+
+    def _on_from_history(self):
+        if self._region is None:
+            return
+        from gui.layout.image_history_dialog import ImageHistoryDialog
+        dlg = ImageHistoryDialog(self._config, self)
+        if dlg.exec():
+            path = dlg.get_selected_image()
+            if path:
+                self._set_image_ref(path)
+
+    def _set_image_ref(self, path: str):
+        self.image_ref_label.setText(path)
+        self.regionContentChanged.emit(self._region.id, path)
+
+    # --- text ---
+    def _on_apply_text(self):
+        if self._region is None:
+            return
+        self.regionContentChanged.emit(self._region.id, self.text_edit.toPlainText())

--- a/gui/layout/designer_panel.py
+++ b/gui/layout/designer_panel.py
@@ -81,7 +81,7 @@ class DesignerPanel(QWidget):
         self.provider_combo.addItems([get_provider_display_name(p) for p in get_all_provider_ids()])
         saved = self._config.get_layout_llm_provider() if self._config else None
         if saved:
-            idx = self.provider_combo.findText(saved, )
+            idx = self.provider_combo.findText(saved)
             if idx < 0:
                 idx = self.provider_combo.findText(saved.capitalize())
             if idx >= 0:
@@ -91,8 +91,7 @@ class DesignerPanel(QWidget):
 
     def _on_provider_changed(self, provider: str):
         from core.llm_models import get_provider_models
-        provider_map = {"claude": "anthropic", "google": "gemini", "lm studio": "lmstudio"}
-        pid = provider_map.get(provider.lower(), provider.lower())
+        _, pid = designer.resolve_provider_ids(provider)  # single source of truth
         self.model_combo.blockSignals(True)
         self.model_combo.clear()
         self.model_combo.addItems(get_provider_models(pid) or [])
@@ -103,6 +102,11 @@ class DesignerPanel(QWidget):
 
     def start_design(self, user_text: str, page_px, current_regions=None,
                      completion_fn: Optional[Callable[[List[Dict]], str]] = None):
+        # Don't overwrite a still-running QThread — dropping its only reference
+        # risks "QThread: Destroyed while thread is still running".
+        if self._worker is not None and self._worker.isRunning():
+            self.console.log("A design is already running — please wait.", "WARNING")
+            return
         kind = self.content_kind()
         messages = designer.build_messages(kind, page_px, user_text, current_regions)
         self.console.log(f"Designing ({kind}, {page_px[0]}x{page_px[1]})", "INFO")
@@ -114,16 +118,18 @@ class DesignerPanel(QWidget):
             model = self.model_combo.currentText()
             cfg = self._config
             completion_fn = lambda m: designer.run_completion(cfg, provider, model, m)
+        self.design_btn.setEnabled(False)
         self._worker = DesignerWorker(messages, page_px, completion_fn)
         self._worker.progress.connect(lambda msg: self.console.log(msg, "INFO"))
         self._worker.proposed.connect(self._on_proposed)
-        self._worker.failed.connect(lambda err: self.console.log(err, "ERROR"))
+        self._worker.failed.connect(self._on_failed)
         if injected:
             self._worker.run()      # synchronous for injected/test completions
         else:
             self._worker.start()
 
     def _on_proposed(self, result):
+        self.design_btn.setEnabled(True)
         if result.raw:
             self.console.log("LLM response:\n" + result.raw, "INFO")
         n = len(result.regions) if result.regions else 0
@@ -132,3 +138,7 @@ class DesignerPanel(QWidget):
         for q in result.questions:
             self.console.log(f"Q: {q}", "WARNING")
         self.layoutProposed.emit(result)
+
+    def _on_failed(self, err: str):
+        self.design_btn.setEnabled(True)
+        self.console.log(err, "ERROR")

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -108,6 +108,8 @@ class LayoutTab(QWidget):
 
     # --- content inspector ---
     def _find_region(self, region_id: str):
+        # MVP edits the first page only (the whole tab operates on pages[0]);
+        # revisit when multi-page navigation lands.
         if not region_id or not self.document or not self.document.pages:
             return None
         for r in self.document.pages[0].regions:
@@ -127,8 +129,12 @@ class LayoutTab(QWidget):
         if region is None:
             return
         if region.kind == "image":
+            if region.image_ref == value:
+                return
             region.image_ref = value
         else:
+            if region.text == value:
+                return
             region.text = value
         self._refresh()
 

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -187,6 +187,9 @@ class LayoutTab(QWidget):
     def restore_snapshot(self, snapshot_id: str):
         restored = self.history.restore(snapshot_id)
         self._adopt_document(restored)
+        # Continuing from a restored point is a branch: the next design snapshot
+        # must parent to snapshot_id, not the timeline's tail.
+        self.history.branch_from(snapshot_id)
         self._refresh()
 
     def _open_history(self):
@@ -211,33 +214,57 @@ class LayoutTab(QWidget):
         self._adopt_document(template_io.import_template(path))
         self._refresh()
 
+    # --- error reporting (repo rule: all errors logged + shown to the user) ---
+    def _report_error(self, what: str, exc: Exception):
+        logger.error("Layout: failed to %s: %s", what, exc, exc_info=True)
+        if hasattr(self, "status"):
+            self.status.setText(f"Error: failed to {what}")
+        try:
+            from PySide6.QtWidgets import QMessageBox
+            QMessageBox.critical(self, "Layout error", f"Failed to {what}:\n{exc}")
+        except Exception:  # noqa: BLE001 - error reporting must never itself crash
+            pass
+
     def _export_template_dialog(self):
-        from PySide6.QtWidgets import QFileDialog
         path, _ = QFileDialog.getSaveFileName(self, "Export Template", "",
                                               "ImageAI Layout Template (*.iailayout.json)")
         if path:
-            self.export_template_to(path)
+            try:
+                self.export_template_to(path)
+            except Exception as e:  # noqa: BLE001 - surfaced to UI + log
+                self._report_error("export template", e)
 
     def _import_template_dialog(self):
-        from PySide6.QtWidgets import QFileDialog
         path, _ = QFileDialog.getOpenFileName(self, "Import Template", "",
                                               "ImageAI Layout Template (*.iailayout.json)")
         if path:
-            self.import_template_from(path)
+            try:
+                self.import_template_from(path)
+            except Exception as e:  # noqa: BLE001 - surfaced to UI + log
+                self._report_error("import template", e)
 
     # --- dialogs ---
     def _save_dialog(self):
         path, _ = QFileDialog.getSaveFileName(self, "Save Project", "", "ImageAI Project (*.iaiproj.json)")
         if path:
-            self.save_project_to(path)
+            try:
+                self.save_project_to(path)
+            except Exception as e:  # noqa: BLE001 - surfaced to UI + log
+                self._report_error("save project", e)
 
     def _open_dialog(self):
         path, _ = QFileDialog.getOpenFileName(self, "Open Project", "",
                                               "ImageAI Project (*.iaiproj.json *.layout.json)")
         if path:
-            self.open_project_from(path)
+            try:
+                self.open_project_from(path)
+            except Exception as e:  # noqa: BLE001 - surfaced to UI + log
+                self._report_error("open project", e)
 
     def _export_dialog(self):
         path, _ = QFileDialog.getSaveFileName(self, "Export PDF", "", "PDF (*.pdf)")
         if path:
-            self.export_pdf_to(path)
+            try:
+                self.export_pdf_to(path)
+            except Exception as e:  # noqa: BLE001 - surfaced to UI + log
+                self._report_error("export PDF", e)

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -16,6 +16,7 @@ from gui.layout.canvas_widget import CanvasWidget
 from gui.layout.designer_panel import DesignerPanel
 from gui.layout.history_window import HistoryWindow
 from gui.layout.style_panel import StylePanel
+from gui.layout.content_inspector import ContentInspector
 
 logger = logging.getLogger("imageai.layout.tab")
 
@@ -64,6 +65,11 @@ class LayoutTab(QWidget):
         self.canvas = CanvasWidget()
         root.addWidget(self.canvas, 1)
 
+        self.inspector = ContentInspector(self.config)
+        self.inspector.regionContentChanged.connect(self._on_region_content_changed)
+        root.addWidget(self.inspector)
+        self.canvas.regionSelected.connect(self._on_region_selected)
+
         self.status = QLabel("")
         root.addWidget(self.status)
 
@@ -76,6 +82,8 @@ class LayoutTab(QWidget):
         self._style_user_modified = False
         if hasattr(self, "style_panel") and self.document.style:
             self.style_panel.set_style(self.document.style)
+        if hasattr(self, "inspector"):
+            self.inspector.set_region(None)
 
     def new_document(self):
         ps = self.page_setup.page_size() if hasattr(self, "page_setup") else PageSize(8.5, 11, "in")
@@ -97,6 +105,32 @@ class LayoutTab(QWidget):
             self.canvas.load_page(self.document.pages[0], self.document.style)
             self.status.setText(f"{self.document.title} — {self.document.pages[0].page_size_px}")
         self.documentChanged.emit()
+
+    # --- content inspector ---
+    def _find_region(self, region_id: str):
+        if not region_id or not self.document or not self.document.pages:
+            return None
+        for r in self.document.pages[0].regions:
+            if r.id == region_id:
+                return r
+        return None
+
+    def _on_region_selected(self, region_id: str):
+        self.inspector.set_region(self._find_region(region_id))
+
+    def _on_region_content_changed(self, region_id: str, value: str):
+        self.set_region_content(region_id, value)
+
+    def set_region_content(self, region_id: str, value: str):
+        """Apply edited content to a region and re-render (programmatic API)."""
+        region = self._find_region(region_id)
+        if region is None:
+            return
+        if region.kind == "image":
+            region.image_ref = value
+        else:
+            region.text = value
+        self._refresh()
 
     # --- programmatic API (tested) ---
     def save_project_to(self, path: str):

--- a/tests/layout/test_content_inspector.py
+++ b/tests/layout/test_content_inspector.py
@@ -1,0 +1,79 @@
+# tests/layout/test_content_inspector.py
+from core.layout.models import Region
+from gui.layout.content_inspector import ContentInspector
+
+
+def _img(rid="i", ref=None):
+    return Region(id=rid, kind="image", bbox=(0, 0, 10, 10), image_ref=ref)
+
+
+def _txt(rid="t", text=""):
+    return Region(id=rid, kind="text", bbox=(0, 0, 10, 10), text=text)
+
+
+def test_set_region_switches_editor(qapp):
+    insp = ContentInspector()
+    insp.set_region(_img(ref="/p.png"))
+    assert insp.stack.currentIndex() == 1
+    assert "/p.png" in insp.image_ref_label.text()
+    insp.set_region(_txt(text="hello"))
+    assert insp.stack.currentIndex() == 2
+    assert insp.text_edit.toPlainText() == "hello"
+    insp.set_region(None)
+    assert insp.stack.currentIndex() == 0
+
+
+def test_import_image_emits(qapp, monkeypatch):
+    from gui.layout import content_inspector as ci
+    insp = ContentInspector()
+    insp.set_region(_img(rid="i1"))
+    monkeypatch.setattr(ci.QFileDialog, "getOpenFileName",
+                        staticmethod(lambda *a, **k: ("/tmp/x.png", "")))
+    got = []
+    insp.regionContentChanged.connect(lambda rid, v: got.append((rid, v)))
+    insp.import_btn.click()
+    assert got == [("i1", "/tmp/x.png")]
+
+
+def test_import_cancelled_emits_nothing(qapp, monkeypatch):
+    from gui.layout import content_inspector as ci
+    insp = ContentInspector()
+    insp.set_region(_img(rid="i1"))
+    monkeypatch.setattr(ci.QFileDialog, "getOpenFileName",
+                        staticmethod(lambda *a, **k: ("", "")))
+    got = []
+    insp.regionContentChanged.connect(lambda rid, v: got.append((rid, v)))
+    insp.import_btn.click()
+    assert got == []
+
+
+def test_from_history_emits(qapp, monkeypatch):
+    import gui.layout.image_history_dialog as ihd
+
+    class FakeDlg:
+        def __init__(self, config, parent=None):
+            pass
+
+        def exec(self):
+            return True
+
+        def get_selected_image(self):
+            return "/hist/a.png"
+
+    monkeypatch.setattr(ihd, "ImageHistoryDialog", FakeDlg)
+    insp = ContentInspector(config=object())
+    insp.set_region(_img(rid="i2"))
+    got = []
+    insp.regionContentChanged.connect(lambda rid, v: got.append((rid, v)))
+    insp.history_btn.click()
+    assert got == [("i2", "/hist/a.png")]
+
+
+def test_apply_text_emits(qapp):
+    insp = ContentInspector()
+    insp.set_region(_txt(rid="t1", text="old"))
+    got = []
+    insp.regionContentChanged.connect(lambda rid, v: got.append((rid, v)))
+    insp.text_edit.setPlainText("new text")
+    insp.apply_text_btn.click()
+    assert got == [("t1", "new text")]

--- a/tests/layout/test_designer.py
+++ b/tests/layout/test_designer.py
@@ -74,3 +74,29 @@ def test_build_messages_instructs_role_with_kind_roles():
     joined = " ".join(m["content"] for m in msgs)
     assert '"role"' in joined
     assert "dialogue" in joined  # a comic role name is offered to the model
+
+
+def test_resolve_provider_ids_known_names():
+    cases = {
+        "OpenAI": ("openai", "openai"),
+        "Anthropic": ("anthropic", "anthropic"),
+        "Claude": ("anthropic", "anthropic"),   # defensive alias
+        "Google": ("google", "gemini"),          # api-key id vs registry id differ
+        "Ollama": ("ollama", "ollama"),
+        "LM Studio": ("lmstudio", "lmstudio"),
+    }
+    for display, expected in cases.items():
+        assert designer.resolve_provider_ids(display) == expected
+
+
+def test_every_provider_display_name_resolves_to_a_registry_id_with_models():
+    # Regression guard for the Anthropic/Claude path: every display name shown in
+    # the designer's provider combo must resolve to a registry id that actually
+    # has models, else the production LLM call would fail at runtime.
+    from core.llm_models import (
+        get_all_provider_ids, get_provider_display_name, get_provider_models)
+    for pid in get_all_provider_ids():
+        display = get_provider_display_name(pid)
+        _, registry_id = designer.resolve_provider_ids(display)
+        assert get_provider_models(registry_id), \
+            f"{display!r} -> {registry_id!r} resolves to no models"

--- a/tests/layout/test_designer_panel.py
+++ b/tests/layout/test_designer_panel.py
@@ -33,3 +33,20 @@ def test_panel_start_design_emits_layout_proposed(qapp):
     fake = lambda m: '{"layout": {"regions": [{"id":"z","kind":"text","bbox":[0,0,50,50],"text":"hi"}]}}'
     p.start_design("a title page", (300, 300), completion_fn=fake)
     assert got and [r.id for r in got[0].regions] == ["z"]
+
+
+def test_design_button_reenabled_after_completion(qapp):
+    p = DesignerPanel(FakeConfig())
+    fake = lambda m: '{"layout": {"regions": [{"id":"z","kind":"image","bbox":[0,0,50,50]}]}}'
+    p.start_design("a page", (300, 300), completion_fn=fake)
+    assert p.design_btn.isEnabled()  # re-enabled once the (synchronous) design finished
+
+
+def test_design_button_reenabled_after_failure(qapp):
+    p = DesignerPanel(FakeConfig())
+
+    def boom(m):
+        raise RuntimeError("provider exploded")
+
+    p.start_design("a page", (300, 300), completion_fn=boom)
+    assert p.design_btn.isEnabled()  # _on_failed must re-enable the button

--- a/tests/layout/test_history.py
+++ b/tests/layout/test_history.py
@@ -61,3 +61,22 @@ def test_history_get_missing_returns_none():
     from core.layout.history import History
     h = History(_doc_with_text("v1"))
     assert h.get("nope") is None
+
+
+def test_branch_from_records_real_branch_topology():
+    from core.layout.history import History
+    doc = _doc_with_text("v1")
+    h = History(doc)
+    h.append("first", snapshot_id="s1", timestamp="t1")
+    doc.pages[0].regions[0].text = "v2"
+    h.append("second", snapshot_id="s2", timestamp="t2")
+    # user restores s1 and keeps iterating -> a fresh History on the restored doc
+    restored = h.restore("s1")
+    h2 = History(restored)
+    h2.branch_from("s1")
+    s3 = h2.append("third", snapshot_id="s3", timestamp="t3")
+    # parents to the restored branch point, NOT the timeline tail (s2)
+    assert s3.parent_id == "s1"
+    # and the next append chains from s3, not s1 again
+    s4 = h2.append("fourth", snapshot_id="s4", timestamp="t4")
+    assert s4.parent_id == "s3"

--- a/tests/layout/test_layout_tab.py
+++ b/tests/layout/test_layout_tab.py
@@ -41,3 +41,20 @@ def test_export_pdf(qapp, tmp_path):
     out = tmp_path / "out.pdf"
     tab.export_pdf_to(str(out))
     assert out.exists() and out.read_bytes()[:4] == b"%PDF"
+
+
+def test_open_dialog_reports_error_on_malformed_file(qapp, tmp_path, monkeypatch):
+    # A malformed project file must not raise out of the Qt slot — it must be
+    # logged and surfaced via a dialog (repo rule: all errors logged + shown).
+    import gui.layout.layout_tab as lt
+    bad = tmp_path / "bad.iaiproj.json"
+    bad.write_text("{ this is not valid json", encoding="utf-8")
+    monkeypatch.setattr(lt.QFileDialog, "getOpenFileName",
+                        staticmethod(lambda *a, **k: (str(bad), "")))
+    reported = {}
+    monkeypatch.setattr(LayoutTab, "_report_error",
+                        lambda self, what, exc: reported.update(what=what, exc=exc))
+    tab = LayoutTab(config=FakeConfig())
+    tab._open_dialog()  # must not raise
+    assert reported.get("what") == "open project"
+    assert isinstance(reported.get("exc"), Exception)

--- a/tests/layout/test_layout_tab_content.py
+++ b/tests/layout/test_layout_tab_content.py
@@ -1,0 +1,55 @@
+# tests/layout/test_layout_tab_content.py
+from core.layout import designer
+from gui.layout.layout_tab import LayoutTab
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tab_with_regions():
+    tab = LayoutTab(config=FakeConfig())
+    tab.apply_designer_result(designer.DesignerResult(regions=[
+        designer.Region(id="img", kind="image", bbox=(0, 0, 100, 100)),
+        designer.Region(id="txt", kind="text", bbox=(0, 110, 100, 40), text="", role="title"),
+    ]), user_text="page")
+    return tab
+
+
+def test_selecting_region_populates_inspector(qapp):
+    tab = _tab_with_regions()
+    tab._on_region_selected("img")
+    assert tab.inspector.stack.currentIndex() == 1   # image editor
+    tab._on_region_selected("txt")
+    assert tab.inspector.stack.currentIndex() == 2   # text editor
+    tab._on_region_selected("")                      # deselect
+    assert tab.inspector.stack.currentIndex() == 0
+
+
+def test_image_content_change_sets_image_ref(qapp):
+    tab = _tab_with_regions()
+    tab._on_region_content_changed("img", "/path/to/pic.png")
+    assert tab.document.pages[0].regions[0].image_ref == "/path/to/pic.png"
+
+
+def test_text_content_change_sets_text(qapp):
+    tab = _tab_with_regions()
+    tab._on_region_content_changed("txt", "Once upon a time")
+    assert tab.document.pages[0].regions[1].text == "Once upon a time"
+
+
+def test_set_region_content_unknown_id_is_noop(qapp):
+    tab = _tab_with_regions()
+    tab.set_region_content("nope", "x")  # must not raise
+    assert tab.document.pages[0].regions[0].image_ref is None
+
+
+def test_inspector_resets_on_new_document(qapp):
+    tab = _tab_with_regions()
+    tab._on_region_selected("img")
+    assert tab.inspector.stack.currentIndex() == 1
+    tab.new_document()
+    assert tab.inspector.stack.currentIndex() == 0

--- a/tests/layout/test_layout_tab_content.py
+++ b/tests/layout/test_layout_tab_content.py
@@ -29,6 +29,18 @@ def test_selecting_region_populates_inspector(qapp):
     assert tab.inspector.stack.currentIndex() == 0
 
 
+def test_canvas_selection_drives_inspector(qapp):
+    # Exercise the real signal path: selecting a scene item fires the scene's
+    # selectionChanged -> canvas.regionSelected -> _on_region_selected.
+    from PySide6.QtWidgets import QGraphicsItem
+    tab = _tab_with_regions()
+    scene = tab.canvas.scene()
+    target = next(it for it in scene.items()
+                  if (it.flags() & QGraphicsItem.ItemIsSelectable) and it.data(0) == "txt")
+    target.setSelected(True)
+    assert tab.inspector.stack.currentIndex() == 2  # text editor
+
+
 def test_image_content_change_sets_image_ref(qapp):
     tab = _tab_with_regions()
     tab._on_region_content_changed("img", "/path/to/pic.png")

--- a/tests/layout/test_layout_tab_content.py
+++ b/tests/layout/test_layout_tab_content.py
@@ -53,3 +53,27 @@ def test_inspector_resets_on_new_document(qapp):
     assert tab.inspector.stack.currentIndex() == 1
     tab.new_document()
     assert tab.inspector.stack.currentIndex() == 0
+
+
+def test_fill_image_and_text_then_export_pdf(qapp, tmp_path):
+    # F-MVP acceptance: design a page, fill an image region (real file) and a
+    # text region, then export a valid PDF — no AI content features needed.
+    from PySide6.QtGui import QImage
+    from PySide6.QtCore import Qt
+    tab = _tab_with_regions()
+
+    img_path = tmp_path / "pic.png"
+    im = QImage(40, 40, QImage.Format_RGB32)
+    im.fill(Qt.blue)
+    assert im.save(str(img_path))
+
+    tab.set_region_content("img", str(img_path))
+    tab.set_region_content("txt", "The Title")
+
+    page = tab.document.pages[0]
+    assert page.regions[0].image_ref == str(img_path)
+    assert page.regions[1].text == "The Title"
+
+    out = tmp_path / "out.pdf"
+    tab.export_pdf_to(str(out))
+    assert out.exists() and out.read_bytes()[:4] == b"%PDF"

--- a/tests/layout/test_layout_tab_designer.py
+++ b/tests/layout/test_layout_tab_designer.py
@@ -48,6 +48,24 @@ def test_design_button_calls_start_design_with_page_size(qapp):
     assert a[1] == tab.document.pages[0].page_size_px    # current page size supplied
 
 
+def test_design_after_restore_parents_to_branch_point(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    tab.apply_designer_result(
+        designer.DesignerResult(regions=[designer.Region(id="a", kind="image", bbox=(0, 0, 50, 50))]),
+        user_text="v1")
+    s1 = tab.history.snapshots()[0].id
+    tab.apply_designer_result(
+        designer.DesignerResult(regions=[designer.Region(id="b", kind="image", bbox=(0, 0, 50, 50))]),
+        user_text="v2")
+    tab.restore_snapshot(s1)              # branch off v1
+    tab.apply_designer_result(
+        designer.DesignerResult(regions=[designer.Region(id="c", kind="image", bbox=(0, 0, 50, 50))]),
+        user_text="v3")
+    newest = tab.history.snapshots()[-1]
+    assert newest.prompt == "v3"
+    assert newest.parent_id == s1        # parents to the restored point, not v2
+
+
 def test_apply_designer_result_questions_only_sets_status(qapp):
     tab = LayoutTab(config=FakeConfig())
     res = designer.DesignerResult(questions=["how many panels?"], regions=None, raw="")

--- a/tests/layout/test_qt_renderer.py
+++ b/tests/layout/test_qt_renderer.py
@@ -49,6 +49,27 @@ def test_export_pdf(qapp, tmp_path):
     assert out.read_bytes()[:4] == b"%PDF"
 
 
+def test_filled_image_region_is_selectable(qapp, tmp_path):
+    # The loaded image draws a pixmap ON TOP of the placeholder rect; that
+    # topmost item is what a click hits, so it must itself be selectable and
+    # carry the region id (else a filled image region can't be re-selected).
+    from PySide6.QtWidgets import QGraphicsItem, QGraphicsPixmapItem
+    from PySide6.QtGui import QImage
+    from PySide6.QtCore import Qt
+    img_path = tmp_path / "ref.png"
+    im = QImage(20, 20, QImage.Format_RGB32)
+    im.fill(Qt.white)
+    assert im.save(str(img_path))
+    page = PageSpec(page_size_px=(200, 150), background="#FFFFFF", regions=[
+        Region(id="img1", kind="image", bbox=(10, 10, 80, 80), image_ref=str(img_path))])
+    scene = qt_renderer.build_scene(page, selectable=True)
+    pix_items = [it for it in scene.items() if isinstance(it, QGraphicsPixmapItem)]
+    assert pix_items, "expected a pixmap item for the loaded image"
+    pi = pix_items[0]
+    assert pi.flags() & QGraphicsItem.ItemIsSelectable
+    assert pi.data(0) == "img1"
+
+
 def test_text_region_resolves_font_role_from_style(qapp):
     from core.layout.models import Region, PageSpec, ProjectStyle, TextStyle
     from core.layout import qt_renderer

--- a/tests/layout/test_schema.py
+++ b/tests/layout/test_schema.py
@@ -55,6 +55,25 @@ def test_validate_document_flags_empty_pages():
     assert any("page" in i.lower() for i in issues)
 
 
+def test_from_dict_tolerates_unknown_and_forward_version_keys():
+    # A hand-edited / future-schema file with extra top-level keys and an
+    # unknown style key must load, not crash with TypeError/KeyError.
+    d = {
+        "id": "r1", "kind": "text", "bbox": [0, 0, 50, 20],
+        "text": "Hi", "future_field": 123,                 # unknown top-level key
+        "text_style": {"family": ["Arial"], "size_px": 18, "shadow": "yes"},  # unknown style key
+    }
+    r = schema.region_from_dict(d)
+    assert r.id == "r1" and r.text == "Hi"
+    assert r.text_style is not None and r.text_style.size_px == 18
+
+
+def test_region_from_dict_missing_id_and_kind_does_not_crash():
+    r = schema.region_from_dict({"bbox": [0, 0, 10, 10]})
+    assert r.kind == "image"   # sensible default, no KeyError
+    assert r.id == ""
+
+
 def test_normalize_region_origin_at_or_beyond_boundary():
     r = Region(id="r", kind="image", bbox=(1100, 900, 200, 200))
     n = schema.normalize_region(r, (1000, 800))


### PR DESCRIPTION
## Phase 4 — Content MVP (F-MVP)

Fourth phase of the AI Layout Designer redesign (spec §9 Subsystem F). **Stacked on #20** (base = `feat/layout-ai-designer-phase3`).

Fills the placeholders the designer/canvas already produce, so a designed page becomes a finished, exportable publication — with **no** AI content features.

### What's here
- **`ContentInspector`** (new `gui/layout/content_inspector.py`): per-region editor.
  - Image region → **Import image…** (`QFileDialog`) and **From history…** (reuses the existing `ImageHistoryDialog`).
  - Text region → editor + **Apply text**.
  - Display-only; emits `regionContentChanged(region_id, value)`.
- **LayoutTab wiring**: `canvas.regionSelected` → inspector; edits → `set_region_content(id, value)` → set `image_ref`/`text` → re-render. Single-mutator pattern (LayoutTab owns all document mutation). `set_region_content` is the programmatic hook Phase 5 reuses to place images by region id.
- **Renderer fix**: a *filled* image region's pixmap is now selectable (it sits on top of the placeholder), so you can click it to swap the image — but not movable, so it can't be dragged off its frame.

### Acceptance (met)
A user fills every region of an AI-designed page with an imported image and typed text and exports a correct PDF — proven by `test_fill_image_and_text_then_export_pdf`.

### Tests
`QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` → **88 passed, 0 warnings** (75 → +13).

### Review
Whole-branch opus structured review: **APPROVE** (no Critical/Important). One consolidated fix wave applied the optional Minor items (non-movable pixmap, null-region guard, skip-unchanged re-render, single-page comment, real-selection wiring test).

### Out of scope (Phase 5)
Per-region AI prompt help, "Send to Image tab", batch placement, layout-complete mode, `.iaibundle`. Multi-page content editing and renderer deferrals (PNG transparency, image-path backgrounds) also deferred.

Plan: `Plans/2026-06-24-layout-ai-designer-phase4-content.md` · Summary: `Plans/2026-06-24-layout-ai-designer-phase4-completion.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)