### PR TITLE
feat(layout): Phase 5a — AI prompt help + .iaibundle export/import

### DIFF
--- a/Plans/2026-06-25-layout-ai-designer-phase5a-completion.md
+++ b/Plans/2026-06-25-layout-ai-designer-phase5a-completion.md
@@ -1,0 +1,73 @@
+# Phase 5a — AI prompt help + bundles — Completion Summary ✅
+**Last Updated:** 2026-06-25 17:45
+
+First slice of **Phase 5** (AI content & bundles) of the AI Layout Designer
+redesign. Phase 5 is larger than any prior phase, so it ships as a series of PRs;
+**5a** delivers the two self-contained, fully headless-testable pieces.
+
+Branch: `feat/layout-ai-designer-phase5` (off `main`). Plan:
+`Plans/2026-06-25-layout-ai-designer-phase5a-content.md`. Design source:
+`Plans/2026-06-24-layout-ai-designer-design.md` §9 (F-AI) + §8 (bundles).
+
+## What shipped
+
+### 1. Per-region AI image-prompt help (`4356005`)
+- **`core/layout/prompt_helper.py`** (NEW, pure): `build_prompt_messages(document,
+  region, hint)` assembles `<context>` (content_kind, title, palette, region
+  name/role/aspect) + sibling text-region content for scene context;
+  `parse_prompt_response` (JSON `{"prompt"}` → fenced → plain text → "");
+  `run_prompt_help(messages, completion_fn)`. Reuses `designer.run_completion`
+  for the production LLM call (registry-resolved model IDs, LiteLLM, logging).
+  **Never** emits a pixel/ratio token into the prompt (Gemini would render it).
+- **`gui/layout/prompt_worker.py`** (NEW): `PromptSuggestWorker(QThread)`, mirrors
+  `DesignerWorker` — synchronous when a `completion_fn` is injected (tests),
+  threaded otherwise.
+- **`ContentInspector`**: image page gains a prompt box + **Suggest with AI** /
+  **Apply prompt**; loads `region.prompt` on selection; stays display-only.
+- **`LayoutTab`**: `suggest_region_prompt()` orchestrates via the Designer
+  panel's provider/model; re-fetches the region by id on completion (correct
+  region even after a scene rebuild); logs request+response to the Designer
+  console; failures auto-expand it (errors never hidden); empty result keeps the
+  existing prompt; second click while running is rejected.
+
+### 2. `.iaibundle` export/import (`39734fb`)
+- **`core/layout/bundle_io.py`** (NEW): `export_bundle(doc, path, font_resolver)`
+  deep-copies the doc (live one never mutated), copies every referenced image
+  into `images/` (deduped by resolved source path) and rewrites refs to
+  bundle-relative, embeds resolvable fonts into `fonts/` (else records the family
+  "by-name"), and writes `project.iaiproj.json` + a `bundle.json` manifest
+  (images/fonts/warnings). Missing images warn but don't fail.
+  `import_bundle(path, dest)` extracts (with a **zip-slip guard**) and rewrites
+  relative refs back to absolute under the extract dir. Font resolution is
+  **injected**, so the core is unit-testable without scanning system fonts.
+- **`LayoutTab`**: Export/Import Bundle… toolbar buttons + `export_bundle_to` /
+  `import_bundle_from`; the production `font_resolver` lazily wraps a cached
+  `FontManager` (any failure degrades to by-name — never blocks export). Dialog
+  failures go through `_report_error` (logged + shown).
+
+## Tests
+`QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q`
+→ **151 passed** (112 before 5a → **+39**):
+- `test_prompt_helper.py` (10): context assembly, no pixel token, JSON/fenced/
+  plain/empty parsing, injected-completion run.
+- `test_content_inspector.py` (+5): prompt load, apply/suggest signals,
+  `set_prompt_text` region-guard.
+- `test_layout_tab_prompt.py` (7): suggest writes prompt + updates inspector,
+  empty keeps existing, text-region/unknown-id no-ops, failure surfaces console.
+- `test_bundle_io.py` (7): round-trip, relative-ref rewrite, missing-image
+  warning, shared-image dedup, font embed vs by-name, zip-slip rejection.
+- `test_layout_tab_bundle.py` (2): full export→import round trip; missing-image
+  warning surfaced.
+
+## Cross-cutting compliance (design §11)
+- LLM request + full response logged (file + Designer console); model IDs
+  registry-resolved (no hardcoding); all errors logged + surfaced; images only
+  copied (fit modes untouched, scaled-not-cropped preserved); no size/ratio
+  tokens injected into image prompts.
+
+## Out of scope (Phase 5b+)
+- "Send to Image tab" handoff, Batch API placement, layout-complete mode — all
+  need LayoutTab↔MainWindow wiring + a GUI runtime to verify.
+- Installing embedded fonts into the OS on import (we extract + reference only).
+- `region.gen_settings` is carried/serialized but not yet populated (the handoff
+  phase fills provider/model/size there).

--- a/Plans/2026-06-25-layout-ai-designer-phase5a-content.md
+++ b/Plans/2026-06-25-layout-ai-designer-phase5a-content.md
@@ -1,0 +1,177 @@
+# Phase 5a — AI prompt help + bundles — Implementation Plan ⏳ 0%
+**Last Updated:** 2026-06-25 17:05
+**Author:** Leland Green + Claude (Opus 4.8)
+**Design source:** `Plans/2026-06-24-layout-ai-designer-design.md` §9 (F-AI) + §8 (bundles)
+**Branch:** `feat/layout-ai-designer-phase5`
+
+Phase 5 (AI content & bundles) is larger than any prior phase, so it lands as a
+series of PRs. **Phase 5a** ships the two self-contained, fully headless-testable
+deliverables first:
+
+1. **Per-region AI prompt help** — generate an image-generation prompt for an
+   image region from the project theme/content_kind (spec §9 F-AI, first bullet).
+2. **`.iaibundle` export/import** — a self-contained zip of project JSON +
+   referenced images + embedded fonts (spec §8, Phase-5 row).
+
+Deferred to **Phase 5b+** (later PRs): "Send to Image tab" handoff, Batch API
+placement, layout-complete mode (all require LayoutTab↔MainWindow wiring and a
+GUI runtime to verify).
+
+---
+
+## Why these two first
+
+- Both live entirely in `core/layout/` + `gui/layout/` with **no cross-tab
+  coupling** — `LayoutTab` is constructed with only `config` (`main_window.py:554`)
+  and has no MainWindow reference, which the handoff/batch features need but these
+  two don't.
+- Both are unit-testable headless in WSL exactly like Phases 1–4
+  (`QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q`).
+- Prompt-help **unblocks** the rest of the AI-content chain: the prompt it writes
+  to `region.prompt` is the same field "Send to Image tab" and Batch consume.
+
+---
+
+## Feature 1 — Per-region AI prompt help
+
+### Goal
+Select an image region → ask the LLM to draft an image-generation **prompt**
+informed by the project (content_kind, title, style palette), the region (role,
+name, bbox aspect), and nearby text regions → the suggestion fills the region's
+`prompt` field (already on `Region`, `models.py:109`, round-tripped by
+`schema.region_to_dict/from_dict`). The user can edit and keep it; later phases
+send it to generation.
+
+### Reuses (no new plumbing)
+- `core.layout.designer.run_completion(config, provider, model, messages, temperature)`
+  — the production LLM call (LiteLLM, key resolution, logging) — `designer.py:131`.
+- `gui.llm_utils.LLMResponseParser` — robust JSON/prose extraction.
+- The Designer panel's provider/model selectors (`DesignerPanel.provider_combo`,
+  `.model_combo`) — one LLM config for the whole tab; no second selector.
+
+### New module — `core/layout/prompt_helper.py` (pure, unit-tested)
+```
+build_prompt_messages(document, region, hint="") -> List[Dict]
+    # <context>: content_kind, document.title, palette/theme, region.kind/role/
+    #   name, bbox aspect ratio (w:h), and neighboring text-region content for
+    #   scene context. <instructions>: return a SINGLE vivid image-generation
+    #   prompt as JSON {"prompt": "..."} (robustly parsed; plain text tolerated).
+    #   <example>: one worked case. Honors the repo rule: NO dimensions/ratios in
+    #   the prompt text itself (Gemini renders them literally) — aspect is context
+    #   only, never an instruction to embed "(1024x768)".
+parse_prompt_response(content) -> str
+    # LLMResponseParser → dict{"prompt"} if present, else stripped plain text;
+    # empty/garbage → "" (caller keeps the existing prompt, logs).
+run_prompt_help(messages, completion_fn) -> str
+    # completion_fn injected in tests; production lambda wraps run_completion.
+```
+
+### GUI wiring
+- **`gui/layout/content_inspector.py`** — image page gains:
+  - a `prompt_edit` (`QPlainTextEdit`) showing `region.prompt`,
+  - **"Suggest with AI"** → emits `regionPromptSuggestRequested(region_id, hint)`,
+  - **"Apply prompt"** → emits `regionPromptChanged(region_id, prompt)`.
+  - `set_region()` loads `region.prompt` into the box for image regions.
+  - Inspector stays **display-only**; LayoutTab owns all mutation (Phase-4 pattern).
+- **`gui/layout/prompt_worker.py`** (NEW) — `PromptSuggestWorker(QThread)` mirrors
+  `DesignerWorker`: runs synchronously when a `completion_fn` is injected (tests),
+  else `start()`s a thread. Emits `suggested(region_id, prompt)` / `failed(str)`.
+- **`gui/layout/layout_tab.py`**:
+  - `_on_region_prompt_changed(id, text)` → writes `region.prompt` (no re-render;
+    prompt is metadata, not drawn).
+  - `suggest_region_prompt(region_id, hint, completion_fn=None)` → builds messages
+    via `prompt_helper`, runs the worker (production `completion_fn` wraps
+    `designer.run_completion` with the Designer panel's provider/model), and on
+    success sets `region.prompt` + pushes the text back into the inspector.
+  - The Designer console logs the request + response (repo LLM-logging rule §8).
+
+### Tests (`tests/layout/test_prompt_helper.py`, extend `test_layout_tab_content.py`)
+- `build_prompt_messages` includes content_kind, title, role/name, aspect, and a
+  neighboring text region's content; **never** embeds a pixel/ratio token in the
+  instruction to the image model.
+- `parse_prompt_response`: JSON `{"prompt"}`, fenced JSON, plain prose, empty → "".
+- `run_prompt_help` with an injected `completion_fn` returns the parsed prompt.
+- LayoutTab: `suggest_region_prompt(id, hint, completion_fn=fake)` writes
+  `region.prompt`; `_on_region_prompt_changed` persists an edited prompt;
+  a text region or unknown id is a no-op.
+
+---
+
+## Feature 2 — `.iaibundle` export/import
+
+### Goal (spec §8)
+A **self-contained** zip a recipient can open without the original assets:
+project JSON + every referenced image + embedded fonts (license permitting),
+with image references rewritten to bundle-relative paths so nothing dangles.
+
+### New module — `core/layout/bundle_io.py`
+```
+export_bundle(doc, path, config=None) -> BundleManifest
+    # 1. Deep-copy the doc; walk every page's regions.
+    # 2. For each image region with an existing image_ref file: copy into the zip
+    #    under images/<sanitized-stem>-<n><ext>, dedup identical source paths,
+    #    and rewrite that region's image_ref to the RELATIVE bundle path.
+    #    Missing/unreadable refs are recorded as warnings, left as-is.
+    # 3. Fonts: collect families from project style roles + per-region text_style;
+    #    resolve each via FontManager.select_font_file(families,...) and embed the
+    #    file under fonts/<file>. Unresolved families → recorded "by-name" + warn
+    #    (licensing per design §7 — embed only what resolves to a file).
+    # 4. Write project.iaiproj.json (rewritten refs) + bundle.json manifest
+    #    (version, title, images map, fonts map, warnings) into the zip.
+import_bundle(path, dest_dir) -> DocumentSpec
+    # Extract zip into dest_dir; load project.iaiproj.json; rewrite each relative
+    # image_ref back to its absolute extracted path (dest_dir/images/...).
+    # Return the DocumentSpec (fonts referenced by name; extracted to fonts/).
+```
+- **Manifest** `bundle.json`: `{schema_version, title, images:{orig→bundle},
+  fonts:{family→bundle|"by-name"}, warnings:[...]}` — small, human-readable,
+  the source of truth for round-trip mapping.
+- **Format**: a `zipfile.ZipFile`; extension `.iaibundle`. Reuses
+  `schema.document_to_dict/from_dict` for the embedded project JSON.
+
+### GUI wiring — `gui/layout/layout_tab.py`
+- Toolbar: **"Export Bundle…"** (`*.iaibundle`) / **"Import Bundle…"** with
+  `QFileDialog` + the existing `_report_error` path (errors logged + shown, §6).
+- Programmatic API (tested): `export_bundle_to(path)` / `import_bundle_from(path)`.
+- Import adopts the returned doc via `_adopt_document` + `_refresh` (same as
+  template import).
+
+### Tests (`tests/layout/test_bundle_io.py`, extend `test_layout_tab*.py`)
+- Round-trip: build a doc with 2 image regions pointing at temp PNGs, export →
+  the zip contains `project.iaiproj.json`, `bundle.json`, and both images under
+  `images/`; the embedded project JSON's `image_ref`s are **relative**.
+- Import into a fresh dir → `image_ref`s are absolute paths that **exist**; the
+  doc loads and equals the original geometry/text.
+- Missing source image → warning recorded, export still succeeds, ref preserved.
+- Two regions sharing one source file dedup to a single embedded image.
+- (Font embedding asserted best-effort: when `select_font_file` resolves a file
+  it's embedded; the test tolerates headless font absence by checking the
+  manifest records either a path or "by-name".)
+
+---
+
+## Cross-cutting compliance (design §11)
+- **LLM logging:** prompt-help request + full response shown in the Designer
+  console **and** the file logger (reuses `run_completion`'s logging).
+- **Model IDs** via the registry (`run_completion` already resolves) — none
+  hardcoded.
+- **All errors logged + surfaced** (the `_report_error` path; worker `failed`
+  signal expands the Designer console).
+- **Images scaled, not cropped:** unchanged — bundles only copy files; rendering
+  still honors fit modes. No pixel/ratio tokens injected into image prompts.
+
+## Out of scope (Phase 5b+)
+- "Send to Image tab" handoff, Batch API placement, layout-complete mode.
+- Multi-page is handled (bundle walks all pages); prompt-help still operates on
+  the selected region regardless of page.
+- Installing embedded fonts into the OS on import (we reference + extract only).
+
+---
+
+## Task checklist
+1. ⏳ Plan doc (this file) — committed on the feature branch.
+2. ⬜ `core/layout/prompt_helper.py` + `tests/layout/test_prompt_helper.py`.
+3. ⬜ Inspector prompt UI + `prompt_worker.py` + LayoutTab orchestration + tests.
+4. ⬜ `core/layout/bundle_io.py` + `tests/layout/test_bundle_io.py`.
+5. ⬜ LayoutTab bundle toolbar + programmatic API + tests.
+6. ⬜ Full `tests/layout/` green headless; completion summary; PR.

--- a/Plans/2026-06-25-layout-ai-designer-phase5a-content.md
+++ b/Plans/2026-06-25-layout-ai-designer-phase5a-content.md
@@ -1,5 +1,5 @@
-# Phase 5a — AI prompt help + bundles — Implementation Plan ⏳ 0%
-**Last Updated:** 2026-06-25 17:05
+# Phase 5a — AI prompt help + bundles — Implementation Plan ✅ 100%
+**Last Updated:** 2026-06-25 17:45
 **Author:** Leland Green + Claude (Opus 4.8)
 **Design source:** `Plans/2026-06-24-layout-ai-designer-design.md` §9 (F-AI) + §8 (bundles)
 **Branch:** `feat/layout-ai-designer-phase5`
@@ -169,9 +169,10 @@ import_bundle(path, dest_dir) -> DocumentSpec
 ---
 
 ## Task checklist
-1. ⏳ Plan doc (this file) — committed on the feature branch.
-2. ⬜ `core/layout/prompt_helper.py` + `tests/layout/test_prompt_helper.py`.
-3. ⬜ Inspector prompt UI + `prompt_worker.py` + LayoutTab orchestration + tests.
-4. ⬜ `core/layout/bundle_io.py` + `tests/layout/test_bundle_io.py`.
-5. ⬜ LayoutTab bundle toolbar + programmatic API + tests.
-6. ⬜ Full `tests/layout/` green headless; completion summary; PR.
+1. ✅ Plan doc (this file) — committed `3d4a7c9`.
+2. ✅ `core/layout/prompt_helper.py` + `tests/layout/test_prompt_helper.py` (`4356005`).
+3. ✅ Inspector prompt UI + `prompt_worker.py` + LayoutTab orchestration + tests (`4356005`).
+4. ✅ `core/layout/bundle_io.py` + `tests/layout/test_bundle_io.py` (`39734fb`).
+5. ✅ LayoutTab bundle toolbar + programmatic API + tests (`39734fb`).
+6. ✅ Full `tests/layout/` green headless — **151 passed** (112 → +39); see
+   `Plans/2026-06-25-layout-ai-designer-phase5a-completion.md`.

--- a/core/layout/bundle_io.py
+++ b/core/layout/bundle_io.py
@@ -1,0 +1,188 @@
+"""Self-contained ``.iaibundle`` export/import (Phase 5a, design spec §8).
+
+A bundle is a zip a recipient can open without the original assets:
+
+    project.iaiproj.json   # the DocumentSpec, with image refs rewritten relative
+    bundle.json            # manifest: images map, fonts map, warnings
+    images/...             # every referenced image, deduped
+    fonts/...              # embedded font files (when resolvable; else by-name)
+
+Font resolution is injected (``font_resolver``) so the module stays decoupled
+from ``FontManager`` and fully unit-testable without scanning system fonts.
+"""
+import copy
+import json
+import logging
+import re
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+from core.layout.models import DocumentSpec
+from core.layout import schema
+
+logger = logging.getLogger("imageai.layout.bundle")
+
+BUNDLE_SCHEMA_VERSION = "1"
+_PROJECT_NAME = "project.iaiproj.json"
+_MANIFEST_NAME = "bundle.json"
+_IMAGES_DIR = "images"
+_FONTS_DIR = "fonts"
+
+# Resolve a priority-ordered family list to a concrete font file (or None).
+FontResolver = Callable[[List[str]], Optional[Path]]
+
+
+@dataclass
+class BundleManifest:
+    schema_version: str = BUNDLE_SCHEMA_VERSION
+    title: str = ""
+    images: Dict[str, str] = field(default_factory=dict)  # orig abs path -> bundle rel path
+    fonts: Dict[str, str] = field(default_factory=dict)   # family -> bundle rel path | "by-name"
+    warnings: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict:
+        return {
+            "schema_version": self.schema_version, "title": self.title,
+            "images": dict(self.images), "fonts": dict(self.fonts),
+            "warnings": list(self.warnings),
+        }
+
+
+def _safe_stem(name: str) -> str:
+    stem = re.sub(r"[^A-Za-z0-9_.-]+", "_", name).strip("_") or "file"
+    return stem
+
+
+def _unique_member(directory: str, filename: str, used: set) -> str:
+    stem = Path(filename).stem
+    ext = Path(filename).suffix
+    candidate = f"{directory}/{_safe_stem(stem)}{ext}"
+    n = 1
+    while candidate in used:
+        candidate = f"{directory}/{_safe_stem(stem)}-{n}{ext}"
+        n += 1
+    used.add(candidate)
+    return candidate
+
+
+def _collect_font_family_lists(doc: DocumentSpec) -> List[List[str]]:
+    """All distinct priority-ordered family lists used by the document."""
+    seen = set()
+    out: List[List[str]] = []
+
+    def add(families):
+        if not families:
+            return
+        key = tuple(families)
+        if key in seen:
+            return
+        seen.add(key)
+        out.append(list(families))
+
+    if doc.style:
+        for ts in doc.style.font_roles.values():
+            add(ts.family)
+    for page in doc.pages:
+        for r in page.regions:
+            if r.text_style and r.text_style.family:
+                add(r.text_style.family)
+    return out
+
+
+def export_bundle(doc: DocumentSpec, path: str,
+                  font_resolver: Optional[FontResolver] = None) -> BundleManifest:
+    """Write ``doc`` and its assets to a ``.iaibundle`` zip at ``path``.
+
+    Returns the :class:`BundleManifest` (also embedded as ``bundle.json``) so the
+    caller can surface warnings (missing images, fonts embedded by name only).
+    The live ``doc`` is never mutated — refs are rewritten on a deep copy.
+    """
+    manifest = BundleManifest(title=doc.title)
+    doc2 = copy.deepcopy(doc)
+    used_names: set = set()
+    # abs source path -> (archive rel path); dedups identical sources.
+    image_archive: Dict[str, str] = {}
+    font_archive: Dict[str, str] = {}  # abs font source -> archive rel path
+
+    # --- images: copy + rewrite refs to relative bundle paths ---
+    for page in doc2.pages:
+        for r in page.regions:
+            if r.kind != "image" or not r.image_ref:
+                continue
+            src = Path(r.image_ref)
+            if not src.is_file():
+                manifest.warnings.append(f"Image not found, left as-is: {r.image_ref}")
+                continue
+            key = str(src.resolve())
+            rel = image_archive.get(key)
+            if rel is None:
+                rel = _unique_member(_IMAGES_DIR, src.name, used_names)
+                image_archive[key] = rel
+                manifest.images[str(src)] = rel
+            r.image_ref = rel  # forward-slash relative path inside the bundle
+
+    # --- fonts: embed resolved files; record unresolved families by name ---
+    for families in _collect_font_family_lists(doc2):
+        primary = families[0]
+        if primary in manifest.fonts:
+            continue
+        font_path = font_resolver(families) if font_resolver else None
+        if font_path and Path(font_path).is_file():
+            key = str(Path(font_path).resolve())
+            rel = font_archive.get(key)
+            if rel is None:
+                rel = _unique_member(_FONTS_DIR, Path(font_path).name, used_names)
+                font_archive[key] = rel
+            manifest.fonts[primary] = rel
+        else:
+            manifest.fonts[primary] = "by-name"
+            manifest.warnings.append(f"Font embedded by name only (not found): {primary}")
+
+    # --- write the zip ---
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    project_json = json.dumps(schema.document_to_dict(doc2), indent=2)
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(_PROJECT_NAME, project_json)
+        zf.writestr(_MANIFEST_NAME, json.dumps(manifest.to_dict(), indent=2))
+        for src_key, rel in image_archive.items():
+            zf.write(src_key, rel)
+        for src_key, rel in font_archive.items():
+            zf.write(src_key, rel)
+    logger.info("Exported bundle %s (%d images, %d fonts, %d warnings)",
+                out, len(image_archive), len(font_archive), len(manifest.warnings))
+    return manifest
+
+
+def _safe_extract(zf: zipfile.ZipFile, dest: Path) -> None:
+    """Extract guarding against zip-slip (members escaping ``dest``)."""
+    dest = dest.resolve()
+    for member in zf.infolist():
+        target = (dest / member.filename).resolve()
+        if target != dest and dest not in target.parents:
+            raise ValueError(f"Unsafe path in bundle: {member.filename!r}")
+    zf.extractall(dest)
+
+
+def import_bundle(path: str, dest_dir: str) -> DocumentSpec:
+    """Extract a ``.iaibundle`` into ``dest_dir`` and load its document.
+
+    Relative image refs are rewritten back to absolute paths under ``dest_dir``
+    so the returned :class:`DocumentSpec` renders without the original assets.
+    """
+    dest = Path(dest_dir)
+    dest.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path) as zf:
+        _safe_extract(zf, dest)
+    proj_path = dest / _PROJECT_NAME
+    doc = schema.document_from_dict(json.loads(proj_path.read_text(encoding="utf-8")))
+    for page in doc.pages:
+        for r in page.regions:
+            if r.kind == "image" and r.image_ref and not Path(r.image_ref).is_absolute():
+                candidate = (dest / r.image_ref)
+                if candidate.exists():
+                    r.image_ref = str(candidate.resolve())
+    logger.info("Imported bundle %s into %s", path, dest)
+    return doc

--- a/core/layout/prompt_helper.py
+++ b/core/layout/prompt_helper.py
@@ -1,0 +1,126 @@
+"""Per-region AI prompt help: draft an image-generation prompt from the project.
+
+Phase 5a, spec §9 (F-AI) first bullet. Pure prompt-building + response parsing;
+the production LLM call reuses ``core.layout.designer.run_completion`` (LiteLLM,
+key resolution, logging) injected as ``completion_fn`` — so this module is fully
+unit-testable headless with a fake completion.
+"""
+import logging
+from math import gcd
+from typing import Callable, Dict, List, Optional
+
+from core.layout.models import DocumentSpec, PageSpec, Region
+
+logger = logging.getLogger("imageai.layout.prompt_helper")
+
+_SYSTEM = (
+    "You write vivid, concrete image-generation prompts for a single illustration "
+    "that fits one region of a page layout. You return ONE prompt only. Never put "
+    "page dimensions, pixel sizes, or aspect-ratio tokens in the prompt text — the "
+    "image pipeline handles size separately and would otherwise render them as "
+    'literal text. Respond with a single JSON object: {"prompt": "..."}.'
+)
+
+
+def _aspect_ratio(bbox) -> str:
+    """Reduced w:h ratio for *context only* (never a pixel token in the prompt)."""
+    _, _, w, h = bbox
+    w, h = int(round(w)), int(round(h))
+    if w <= 0 or h <= 0:
+        return "1:1"
+    g = gcd(w, h) or 1
+    return f"{w // g}:{h // g}"
+
+
+def _find_page(document: DocumentSpec, region: Region) -> Optional[PageSpec]:
+    for page in document.pages or []:
+        for r in page.regions:
+            if r is region or r.id == region.id:
+                return page
+    return None
+
+
+def _neighbor_text(document: DocumentSpec, region: Region) -> List[str]:
+    """Text from sibling text regions on the same page (scene context)."""
+    page = _find_page(document, region)
+    if page is None:
+        return []
+    return [r.text.strip() for r in page.regions
+            if r.kind == "text" and r.id != region.id and (r.text or "").strip()]
+
+
+def build_prompt_messages(document: DocumentSpec, region: Region,
+                          hint: str = "") -> List[Dict[str, str]]:
+    """Build the chat messages that ask the LLM for one image prompt."""
+    style = document.style
+    palette = (", ".join(f"{k}={v}" for k, v in style.palette.items())
+               if style and style.palette else "(default)")
+    name = region.name or region.id
+    role = region.role or "(unspecified)"
+    aspect = _aspect_ratio(region.bbox)
+
+    neighbors = _neighbor_text(document, region)
+    neighbor_block = ""
+    if neighbors:
+        joined = "\n".join(f"- {t}" for t in neighbors)
+        neighbor_block = f"<page_text>\n{joined}\n</page_text>\n"
+    hint_block = f"<user_hint>\n{hint.strip()}\n</user_hint>\n" if hint.strip() else ""
+
+    user = (
+        f"<context>\n"
+        f"document_title: {document.title}\n"
+        f"content_kind: {document.content_kind}\n"
+        f"color_palette: {palette}\n"
+        f"region_name: {name}\n"
+        f"region_role: {role}\n"
+        f"region_aspect: {aspect}\n"
+        f"</context>\n"
+        f"{neighbor_block}"
+        f"{hint_block}"
+        f"<instructions>\n"
+        f"Write one vivid image-generation prompt for the '{name}' image region of "
+        f"this {document.content_kind} page. Match the subject and mood to the page "
+        f"text and user hint above when present. Keep it a single prompt of 1-3 "
+        f'sentences. Return JSON: {{"prompt": "..."}}. Do NOT include pixel sizes or '
+        f"aspect-ratio tokens in the prompt text.\n"
+        f"</instructions>"
+    )
+    return [{"role": "system", "content": _SYSTEM}, {"role": "user", "content": user}]
+
+
+def _strip_fences(text: str) -> str:
+    t = text.strip()
+    if t.startswith("```"):
+        parts = t.split("```")
+        if len(parts) >= 2:
+            t = parts[1]
+            for lang in ("json", "JSON"):
+                if t.startswith(lang):
+                    t = t[len(lang):]
+                    break
+            t = t.strip()
+    return t
+
+
+def parse_prompt_response(content: str) -> str:
+    """Extract the prompt: JSON ``{"prompt": ...}`` first, else fenced/plain text.
+
+    Empty or whitespace-only input returns ``""`` so the caller can keep the
+    region's existing prompt and log the miss.
+    """
+    if not content or not content.strip():
+        return ""
+    from gui.llm_utils import LLMResponseParser
+    data = LLMResponseParser.parse_json_response(content, expected_type=dict)
+    if isinstance(data, dict):
+        p = data.get("prompt")
+        if isinstance(p, str) and p.strip():
+            return p.strip()
+    return _strip_fences(content)
+
+
+def run_prompt_help(messages: List[Dict[str, str]],
+                    completion_fn: Callable[[List[Dict[str, str]]], str]) -> str:
+    """Run the LLM (injected) and parse out the suggested prompt."""
+    content = completion_fn(messages)
+    return parse_prompt_response(content or "")

--- a/gui/layout/content_inspector.py
+++ b/gui/layout/content_inspector.py
@@ -27,6 +27,8 @@ class ContentInspector(QWidget):
 
     regionContentChanged = Signal(str, str)       # (region_id, new_value)
     regionTextStyleChanged = Signal(str, str, int)  # (region_id, family, size_px)
+    regionPromptChanged = Signal(str, str)          # (region_id, image prompt)
+    regionPromptSuggestRequested = Signal(str, str)  # (region_id, hint = current prompt)
 
     def __init__(self, config=None, parent=None):
         super().__init__(parent)
@@ -67,6 +69,25 @@ class ContentInspector(QWidget):
         self.image_ref_label.setWordWrap(True)
         self.image_ref_label.setStyleSheet("color: #666; font-size: 11px;")
         img_lay.addWidget(self.image_ref_label)
+
+        # Image-generation prompt (saved on the region; used by the AI handoff /
+        # batch phases). "Suggest with AI" drafts one from the project theme.
+        img_lay.addWidget(QLabel("Image prompt:"))
+        self.prompt_edit = QPlainTextEdit()
+        self.prompt_edit.setPlaceholderText(
+            "Prompt for generating this image (optional)…")
+        self.prompt_edit.setFixedHeight(70)
+        img_lay.addWidget(self.prompt_edit)
+        prompt_btns = QHBoxLayout()
+        self.suggest_prompt_btn = QPushButton("Suggest with AI")
+        self.suggest_prompt_btn.clicked.connect(self._on_suggest_prompt)
+        self.apply_prompt_btn = QPushButton("Apply prompt")
+        self.apply_prompt_btn.clicked.connect(self._on_apply_prompt)
+        prompt_btns.addWidget(self.suggest_prompt_btn)
+        prompt_btns.addWidget(self.apply_prompt_btn)
+        prompt_btns.addStretch(1)
+        img_lay.addLayout(prompt_btns)
+
         img_lay.addStretch(1)
         self.stack.addWidget(img_page)
 
@@ -135,6 +156,9 @@ class ContentInspector(QWidget):
         if region.kind == "image":
             self.header.setText(f"Image region: {label}")
             self.image_ref_label.setText(region.image_ref or "(no image)")
+            self.prompt_edit.blockSignals(True)
+            self.prompt_edit.setPlainText(region.prompt or "")
+            self.prompt_edit.blockSignals(False)
             self.stack.setCurrentIndex(1)
         else:
             self.header.setText(f"Text region: {label}")
@@ -179,6 +203,30 @@ class ContentInspector(QWidget):
             return
         self.image_ref_label.setText(path)
         self.regionContentChanged.emit(self._region.id, path)
+
+    # --- image prompt ---
+    def _on_apply_prompt(self):
+        if self._region is None:
+            return
+        self.regionPromptChanged.emit(self._region.id, self.prompt_edit.toPlainText().strip())
+
+    def _on_suggest_prompt(self):
+        if self._region is None:
+            return
+        # The current text doubles as a hint to steer the suggestion.
+        self.regionPromptSuggestRequested.emit(
+            self._region.id, self.prompt_edit.toPlainText().strip())
+
+    def set_prompt_text(self, region_id: str, text: str):
+        """Push an AI-suggested prompt into the box (only if still showing it)."""
+        if self._region is not None and self._region.id == region_id:
+            self.prompt_edit.blockSignals(True)
+            self.prompt_edit.setPlainText(text)
+            self.prompt_edit.blockSignals(False)
+
+    def set_suggest_enabled(self, enabled: bool):
+        """Disable the Suggest button while a suggestion is in flight."""
+        self.suggest_prompt_btn.setEnabled(enabled)
 
     # --- text ---
     def _on_apply_text(self):

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -425,6 +425,8 @@ class LayoutTab(QWidget):
         return Path(path).parent / f"{stem}_files"
 
     def export_bundle_to(self, path: str):
+        if self.document is None:
+            return
         manifest = bundle_io.export_bundle(
             self.document, path, font_resolver=self._bundle_font_resolver())
         msg = f"Exported bundle {path}"

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -11,7 +11,7 @@ from PySide6.QtCore import Signal
 from core.layout.models import DocumentSpec, PageSpec, PageSize, TextStyle
 from core.layout import project_io, qt_renderer
 from core.layout import styles, template_io
-from core.layout import designer, prompt_helper
+from core.layout import designer, prompt_helper, bundle_io
 from core.layout.history import History
 from gui.layout.page_setup_widget import PageSetupWidget
 from gui.layout.canvas_widget import CanvasWidget
@@ -46,6 +46,8 @@ class LayoutTab(QWidget):
             ("History…", self._open_history),
             ("Export Template…", self._export_template_dialog),
             ("Import Template…", self._import_template_dialog),
+            ("Export Bundle…", self._export_bundle_dialog),
+            ("Import Bundle…", self._import_bundle_dialog),
         ]:
             btn = QPushButton(label)
             btn.clicked.connect(slot)
@@ -395,6 +397,67 @@ class LayoutTab(QWidget):
     def import_template_from(self, path: str):
         self._adopt_document(template_io.import_template(path))
         self._refresh()
+
+    # --- bundles (.iaibundle: project + images + fonts, self-contained) ---
+    def _bundle_font_resolver(self):
+        """Lazily build a font_resolver from FontManager (best-effort).
+
+        Discovery scans system fonts, so it's built once and cached; any failure
+        degrades to None (fonts recorded by-name) — never blocks export.
+        """
+        if getattr(self, "_font_manager", None) is None:
+            try:
+                from core.layout.font_manager import FontManager
+                custom = self.config.get_fonts_dir() if self.config else None
+                self._font_manager = FontManager(
+                    custom_dirs=[custom] if custom else None)
+            except Exception:  # noqa: BLE001 - font scan must never block export
+                logger.exception("Layout: font discovery failed; bundling by name")
+                self._font_manager = False  # sentinel: tried and failed
+        fm = self._font_manager
+        return fm.select_font_file if fm else None
+
+    def _bundle_extract_dir(self, path: str) -> Path:
+        stem = Path(path).stem
+        base = getattr(self.config, "config_dir", None) if self.config else None
+        if base:
+            return Path(base) / "layout" / "bundles" / stem
+        return Path(path).parent / f"{stem}_files"
+
+    def export_bundle_to(self, path: str):
+        manifest = bundle_io.export_bundle(
+            self.document, path, font_resolver=self._bundle_font_resolver())
+        msg = f"Exported bundle {path}"
+        if manifest.warnings:
+            msg += f" ({len(manifest.warnings)} warning(s))"
+        self.status.setText(msg)
+
+    def import_bundle_from(self, path: str):
+        dest = self._bundle_extract_dir(path)
+        self._adopt_document(bundle_io.import_bundle(path, str(dest)))
+        page = (self.document.pages[0]
+                if self.document and self.document.pages else None)
+        if page is not None and page.page_size and hasattr(self, "page_setup"):
+            self.page_setup.set_page_size(page.page_size)
+        self._refresh()
+
+    def _export_bundle_dialog(self):
+        path, _ = QFileDialog.getSaveFileName(self, "Export Bundle", "",
+                                              "ImageAI Layout Bundle (*.iaibundle)")
+        if path:
+            try:
+                self.export_bundle_to(path)
+            except Exception as e:  # noqa: BLE001 - surfaced to UI + log
+                self._report_error("export bundle", e)
+
+    def _import_bundle_dialog(self):
+        path, _ = QFileDialog.getOpenFileName(self, "Import Bundle", "",
+                                              "ImageAI Layout Bundle (*.iaibundle)")
+        if path:
+            try:
+                self.import_bundle_from(path)
+            except Exception as e:  # noqa: BLE001 - surfaced to UI + log
+                self._report_error("import bundle", e)
 
     # --- error reporting (repo rule: all errors logged + shown to the user) ---
     def _report_error(self, what: str, exc: Exception):

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -11,6 +11,7 @@ from PySide6.QtCore import Signal
 from core.layout.models import DocumentSpec, PageSpec, PageSize, TextStyle
 from core.layout import project_io, qt_renderer
 from core.layout import styles, template_io
+from core.layout import designer, prompt_helper
 from core.layout.history import History
 from gui.layout.page_setup_widget import PageSetupWidget
 from gui.layout.canvas_widget import CanvasWidget
@@ -30,6 +31,7 @@ class LayoutTab(QWidget):
         self.config = config
         self.document: Optional[DocumentSpec] = None
         self.history: Optional[History] = None
+        self._prompt_worker = None  # keep alive so the QThread isn't GC'd mid-run
         self._locked = self._load_locked()
         self._build()
         self._restore_session_or_new()
@@ -78,6 +80,8 @@ class LayoutTab(QWidget):
         self.inspector = ContentInspector(self.config)
         self.inspector.regionContentChanged.connect(self._on_region_content_changed)
         self.inspector.regionTextStyleChanged.connect(self._on_region_text_style_changed)
+        self.inspector.regionPromptChanged.connect(self._on_region_prompt_changed)
+        self.inspector.regionPromptSuggestRequested.connect(self._on_region_prompt_suggest)
         root.addWidget(self.inspector)
         self.canvas.regionSelected.connect(self._on_region_selected)
 
@@ -248,6 +252,73 @@ class LayoutTab(QWidget):
                 return
             region.text = value
         self._refresh()
+
+    # --- per-region AI image-prompt help (Phase 5a) ---
+    def _on_region_prompt_changed(self, region_id: str, prompt: str):
+        """Persist an edited image prompt on the region (metadata; no re-render)."""
+        region = self._find_region(region_id)
+        if region is None or region.kind != "image":
+            return
+        region.prompt = prompt
+        self.status.setText(f"Saved prompt for {region.name or region.id}")
+
+    def _on_region_prompt_suggest(self, region_id: str, hint: str):
+        self.suggest_region_prompt(region_id, hint)
+
+    def suggest_region_prompt(self, region_id: str, hint: str = "", completion_fn=None):
+        """Draft an image prompt for ``region_id`` from the project theme.
+
+        ``completion_fn`` is injected in tests (run synchronously); in production
+        it wraps ``designer.run_completion`` with the Designer panel's selected
+        provider/model so there's a single LLM config for the tab.
+        """
+        region = self._find_region(region_id)
+        if region is None or region.kind != "image" or self.document is None:
+            return
+        if self._prompt_worker is not None and self._prompt_worker.isRunning():
+            self.designer.console.log("A prompt suggestion is already running.", "WARNING")
+            return
+        messages = prompt_helper.build_prompt_messages(self.document, region, hint)
+        self.designer.console.log(
+            f"Suggesting image prompt for {region.name or region.id}:\n"
+            + messages[-1]["content"], "INFO")
+        injected = completion_fn is not None
+        if completion_fn is None:
+            provider = self.designer.provider_combo.currentText()
+            model = self.designer.model_combo.currentText()
+            cfg = self.config
+            completion_fn = lambda m: designer.run_completion(cfg, provider, model, m)
+        self.inspector.set_suggest_enabled(False)
+        from gui.layout.prompt_worker import PromptSuggestWorker
+        self._prompt_worker = PromptSuggestWorker(region_id, messages, completion_fn)
+        self._prompt_worker.suggested.connect(self._on_prompt_suggested)
+        self._prompt_worker.failed.connect(self._on_prompt_failed)
+        if injected:
+            self._prompt_worker.run()   # synchronous for injected/test completions
+        else:
+            self._prompt_worker.start()
+
+    def _on_prompt_suggested(self, region_id: str, prompt: str):
+        self.inspector.set_suggest_enabled(True)
+        region = self._find_region(region_id)
+        if region is None or region.kind != "image":
+            return
+        if not prompt:
+            self.designer.console.log(
+                "Prompt suggestion came back empty — keeping the existing prompt.",
+                "WARNING")
+            return
+        region.prompt = prompt
+        self.inspector.set_prompt_text(region_id, prompt)
+        self.designer.console.log("Suggested prompt:\n" + prompt, "SUCCESS")
+        self.status.setText(f"Suggested prompt for {region.name or region.id}")
+
+    def _on_prompt_failed(self, region_id: str, err: str):
+        self.inspector.set_suggest_enabled(True)
+        if not self.designer.console_toggle.isChecked():
+            self.designer.console_toggle.setChecked(True)  # surface the failure
+        self.designer.console.log(f"Prompt suggestion failed: {err}", "ERROR")
+        self.status.setText("Error: prompt suggestion failed")
 
     # --- programmatic API (tested) ---
     def save_project_to(self, path: str):

--- a/gui/layout/prompt_worker.py
+++ b/gui/layout/prompt_worker.py
@@ -1,0 +1,34 @@
+"""Worker thread for per-region AI image-prompt suggestions.
+
+Mirrors ``DesignerWorker``: when a ``completion_fn`` is injected (tests) the
+caller runs it synchronously via ``run()``; in production the LayoutTab calls
+``start()`` so the LLM call never blocks the GUI thread.
+"""
+import logging
+from typing import Callable, Dict, List
+
+from PySide6.QtCore import QThread, Signal
+
+from core.layout import prompt_helper
+
+logger = logging.getLogger("imageai.layout.prompt_worker")
+
+
+class PromptSuggestWorker(QThread):
+    suggested = Signal(str, str)  # (region_id, prompt)
+    failed = Signal(str, str)     # (region_id, error)
+
+    def __init__(self, region_id: str, messages: List[Dict[str, str]],
+                 completion_fn: Callable[[List[Dict[str, str]]], str], parent=None):
+        super().__init__(parent)
+        self._region_id = region_id
+        self._messages = messages
+        self._completion_fn = completion_fn
+
+    def run(self):
+        try:
+            prompt = prompt_helper.run_prompt_help(self._messages, self._completion_fn)
+            self.suggested.emit(self._region_id, prompt)
+        except Exception as e:  # noqa: BLE001 - surfaced to UI + log
+            logger.error("Prompt-suggest worker failed: %s", e, exc_info=True)
+            self.failed.emit(self._region_id, str(e))

--- a/tests/layout/test_bundle_io.py
+++ b/tests/layout/test_bundle_io.py
@@ -1,0 +1,110 @@
+"""Phase 5a — .iaibundle export/import (project + images + fonts, self-contained)."""
+import json
+import zipfile
+from pathlib import Path
+
+from core.layout.models import DocumentSpec, PageSpec, Region
+from core.layout import bundle_io, styles
+
+
+def _doc(regions, content_kind="children", title="Story"):
+    page = PageSpec(page_size_px=(1000, 1500), regions=regions)
+    return DocumentSpec(title=title, pages=[page], content_kind=content_kind,
+                        style=styles.default_style_for(content_kind))
+
+
+def test_export_bundle_contains_project_images_and_manifest(tmp_path):
+    img1 = tmp_path / "a.png"; img1.write_bytes(b"PNG-A")
+    img2 = tmp_path / "b.png"; img2.write_bytes(b"PNG-B")
+    doc = _doc([
+        Region(id="i1", kind="image", bbox=(0, 0, 500, 500), image_ref=str(img1)),
+        Region(id="i2", kind="image", bbox=(0, 500, 500, 500), image_ref=str(img2)),
+    ])
+    out = tmp_path / "bundle.iaibundle"
+    bundle_io.export_bundle(doc, str(out))
+    assert out.exists()
+    with zipfile.ZipFile(out) as zf:
+        names = zf.namelist()
+        assert bundle_io._PROJECT_NAME in names
+        assert bundle_io._MANIFEST_NAME in names
+        assert len([n for n in names if n.startswith("images/")]) == 2
+        proj = json.loads(zf.read(bundle_io._PROJECT_NAME))
+    refs = [r["image_ref"] for r in proj["pages"][0]["regions"]]
+    assert all(ref.startswith("images/") for ref in refs)  # rewritten to relative
+    # the live document must not be mutated by export
+    assert doc.pages[0].regions[0].image_ref == str(img1)
+
+
+def test_export_import_round_trip(tmp_path):
+    img = tmp_path / "pic.png"; img.write_bytes(b"DATA")
+    doc = _doc([
+        Region(id="i1", kind="image", bbox=(0, 0, 100, 100), image_ref=str(img)),
+        Region(id="t1", kind="text", bbox=(0, 110, 100, 40), text="Hi", role="title"),
+    ])
+    out = tmp_path / "b.iaibundle"
+    bundle_io.export_bundle(doc, str(out))
+
+    dest = tmp_path / "extracted"
+    doc2 = bundle_io.import_bundle(str(out), str(dest))
+    r = doc2.pages[0].regions[0]
+    assert Path(r.image_ref).is_absolute() and Path(r.image_ref).exists()
+    assert Path(r.image_ref).read_bytes() == b"DATA"
+    assert doc2.pages[0].regions[1].text == "Hi"
+    assert doc2.title == "Story"
+
+
+def test_missing_image_is_warned_not_fatal(tmp_path):
+    doc = _doc([Region(id="i1", kind="image", bbox=(0, 0, 100, 100),
+                       image_ref="/does/not/exist.png")])
+    out = tmp_path / "b.iaibundle"
+    manifest = bundle_io.export_bundle(doc, str(out))
+    assert any("exist.png" in w for w in manifest.warnings)
+    assert out.exists()
+    with zipfile.ZipFile(out) as zf:
+        proj = json.loads(zf.read(bundle_io._PROJECT_NAME))
+    # missing ref preserved as-is (no rewrite)
+    assert proj["pages"][0]["regions"][0]["image_ref"] == "/does/not/exist.png"
+
+
+def test_shared_image_is_embedded_once(tmp_path):
+    img = tmp_path / "shared.png"; img.write_bytes(b"S")
+    doc = _doc([
+        Region(id="i1", kind="image", bbox=(0, 0, 100, 100), image_ref=str(img)),
+        Region(id="i2", kind="image", bbox=(0, 100, 100, 100), image_ref=str(img)),
+    ])
+    out = tmp_path / "b.iaibundle"
+    bundle_io.export_bundle(doc, str(out))
+    with zipfile.ZipFile(out) as zf:
+        assert len([n for n in zf.namelist() if n.startswith("images/")]) == 1
+        proj = json.loads(zf.read(bundle_io._PROJECT_NAME))
+    refs = {r["image_ref"] for r in proj["pages"][0]["regions"]}
+    assert len(refs) == 1  # both regions share the single embedded image
+
+
+def test_font_embedding_records_resolved_path(tmp_path):
+    font_file = tmp_path / "MyFont.ttf"; font_file.write_bytes(b"TTF")
+    doc = _doc([Region(id="t1", kind="text", bbox=(0, 0, 100, 40), text="x", role="title")])
+    out = tmp_path / "b.iaibundle"
+    manifest = bundle_io.export_bundle(doc, str(out), font_resolver=lambda families: font_file)
+    assert any(v.startswith("fonts/") for v in manifest.fonts.values())
+    with zipfile.ZipFile(out) as zf:
+        assert any(n.startswith("fonts/") for n in zf.namelist())
+
+
+def test_font_unresolved_recorded_by_name(tmp_path):
+    doc = _doc([Region(id="t1", kind="text", bbox=(0, 0, 100, 40), text="x", role="title")])
+    out = tmp_path / "b.iaibundle"
+    manifest = bundle_io.export_bundle(doc, str(out), font_resolver=lambda families: None)
+    assert manifest.fonts                                   # roles produced families
+    assert all(v == "by-name" for v in manifest.fonts.values())
+
+
+def test_import_rejects_zip_slip(tmp_path):
+    # A malicious member escaping the destination must be refused.
+    evil = tmp_path / "evil.iaibundle"
+    with zipfile.ZipFile(evil, "w") as zf:
+        zf.writestr(bundle_io._PROJECT_NAME, "{}")
+        zf.writestr("../escape.txt", "pwned")
+    import pytest
+    with pytest.raises(ValueError):
+        bundle_io.import_bundle(str(evil), str(tmp_path / "dest"))

--- a/tests/layout/test_content_inspector.py
+++ b/tests/layout/test_content_inspector.py
@@ -112,3 +112,40 @@ def test_populate_fonts_fills_combo(qapp):
     insp._populate_fonts(["Alpha", "Beta", "Gamma"])
     items = [insp.font_combo.itemText(i) for i in range(insp.font_combo.count())]
     assert items == ["Alpha", "Beta", "Gamma"]
+
+
+def test_image_page_loads_prompt(qapp):
+    insp = ContentInspector()
+    insp.set_region(_img(rid="i", ref="/p.png"))
+    insp._region.prompt = "a castle"          # set then re-show
+    insp.set_region(insp._region)
+    assert insp.prompt_edit.toPlainText() == "a castle"
+
+
+def test_apply_prompt_emits(qapp):
+    insp = ContentInspector()
+    insp.set_region(_img(rid="i1"))
+    got = []
+    insp.regionPromptChanged.connect(lambda rid, v: got.append((rid, v)))
+    insp.prompt_edit.setPlainText("a glowing forest")
+    insp.apply_prompt_btn.click()
+    assert got == [("i1", "a glowing forest")]
+
+
+def test_suggest_prompt_emits_with_hint(qapp):
+    insp = ContentInspector()
+    insp.set_region(_img(rid="i1"))
+    got = []
+    insp.regionPromptSuggestRequested.connect(lambda rid, hint: got.append((rid, hint)))
+    insp.prompt_edit.setPlainText("dawn light")   # current text becomes the hint
+    insp.suggest_prompt_btn.click()
+    assert got == [("i1", "dawn light")]
+
+
+def test_set_prompt_text_only_updates_current_region(qapp):
+    insp = ContentInspector()
+    insp.set_region(_img(rid="i1"))
+    insp.set_prompt_text("other", "ignored")
+    assert insp.prompt_edit.toPlainText() == ""
+    insp.set_prompt_text("i1", "applied")
+    assert insp.prompt_edit.toPlainText() == "applied"

--- a/tests/layout/test_layout_tab_bundle.py
+++ b/tests/layout/test_layout_tab_bundle.py
@@ -1,0 +1,44 @@
+# tests/layout/test_layout_tab_bundle.py — Phase 5a .iaibundle wiring
+from pathlib import Path
+
+from core.layout import designer
+from gui.layout.layout_tab import LayoutTab
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tab_with_image(image_ref):
+    tab = LayoutTab(config=FakeConfig())
+    tab.apply_designer_result(designer.DesignerResult(regions=[
+        designer.Region(id="img", kind="image", bbox=(0, 0, 100, 100), image_ref=image_ref),
+    ]), user_text="page")
+    return tab
+
+
+def test_export_then_import_bundle_round_trip(qapp, tmp_path):
+    img = tmp_path / "pic.png"; img.write_bytes(b"IMG")
+    tab = _tab_with_image(str(img))
+    out = tmp_path / "b.iaibundle"
+    tab.export_bundle_to(str(out))
+    assert out.exists()
+    assert "Exported bundle" in tab.status.text()
+
+    # a fresh tab opens the bundle with no access to the original file
+    tab2 = LayoutTab(config=FakeConfig())
+    tab2.import_bundle_from(str(out))
+    r = tab2.document.pages[0].regions[0]
+    assert Path(r.image_ref).is_absolute() and Path(r.image_ref).exists()
+    assert Path(r.image_ref).read_bytes() == b"IMG"
+
+
+def test_export_bundle_missing_image_reports_warning(qapp, tmp_path):
+    tab = _tab_with_image("/no/such/file.png")
+    out = tmp_path / "b.iaibundle"
+    tab.export_bundle_to(str(out))           # must not raise
+    assert out.exists()
+    assert "warning" in tab.status.text().lower()

--- a/tests/layout/test_layout_tab_prompt.py
+++ b/tests/layout/test_layout_tab_prompt.py
@@ -1,0 +1,84 @@
+# tests/layout/test_layout_tab_prompt.py — Phase 5a per-region AI prompt help
+from core.layout import designer
+from gui.layout.layout_tab import LayoutTab
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tab_with_regions():
+    tab = LayoutTab(config=FakeConfig())
+    tab.apply_designer_result(designer.DesignerResult(regions=[
+        designer.Region(id="img", kind="image", name="hero", bbox=(0, 0, 100, 100)),
+        designer.Region(id="txt", kind="text", bbox=(0, 110, 100, 40), text="hi", role="title"),
+    ]), user_text="page")
+    return tab
+
+
+def test_suggest_writes_prompt_and_updates_inspector(qapp):
+    tab = _tab_with_regions()
+    tab._on_region_selected("img")          # show the image editor
+    captured = {}
+
+    def fake(messages):
+        captured["msgs"] = messages
+        return '{"prompt": "a brave hero on a cliff at dawn"}'
+
+    tab.suggest_region_prompt("img", hint="dawn", completion_fn=fake)
+    region = tab.document.pages[0].regions[0]
+    assert region.prompt == "a brave hero on a cliff at dawn"
+    assert tab.inspector.prompt_edit.toPlainText() == "a brave hero on a cliff at dawn"
+    # the hint reached the LLM messages
+    assert "dawn" in " ".join(m["content"] for m in captured["msgs"])
+
+
+def test_empty_suggestion_keeps_existing_prompt(qapp):
+    tab = _tab_with_regions()
+    tab.document.pages[0].regions[0].prompt = "keep me"
+    tab.suggest_region_prompt("img", completion_fn=lambda m: "")
+    assert tab.document.pages[0].regions[0].prompt == "keep me"
+
+
+def test_suggest_on_text_region_is_noop(qapp):
+    tab = _tab_with_regions()
+    called = {"n": 0}
+
+    def fake(m):
+        called["n"] += 1
+        return '{"prompt": "x"}'
+
+    tab.suggest_region_prompt("txt", completion_fn=fake)
+    assert called["n"] == 0  # never calls the LLM for a text region
+
+
+def test_suggest_unknown_id_is_noop(qapp):
+    tab = _tab_with_regions()
+    tab.suggest_region_prompt("nope", completion_fn=lambda m: '{"prompt":"x"}')  # must not raise
+
+
+def test_apply_prompt_persists_on_region(qapp):
+    tab = _tab_with_regions()
+    tab._on_region_prompt_changed("img", "manually typed prompt")
+    assert tab.document.pages[0].regions[0].prompt == "manually typed prompt"
+
+
+def test_apply_prompt_on_text_region_is_noop(qapp):
+    tab = _tab_with_regions()
+    tab._on_region_prompt_changed("txt", "should not stick")
+    # text regions have no image prompt; nothing written
+    assert tab.document.pages[0].regions[1].prompt == ""
+
+
+def test_failed_suggestion_surfaces_in_console(qapp):
+    tab = _tab_with_regions()
+
+    def boom(m):
+        raise RuntimeError("network down")
+
+    tab.suggest_region_prompt("img", completion_fn=boom)
+    # failure must expand the designer console (errors are never hidden)
+    assert tab.designer.console_toggle.isChecked()

--- a/tests/layout/test_prompt_helper.py
+++ b/tests/layout/test_prompt_helper.py
@@ -1,0 +1,80 @@
+"""Phase 5a — per-region AI prompt help (pure core, injected completion)."""
+from core.layout.models import DocumentSpec, PageSpec, Region
+from core.layout import prompt_helper, styles
+
+
+def _doc(regions, content_kind="children", title="My Story"):
+    page = PageSpec(page_size_px=(1000, 1500), regions=regions)
+    return DocumentSpec(title=title, pages=[page], content_kind=content_kind,
+                        style=styles.default_style_for(content_kind))
+
+
+def test_build_prompt_messages_includes_project_and_region_context():
+    img = Region(id="img1", kind="image", name="hero illustration", bbox=(0, 0, 1000, 1000))
+    txt = Region(id="t1", kind="text", bbox=(0, 1000, 1000, 200), text="Once upon a time")
+    msgs = prompt_helper.build_prompt_messages(_doc([img, txt]), img, hint="cozy forest")
+    assert msgs[0]["role"] == "system"
+    joined = " ".join(m["content"] for m in msgs)
+    assert "children" in joined           # content_kind seeds the style
+    assert "My Story" in joined           # document title
+    assert "hero illustration" in joined  # region name
+    assert "Once upon a time" in joined   # sibling text gives scene context
+    assert "cozy forest" in joined        # user hint
+
+
+def test_build_prompt_messages_aspect_is_context_not_a_pixel_token():
+    # Repo rule: never embed pixel/ratio tokens an image model would render
+    # literally. A ratio may appear as context, but not "(1000x1000)".
+    img = Region(id="img1", kind="image", bbox=(0, 0, 1000, 1000))
+    joined = " ".join(m["content"] for m in prompt_helper.build_prompt_messages(_doc([img]), img))
+    assert "1000x1000" not in joined
+    assert "(1000" not in joined
+
+
+def test_build_prompt_messages_asks_for_a_single_prompt():
+    img = Region(id="img1", kind="image", bbox=(0, 0, 500, 500))
+    joined = " ".join(m["content"] for m in prompt_helper.build_prompt_messages(_doc([img]), img))
+    assert "prompt" in joined.lower()
+
+
+def test_build_prompt_messages_tolerates_region_not_in_document():
+    # A detached region (no page contains it) must not raise — just no neighbors.
+    stray = Region(id="x", kind="image", bbox=(0, 0, 100, 100))
+    msgs = prompt_helper.build_prompt_messages(_doc([]), stray)
+    assert msgs and msgs[-1]["role"] == "user"
+
+
+def test_parse_prompt_response_json():
+    assert prompt_helper.parse_prompt_response('{"prompt": "a red fox"}') == "a red fox"
+
+
+def test_parse_prompt_response_fenced_json():
+    out = prompt_helper.parse_prompt_response('```json\n{"prompt": "a blue whale"}\n```')
+    assert out == "a blue whale"
+
+
+def test_parse_prompt_response_plain_text():
+    assert prompt_helper.parse_prompt_response("a lone lighthouse at dusk") == "a lone lighthouse at dusk"
+
+
+def test_parse_prompt_response_fenced_plain_text():
+    assert prompt_helper.parse_prompt_response("```\na quiet harbor\n```") == "a quiet harbor"
+
+
+def test_parse_prompt_response_empty():
+    assert prompt_helper.parse_prompt_response("") == ""
+    assert prompt_helper.parse_prompt_response("   ") == ""
+
+
+def test_run_prompt_help_uses_injected_completion():
+    captured = {}
+
+    def fake(messages):
+        captured["msgs"] = messages
+        return '{"prompt": "a knight in a misty field"}'
+
+    img = Region(id="img1", kind="image", bbox=(0, 0, 500, 500))
+    msgs = prompt_helper.build_prompt_messages(_doc([img]), img)
+    out = prompt_helper.run_prompt_help(msgs, fake)
+    assert out == "a knight in a misty field"
+    assert captured["msgs"] == msgs


### PR DESCRIPTION
## Phase 5a — AI content & bundles (first slice)

Phase 5 of the AI Layout Designer redesign (design spec §9 F-AI + §8 bundles) is
larger than any prior phase, so it ships as a series of PRs. **5a** delivers the
two self-contained, fully headless-testable pieces; the cross-tab handoff, Batch
placement, and layout-complete mode follow in 5b+.

Plan: `Plans/2026-06-25-layout-ai-designer-phase5a-content.md` ·
Completion: `Plans/2026-06-25-layout-ai-designer-phase5a-completion.md`

### 1. Per-region AI image-prompt help
Select an image region → **Suggest with AI** → the LLM drafts an
image-generation prompt from the project theme (content_kind, title, palette,
region role/name/aspect) plus sibling text-region content for scene context. The
suggestion fills `region.prompt` — the same field the later handoff/batch phases
consume.

- `core/layout/prompt_helper.py` (NEW, pure): `build_prompt_messages` /
  `parse_prompt_response` / `run_prompt_help`. Reuses `designer.run_completion`
  (registry-resolved model IDs, LiteLLM, full logging). **Never** injects a
  pixel/ratio token into the prompt (Gemini renders those literally).
- `gui/layout/prompt_worker.py` (NEW): `PromptSuggestWorker(QThread)` — sync when
  a `completion_fn` is injected (tests), threaded otherwise.
- `ContentInspector`: image page gains a prompt box + Suggest/Apply; display-only.
- `LayoutTab.suggest_region_prompt()`: orchestrates via the Designer panel's
  provider/model; re-fetches the region by id on completion; logs request+response
  to the Designer console; failures auto-expand it (errors never hidden); empty
  result keeps the existing prompt; second click while running is rejected.

### 2. `.iaibundle` export/import
A self-contained zip a recipient opens without the original assets: project JSON
(image refs rewritten relative) + deduped images + embedded fonts + a manifest.

- `core/layout/bundle_io.py` (NEW): `export_bundle` deep-copies the doc (live one
  never mutated; missing images warn, not fatal); `import_bundle` rewrites refs
  back to absolute and **guards against zip-slip**. Font resolution is injected,
  so the core is unit-testable without a system-font scan.
- `LayoutTab`: Export/Import Bundle… toolbar + `export_bundle_to` /
  `import_bundle_from`; production resolver lazily wraps a cached `FontManager`
  (degrades to by-name on failure — never blocks export); errors logged + shown.

### Tests
`QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q`
→ **151 passed** (112 → **+39**): prompt_helper core, inspector signals,
LayoutTab orchestration (empty/failed/no-op paths), bundle round-trip,
relative-ref rewrite, missing-image warning, shared-image dedup, font embed vs
by-name, and zip-slip rejection.

### Review
Opus structured review over the branch diff: **APPROVE — no Critical or Important
issues.** Minor #1 (null-document guard on `export_bundle_to`) applied; #2/#3 were
awareness-only.

### Out of scope (Phase 5b+)
"Send to Image tab" handoff, Batch API placement, layout-complete mode (need
LayoutTab↔MainWindow wiring + a GUI runtime to verify); OS font install on import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)