### PR TITLE
feat(layout): comic-style dynamic page layout (geometry, tiling, overlays, AI designer, manual editor)

### DIFF
--- a/Plans/2026-06-27-comic-layout-ai-designer-design.md
+++ b/Plans/2026-06-27-comic-layout-ai-designer-design.md
@@ -1,0 +1,230 @@
+# Comic Layout — AI Designer Extension (sub-project #4 of 5)
+
+**Status:** Design approved 2026-06-27. Ready for implementation plan.
+**Branch:** `feat/comic-layout-geometry-core` (all 5 comic-layout sub-projects share one branch).
+**PR gate:** Do NOT open a PR — the single PR comes only after sub-project #5.
+
+## 1. Goal
+
+Extend the AI layout designer so it can emit the full geometry surface built by
+sub-projects #1–#3, instead of only axis-aligned `rect`/`polygon` regions:
+
+- **Curved / path panels + bleed / borderless** (#1) — via SVG path `d` strings.
+- **Tiling presets / gap-free partitions** (#2) — the LLM may request a named
+  preset, or free-draw panels.
+- **Overlays** (#3) — speech / thought balloons, captions, SFX — placed
+  **region-relative** (panel id + normalized offset; tail aimed at a panel) with
+  a raw-pixel fallback, resolved to pixels by the designer.
+
+Plus the **`svg⇄segments` converter** that makes curve authoring LLM-native and
+round-trippable.
+
+The manual editor (#5) drag-edits whatever #4 emits; #4 makes the AI output
+appear end-to-end on the canvas.
+
+## 2. Scope decisions (user-approved)
+
+| Decision | Choice |
+|----------|--------|
+| Capabilities the AI gains | **All three**: curved/path panels + bleed/borderless, tiling presets, overlays |
+| How the LLM expresses curves | **SVG path `d` strings** + a bidirectional `svg_path.py` converter |
+| How the AI uses tiling | **Hybrid**: named preset + params **or** free-draw panels per page |
+| Overlay placement | **Region-relative** (`anchor_region` + `anchor_offset`; `tail_to_region`) with **raw-pixel fallback**; designer resolves to pixels |
+| GUI reach | **Core + minimal apply wiring**: `DesignerResult.overlays` + `apply_designer_result` writes regions+overlays onto the page so AI output renders on the canvas. No new editor controls (those are #5) |
+
+## 3. Architecture
+
+**Approach — "the designer fully resolves."** `parse_response` performs all
+expansion — SVG → `PathSegment`s, tiling preset → panel `Region`s,
+region-relative anchors → pixel `anchor`/`tail_target` — and returns a
+`DesignerResult` carrying concrete `Region`s and `Overlay`s ready to drop onto
+the page. The GUI just assigns them. This mirrors how `parse_response` already
+returns normalized `Region`s, keeps every hard part **pure and unit-testable**,
+and means the canvas (which already renders path regions + overlays via the Qt
+renderer) needs **no new rendering code**.
+
+> Rejected alternative: return a high-level intermediate (preset names,
+> region-relative overlays) and expand at apply-time. Adds a layer and buys only
+> page-resize reflow, which #5's manual editor handles anyway. YAGNI.
+
+### Modules
+
+| Module | Change | Qt? |
+|--------|--------|-----|
+| `core/layout/svg_path.py` | **NEW** — bidirectional SVG `d` ⇄ `PathSegment` converter | No (pure) |
+| `core/layout/designer.py` | **EXTEND** — richer prompt; `parse_response` handles svg-path / tiling / overlays + region-relative anchor resolution; `DesignerResult.overlays` | No (pure) |
+| `gui/layout/layout_tab.py` | **EXTEND** — `apply_designer_result` writes `result.overlays` into `pages[0].overlays` | Yes (existing) |
+
+`svg_path.py` and `designer.py` stay Qt-free and headless-importable, consistent
+with #1–#3. Only the existing GUI file touches Qt.
+
+## 4. The LLM JSON contract
+
+Extends today's `{ questions?, layout: { regions: [...] } }`. All keys optional;
+the LLM may still return `questions`, a `layout`, or both.
+
+```jsonc
+"layout": {
+  // (A) Optional tiling preset — engine generates gap-free panels:
+  "tiling": {
+    "preset": "grid | three_tiers | splash_with_strip | diagonal_action | feature_L",
+    "params": { "rows": 3, "cols": 2, "gutter_px": 12 }   // preset-specific
+  },
+
+  // (B) Regions — rect/polygon as today, PLUS shape:"path" via SVG, plus bleed/stroke.
+  //     Coexists with tiling (preset panels + extra free panels) or stands alone.
+  "regions": [
+    { "id": "p1", "kind": "image", "shape": "path",
+      "svg": "M40 40 L380 40 C400 40 400 60 400 80 L400 300 Z",
+      "bleed": true, "stroke_px": 6 },
+    { "id": "t1", "kind": "text", "shape": "rect", "bbox": [40, 320, 360, 80],
+      "role": "caption", "text": "" }
+  ],
+
+  // (C) Overlays — region-relative placement resolved to pixels by the designer.
+  "overlays": [
+    { "id": "o1", "kind": "speech", "text": "Look out!",
+      "anchor_region": "p1", "anchor_offset": [0.5, 0.2],  // 0..1 within p1's bbox
+      "tail_to_region": "p1",                              // tail aims at p1's center
+      "role": "dialogue" },
+    { "id": "o2", "kind": "sfx", "text": "BOOM", "anchor": [620, 240] }  // raw-pixel fallback
+  ]
+}
+```
+
+- **Free-draw and presets coexist.** A page may give `tiling`, hand-authored
+  `regions`, or both.
+- **Raw-pixel `anchor`/`tail_target` remain accepted everywhere** as the
+  fallback when the LLM gives explicit pixels.
+- **Backward compatible.** Today's `rect`/`polygon` + `bbox`/`points` responses
+  parse exactly as before.
+
+## 5. Components & data flow
+
+### 5.1 `core/layout/svg_path.py` (pure)
+
+- `svg_to_segments(d: str) -> List[PathSegment]` — tokenize a path `d` string;
+  support `M/m L/l H/h V/v C/c Q/q Z/z` (absolute + relative); track current
+  point and subpath start (for `Z` and relative commands). Emit exactly the
+  `PathSegment` types the model + renderer already consume
+  (`move/line/quad/cubic/close`). Unknown command or malformed number → log a
+  warning and return what parsed cleanly (or `[]`); never raise.
+- `segments_to_svg(segments: List[PathSegment]) -> str` — inverse, for
+  round-trip, export, and showing current geometry back to the LLM on iterate.
+
+### 5.2 `core/layout/designer.py` (extend)
+
+- `build_messages` — document the new contract in `<instructions>`:
+  `shape:"path"` + `svg`; `bleed` / `stroke_px`; the `tiling` block with the
+  five preset names + params; the `overlays` array with `kind` ∈
+  speech/thought/caption/sfx, region-relative placement
+  (`anchor_region` + `anchor_offset`, `tail_to_region`), and the raw-pixel
+  fallback. Reuses the existing role-name listing.
+- `parse_response` — order of operations:
+  1. If `tiling` present, call the preset fn (`core/layout/tiling.py`) →
+     panel `Region`s.
+  2. Parse `regions`: rect/polygon as today; `shape:"path"` → `svg_to_segments`;
+     carry `bleed` / `stroke_px`. Append/merge with the tiled panels.
+  3. `normalize_region` each resolved region.
+  4. Parse `overlays`: resolve `anchor_region` + `anchor_offset` and
+     `tail_to_region` against the resolved regions' bboxes into pixel `anchor` /
+     `tail_target`; fall back to raw-pixel `anchor` / `tail_target`. Build
+     `Overlay`s.
+- `_resolve_overlay_anchor(...)` — small pure helper (region-id + normalized
+  offset → pixel point). Unknown id → log + drop that one overlay (keep the
+  rest); never crash.
+- `DesignerResult` gains `overlays: List[Overlay] = field(default_factory=list)`.
+  `fallback_result` unchanged (no overlays).
+
+### 5.3 `gui/layout/layout_tab.py` (extend)
+
+- `apply_designer_result`: when `result.overlays`, set
+  `pages[0].overlays = list(result.overlays)`, alongside the existing region
+  assignment + history append + refresh. (Designer-panel log line mentions the
+  overlay count — minor.)
+
+### 5.4 Data flow
+
+```
+panel → build_messages → LLM → parse_response
+        (resolves SVG→segments, tiling→panels, region-relative anchors→pixels)
+      → DesignerResult{regions, overlays, questions}
+      → apply_designer_result writes regions + overlays onto pages[0]
+      → _refresh → Qt renderer draws them (no new render code)
+```
+
+## 6. Error handling (per project rules — all errors logged, never crash)
+
+| Failure | Behavior |
+|---------|----------|
+| Malformed SVG `d` | Log warning; emit what parsed cleanly or `[]`; region falls back to bbox via the existing renderer guard |
+| Unknown tiling preset | Log warning; skip tiling (use explicit regions / fallback) |
+| Unknown `anchor_region` / `tail_to_region` id | Log warning; drop that overlay, keep the rest |
+| Out-of-page coords | `normalize_region` clamps regions; overlays clamp anchor into page |
+| Entirely unparseable response | Existing `fallback_result` (single full-page frame + question) |
+
+All resolution is pure and headless-testable; the live `run_completion` LLM call
+stays network/untested as today.
+
+## 7. Testing
+
+Interpreter `.venv_linux/bin/python`; run with `QT_QPA_PLATFORM=offscreen`.
+Full layout suite currently **250 passed** on `feat/comic-layout-geometry-core`.
+
+- `tests/layout/test_svg_path.py` (NEW) — round-trips (`segments_to_svg ∘
+  svg_to_segments` and back), each command, relative coords, `Z` close,
+  malformed-input degradation.
+- `tests/layout/test_designer.py` (extend) — parse `shape:"path"` + `svg`
+  region; tiling request → expanded gap-free panels; overlays with
+  region-relative anchor resolution; raw-pixel fallback; unknown-id / malformed
+  degradation; **backward-compat** (today's rect/polygon response unchanged);
+  `build_messages` output contains the new capability docs.
+- GUI apply test (`qapp`) — a `DesignerResult` carrying overlays lands on
+  `pages[0].overlays` and survives a `_refresh` (mirrors existing
+  designer/layout_tab tests).
+
+## 8. Provisional task breakdown
+
+(The implementation plan formalizes these; each is a TDD task that keeps the full
+suite green and commits with `feat(layout): …`.)
+
+1. `core/layout/svg_path.py` converter (pure, TDD): `svg_to_segments` +
+   `segments_to_svg`, malformed-input degradation, round-trip.
+2. `DesignerResult.overlays` + overlay parsing + region-relative anchor
+   resolution (`_resolve_overlay_anchor`), raw-pixel fallback.
+3. `parse_response` geometry: `shape:"path"` + `svg` regions and `bleed` /
+   `stroke_px`; tiling-preset request → expanded panels (merge with explicit
+   regions).
+4. `build_messages` prompt extension documenting all new capabilities +
+   prompt-content assertion test.
+5. GUI apply wiring (`apply_designer_result` writes regions + overlays) +
+   integration test; designer-panel overlay-count log line.
+
+## 9. Out of scope / deferred (not gaps)
+
+- **Manual drag-edit / authoring of the emitted geometry** — sub-project #5
+  (knife/split, vertex & curve-handle drag, bleed/borderless toggles, balloon
+  placement, tail→region snapping, SFX rotation, contour-aware wrapping).
+- **Page-resize reflow of resolved overlays** — anchors resolve to pixels at
+  parse time (same as regions today); reflow is an editor concern for #5.
+- **PIL export still bypasses overlays** — carried from #1–#3: overlays render in
+  the live editor + Qt export, not the PIL `export_dialog.py`. Migrating export
+  onto the Qt renderer remains the biggest cross-cutting follow-up for the final
+  feature PR.
+- **The live `run_completion` LLM call** stays network/untested.
+
+## 10. Self-review
+
+- **Spec coverage:** every approved scope decision (§2) maps to a component
+  (§5) and a test (§7); all three new-engine capabilities + the SVG converter +
+  the GUI apply wiring are covered. The 5 provisional tasks (§8) cover the whole
+  surface with no stub/placeholder left.
+- **Internal consistency:** the LLM contract (§4) matches the `parse_response`
+  order of operations (§5.2) and the error table (§6); the "designer fully
+  resolves" approach (§3) is consistent with the GUI staying a dumb assigner
+  (§5.3).
+- **Scope:** focused enough for one implementation plan (5 tasks); larger
+  authoring work is explicitly deferred to #5 (§9).
+- **Ambiguity:** region-relative vs raw-pixel placement is made explicit (both
+  accepted; region-relative resolved first, pixel as fallback); tiling and
+  free-draw explicitly coexist.

--- a/Plans/2026-06-27-comic-layout-ai-designer-plan.md
+++ b/Plans/2026-06-27-comic-layout-ai-designer-plan.md
@@ -1,0 +1,834 @@
+# Comic Layout — AI Designer Extension Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the AI layout designer so it can emit the full geometry surface from sub-projects #1–#3 — curved/path panels (via SVG) + bleed/stroke, tiling presets, and region-relative overlays — and render that AI output on the canvas.
+
+**Architecture:** A new pure module `core/layout/svg_path.py` converts SVG path `d` strings ⇄ `PathSegment`s. `core/layout/designer.py` gains a richer LLM prompt and a `parse_response` that fully resolves the response into concrete `Region`s + `Overlay`s (SVG→segments, tiling preset→panels, region-relative overlay anchors→pixels). `gui/layout/layout_tab.py` writes the resolved overlays onto the page so the existing Qt renderer draws them. The designer "fully resolves"; the GUI just assigns.
+
+**Tech Stack:** Python 3.12, pytest, PySide6 (GUI apply task only). Reuses `PathSegment`/`Region`/`Overlay`/`PageSpec` (`core/layout/models.py`), `schema.region_from_dict`/`normalize_region` (`core/layout/schema.py`), the tiling presets + `tile()` (`core/layout/tiling.py`), and the existing `designer.py` prompt/parse/`DesignerResult` scaffolding.
+
+## Global Constraints
+
+- Test interpreter: `.venv_linux/bin/python`. Run tests with `QT_QPA_PLATFORM=offscreen` prefixed (required for the GUI apply test in Task 5; harmless for the pure tests).
+- Full layout suite must stay green: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` (currently **250 passed** on branch `feat/comic-layout-geometry-core`).
+- **No new third-party dependency** — the SVG parser is hand-rolled in `core/layout/svg_path.py` (no `svgpathtools`, no `lxml`).
+- `core/layout/svg_path.py` and `core/layout/designer.py` must be **Qt-free** (importable headless). Only `gui/layout/layout_tab.py` (Task 5) and its test touch Qt.
+- **All errors logged** (`logging.getLogger(__name__)` in `svg_path.py`; the existing `logging.getLogger("imageai.layout.designer")` in `designer.py`): malformed SVG, unknown tiling preset, unknown `anchor_region`/`tail_to_region`, and unknown overlay `kind` are each logged and degrade (skip the bad item / fall back), **never crash**.
+- **Backward compatibility:** today's `{questions?, layout:{regions:[rect/polygon...]}}` responses must parse exactly as before. A response with no overlays yields `DesignerResult.overlays == []`.
+- `DesignerResult` gains `overlays: List[Overlay] = field(default_factory=list)`; the existing `questions`/`regions`/`raw` fields and `fallback_result` are unchanged.
+- Coordinates are page pixels. SVG subset supported: `M m L l H h V v C c Q q Z z` (absolute + relative; implicit repeats; `M`/`m` repeats become `L`/`l`).
+- Conventional Commits (`feat(layout): …`). Commit after each task.
+- **Branch:** continue on `feat/comic-layout-geometry-core` (all 5 comic-layout sub-projects share one branch). **Do NOT open a pull request** — the single PR comes only after sub-project #5.
+
+### Names used across tasks (keep identical)
+- `svg_to_segments(d: str) -> List[PathSegment]`, `segments_to_svg(segments: List[PathSegment]) -> str` (Task 1).
+- `DesignerResult.overlays: List[Overlay]` (Task 2).
+- `_build_overlay(od: dict, regions_by_id: dict, page_px, idx) -> Optional[Overlay]` and `_resolve_overlay_anchor(od, regions_by_id, page_px) -> Optional[Tuple[Tuple[float,float], str, Optional[Tuple[float,float]]]]` (Task 2).
+- `_regions_from_tiling(tspec, page_px) -> List[Region]` and `_normalize_region_dict(rd: dict) -> dict` (Task 3).
+
+---
+
+### Task 1: `core/layout/svg_path.py` — SVG `d` ⇄ PathSegments
+
+**Files:**
+- Create: `core/layout/svg_path.py`
+- Test: `tests/layout/test_svg_path.py` (create)
+
+**Interfaces:**
+- Consumes: `PathSegment` (`core.layout.models`).
+- Produces: `svg_to_segments(d: str) -> List[PathSegment]`; `segments_to_svg(segments: List[PathSegment]) -> str`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_svg_path.py`:
+
+```python
+from core.layout.models import PathSegment
+from core.layout.svg_path import svg_to_segments, segments_to_svg
+
+
+def test_parse_basic_absolute_commands():
+    segs = svg_to_segments("M10 10 L90 10 L90 90 Z")
+    assert [s.type for s in segs] == ["move", "line", "line", "close"]
+    assert segs[0].pts == [(10.0, 10.0)]
+    assert segs[2].pts == [(90.0, 90.0)]
+
+
+def test_h_and_v_commands():
+    segs = svg_to_segments("M10 10 H50 V40")
+    assert segs[1].type == "line" and segs[1].pts == [(50.0, 10.0)]
+    assert segs[2].type == "line" and segs[2].pts == [(50.0, 40.0)]
+
+
+def test_relative_commands_accumulate():
+    segs = svg_to_segments("m10 10 l20 0 l0 20 z")
+    assert segs[0].pts == [(10.0, 10.0)]
+    assert segs[1].pts == [(30.0, 10.0)]
+    assert segs[2].pts == [(30.0, 30.0)]
+    assert segs[3].type == "close"
+
+
+def test_implicit_line_after_moveto():
+    # extra coordinate pairs after M are implicit L
+    segs = svg_to_segments("M0 0 10 0 10 10")
+    assert [s.type for s in segs] == ["move", "line", "line"]
+    assert segs[2].pts == [(10.0, 10.0)]
+
+
+def test_cubic_command():
+    segs = svg_to_segments("M0 0 C1 2 3 4 5 6")
+    assert segs[1].type == "cubic"
+    assert segs[1].pts == [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
+
+
+def test_quad_command():
+    segs = svg_to_segments("M0 0 Q1 2 3 4")
+    assert segs[1].type == "quad"
+    assert segs[1].pts == [(1.0, 2.0), (3.0, 4.0)]
+
+
+def test_round_trip_segments_to_svg_to_segments():
+    segs = [
+        PathSegment(type="move", pts=[(10.0, 10.0)]),
+        PathSegment(type="line", pts=[(90.0, 10.0)]),
+        PathSegment(type="cubic", pts=[(95.0, 10.0), (95.0, 15.0), (95.0, 20.0)]),
+        PathSegment(type="quad", pts=[(50.0, 80.0), (10.0, 20.0)]),
+        PathSegment(type="close", pts=[]),
+    ]
+    assert svg_to_segments(segments_to_svg(segs)) == segs
+
+
+def test_malformed_input_degrades_without_raising():
+    # 'C' needs 6 args; only 3 given -> keep the valid move, stop, no crash
+    segs = svg_to_segments("M0 0 C1 2 3")
+    assert segs == [PathSegment(type="move", pts=[(0.0, 0.0)])]
+
+
+def test_number_before_command_returns_empty():
+    assert svg_to_segments("10 10 L20 20") == []
+
+
+def test_empty_string_returns_empty():
+    assert svg_to_segments("") == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_svg_path.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'core.layout.svg_path'`.
+
+- [ ] **Step 3: Implement `svg_path.py`**
+
+Create `core/layout/svg_path.py`:
+
+```python
+"""Pure (Qt-free) converter between SVG path 'd' strings and PathSegments.
+
+LLM-native curve authoring: the AI designer emits SVG path data, which this
+module parses into the PathSegment model the renderer already consumes; the
+inverse serializes segments back to a 'd' string (round-trip, export, and
+showing current geometry back to the LLM). Supports the subset
+M L H V C Q Z (absolute + relative, implicit repeats). Malformed input is
+logged and degrades to whatever parsed cleanly; it never raises.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import List, Tuple
+
+from core.layout.models import PathSegment
+
+logger = logging.getLogger(__name__)
+
+_NUM = r"[-+]?(?:\d*\.\d+|\d+\.?)(?:[eE][-+]?\d+)?"
+_TOKEN_RE = re.compile(r"([MmLlHhVvCcQqZz])|(" + _NUM + r")")
+_ARGC = {"M": 2, "L": 2, "H": 1, "V": 1, "C": 6, "Q": 4}
+
+
+def _tokenize(d: str) -> List[Tuple[str, object]]:
+    tokens: List[Tuple[str, object]] = []
+    for m in _TOKEN_RE.finditer(d or ""):
+        if m.group(1):
+            tokens.append(("cmd", m.group(1)))
+        else:
+            tokens.append(("num", float(m.group(2))))
+    return tokens
+
+
+def svg_to_segments(d: str) -> List[PathSegment]:
+    """Parse an SVG path 'd' string into PathSegments (subset M/L/H/V/C/Q/Z)."""
+    tokens = _tokenize(d)
+    segs: List[PathSegment] = []
+    i, n = 0, len(tokens)
+    cx = cy = sx = sy = 0.0
+    cmd = ""
+    while i < n:
+        kind, val = tokens[i]
+        if kind == "cmd":
+            cmd = str(val)
+            i += 1
+            if cmd in ("Z", "z"):
+                segs.append(PathSegment(type="close", pts=[]))
+                cx, cy = sx, sy
+                cmd = ""
+                continue
+        elif not cmd:
+            logger.warning("svg_to_segments: number before any command in %r; stopping", d)
+            break
+        else:
+            # implicit repeat of the previous command; M/m repeats as L/l
+            if cmd == "M":
+                cmd = "L"
+            elif cmd == "m":
+                cmd = "l"
+        c = cmd.upper()
+        rel = cmd.islower()
+        argc = _ARGC.get(c)
+        if argc is None:
+            logger.warning("svg_to_segments: unsupported command %r; stopping", cmd)
+            break
+        if i + argc > n or any(tokens[j][0] != "num" for j in range(i, i + argc)):
+            logger.warning("svg_to_segments: command %r needs %d args; stopping", cmd, argc)
+            break
+        args = [float(tokens[j][1]) for j in range(i, i + argc)]
+        i += argc
+        if c == "M":
+            x, y = args
+            if rel:
+                x, y = cx + x, cy + y
+            segs.append(PathSegment(type="move", pts=[(x, y)]))
+            cx, cy = sx, sy = x, y
+        elif c == "L":
+            x, y = args
+            if rel:
+                x, y = cx + x, cy + y
+            segs.append(PathSegment(type="line", pts=[(x, y)]))
+            cx, cy = x, y
+        elif c == "H":
+            x = args[0] + (cx if rel else 0.0)
+            segs.append(PathSegment(type="line", pts=[(x, cy)]))
+            cx = x
+        elif c == "V":
+            y = args[0] + (cy if rel else 0.0)
+            segs.append(PathSegment(type="line", pts=[(cx, y)]))
+            cy = y
+        elif c == "C":
+            pts = []
+            for k in range(0, 6, 2):
+                px, py = args[k], args[k + 1]
+                if rel:
+                    px, py = cx + px, cy + py
+                pts.append((px, py))
+            segs.append(PathSegment(type="cubic", pts=pts))
+            cx, cy = pts[-1]
+        elif c == "Q":
+            pts = []
+            for k in range(0, 4, 2):
+                px, py = args[k], args[k + 1]
+                if rel:
+                    px, py = cx + px, cy + py
+                pts.append((px, py))
+            segs.append(PathSegment(type="quad", pts=pts))
+            cx, cy = pts[-1]
+    return segs
+
+
+def _fmt(n: float) -> str:
+    return f"{n:g}"
+
+
+def segments_to_svg(segments: List[PathSegment]) -> str:
+    """Serialize PathSegments back to an absolute-coordinate SVG 'd' string."""
+    parts: List[str] = []
+    for s in segments:
+        if s.type == "move":
+            x, y = s.pts[0]
+            parts.append(f"M {_fmt(x)} {_fmt(y)}")
+        elif s.type == "line":
+            x, y = s.pts[0]
+            parts.append(f"L {_fmt(x)} {_fmt(y)}")
+        elif s.type == "quad":
+            (cx, cy), (x, y) = s.pts
+            parts.append(f"Q {_fmt(cx)} {_fmt(cy)} {_fmt(x)} {_fmt(y)}")
+        elif s.type == "cubic":
+            (c1x, c1y), (c2x, c2y), (x, y) = s.pts
+            parts.append(f"C {_fmt(c1x)} {_fmt(c1y)} {_fmt(c2x)} {_fmt(c2y)} {_fmt(x)} {_fmt(y)}")
+        elif s.type == "close":
+            parts.append("Z")
+    return " ".join(parts)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_svg_path.py -q`
+Expected: PASS (10 passed). Then full suite green: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` (expect 260).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/svg_path.py tests/layout/test_svg_path.py
+git commit -m "feat(layout): svg_path.py SVG-d <-> PathSegment converter"
+```
+
+---
+
+### Task 2: `DesignerResult.overlays` + overlay parsing (region-relative + raw pixel)
+
+**Files:**
+- Modify: `core/layout/designer.py`
+- Test: `tests/layout/test_designer.py` (extend)
+
+**Interfaces:**
+- Consumes: `Overlay` (`core.layout.models`); the existing `parse_response`/`DesignerResult`.
+- Produces: `DesignerResult.overlays: List[Overlay]`; `_resolve_overlay_anchor(od, regions_by_id, page_px)`; `_build_overlay(od, regions_by_id, page_px, idx)`. `parse_response` now also parses `layout["overlays"]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/layout/test_designer.py`:
+
+```python
+def test_designer_result_overlays_defaults_empty():
+    res = designer.parse_response(
+        '{"layout": {"regions": [{"id":"a","kind":"image","bbox":[0,0,100,100]}]}}',
+        (200, 200))
+    assert res.overlays == []
+
+
+def test_parse_overlay_raw_pixel_anchor():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","bbox":[0,0,200,200]}],'
+               ' "overlays": [{"id":"o1","kind":"speech","text":"Hi",'
+               ' "anchor":[50,40],"tail_target":[50,120]}]}}')
+    res = designer.parse_response(content, (300, 300))
+    assert len(res.overlays) == 1
+    ov = res.overlays[0]
+    assert ov.kind == "speech" and ov.text == "Hi"
+    assert ov.anchor == (50.0, 40.0)
+    assert ov.tail_target == (50.0, 120.0)
+
+
+def test_parse_overlay_region_relative_anchor_resolves_to_pixels():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","bbox":[100,100,200,100]}],'
+               ' "overlays": [{"id":"o1","kind":"speech","text":"Yo","anchor_region":"p1",'
+               ' "anchor_offset":[0.5,0.5],"tail_to_region":"p1"}]}}')
+    res = designer.parse_response(content, (500, 500))
+    ov = res.overlays[0]
+    assert ov.anchor == (200.0, 150.0)        # 100 + 0.5*200, 100 + 0.5*100
+    assert ov.tail_target == (200.0, 150.0)   # region center
+
+
+def test_parse_overlay_unknown_region_dropped_but_others_kept():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","bbox":[0,0,100,100]}],'
+               ' "overlays": [{"id":"bad","kind":"speech","text":"x","anchor_region":"nope"},'
+               ' {"id":"ok","kind":"sfx","text":"BOOM","anchor":[50,50]}]}}')
+    res = designer.parse_response(content, (200, 200))
+    assert [o.id for o in res.overlays] == ["ok"]
+
+
+def test_parse_overlay_unknown_kind_skipped():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","bbox":[0,0,100,100]}],'
+               ' "overlays": [{"id":"o1","kind":"bubble","text":"x","anchor":[10,10]}]}}')
+    res = designer.parse_response(content, (200, 200))
+    assert res.overlays == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_designer.py -k overlay -q`
+Expected: FAIL — `AttributeError: 'DesignerResult' object has no attribute 'overlays'`.
+
+- [ ] **Step 3: Implement overlays in `designer.py`**
+
+In `core/layout/designer.py`, change the models import to add `Overlay`:
+
+```python
+from core.layout.models import Region, Overlay
+```
+
+Add `overlays` to `DesignerResult` (place after `regions`):
+
+```python
+@dataclass
+class DesignerResult:
+    questions: List[str] = field(default_factory=list)
+    regions: Optional[List[Region]] = None
+    overlays: List[Overlay] = field(default_factory=list)
+    raw: str = ""
+```
+
+Add the two helpers (place them just above `parse_response`):
+
+```python
+def _resolve_overlay_anchor(od: Dict, regions_by_id: Dict, page_px: Tuple[int, int]):
+    """Resolve an overlay dict's placement to (anchor_px, anchor_mode, tail_px|None).
+
+    Raw-pixel "anchor"/"tail_target" win; otherwise "anchor_region"+"anchor_offset"
+    (0..1 within the region bbox) and "tail_to_region" (region center) are resolved
+    against the already-parsed regions. Returns None (drop the overlay) if no anchor
+    can be resolved. All resolution is logged on failure; never raises.
+    """
+    pw, ph = page_px
+    anchor_mode = od.get("anchor_mode", "center")
+    anchor = None
+    raw = od.get("anchor")
+    if isinstance(raw, (list, tuple)) and len(raw) == 2:
+        anchor = (float(raw[0]), float(raw[1]))
+    else:
+        rid = od.get("anchor_region")
+        if rid is not None and rid in regions_by_id:
+            bx, by, bw, bh = regions_by_id[rid].bbox
+            off = od.get("anchor_offset", [0.5, 0.5])
+            if isinstance(off, (list, tuple)) and len(off) == 2:
+                ox, oy = float(off[0]), float(off[1])
+            else:
+                ox, oy = 0.5, 0.5
+            anchor = (bx + ox * bw, by + oy * bh)
+        elif rid is not None:
+            logger.warning("Designer overlay %r: unknown anchor_region %r; skipped",
+                           od.get("id"), rid)
+            return None
+    if anchor is None:
+        logger.warning("Designer overlay %r: no anchor or anchor_region; skipped", od.get("id"))
+        return None
+    anchor = (min(max(anchor[0], 0.0), float(pw)), min(max(anchor[1], 0.0), float(ph)))
+
+    tail = None
+    traw = od.get("tail_target")
+    if isinstance(traw, (list, tuple)) and len(traw) == 2:
+        tail = (float(traw[0]), float(traw[1]))
+    else:
+        trid = od.get("tail_to_region")
+        if trid is not None and trid in regions_by_id:
+            bx, by, bw, bh = regions_by_id[trid].bbox
+            tail = (bx + bw / 2.0, by + bh / 2.0)
+        elif trid is not None:
+            logger.warning("Designer overlay %r: unknown tail_to_region %r; tail dropped",
+                           od.get("id"), trid)
+    return anchor, anchor_mode, tail
+
+
+def _build_overlay(od: Dict, regions_by_id: Dict, page_px: Tuple[int, int], idx: int):
+    """Build one Overlay from an LLM overlay dict, or None to skip it."""
+    kind = od.get("kind")
+    if kind not in ("speech", "thought", "caption", "sfx"):
+        logger.warning("Designer overlay %r: unknown kind %r; skipped", od.get("id"), kind)
+        return None
+    resolved = _resolve_overlay_anchor(od, regions_by_id, page_px)
+    if resolved is None:
+        return None
+    anchor, anchor_mode, tail = resolved
+    return Overlay(
+        id=od.get("id", f"ov{idx + 1}"), kind=kind, text=str(od.get("text", "")),
+        anchor=anchor, anchor_mode=anchor_mode, tail_target=tail,
+        z=int(od.get("z", 0)), role=od.get("role", ""),
+    )
+```
+
+Replace the body of `parse_response` (from the `regions = None` line through the final `return`) with the version below. This preserves the existing region parsing and adds overlay parsing + the `overlays` field:
+
+```python
+    regions = None
+    overlays: List[Overlay] = []
+    layout = data.get("layout")
+    if isinstance(layout, dict):
+        if isinstance(layout.get("regions"), list):
+            collected = []
+            for i, rd in enumerate(layout["regions"]):
+                if not isinstance(rd, dict):
+                    continue
+                rd = dict(rd)  # don't mutate the parsed dict
+                rd.setdefault("id", f"region{i + 1}")
+                rd.setdefault("kind", "image")
+                region = schema.region_from_dict(rd)
+                collected.append(schema.normalize_region(region, page_px))
+            if collected:
+                regions = collected
+        if isinstance(layout.get("overlays"), list):
+            by_id = {r.id: r for r in (regions or [])}
+            for i, od in enumerate(layout["overlays"]):
+                if isinstance(od, dict):
+                    ov = _build_overlay(od, by_id, page_px, i)
+                    if ov is not None:
+                        overlays.append(ov)
+    if regions is None and not questions and not overlays:
+        return fallback_result(page_px)
+    return DesignerResult(questions=questions, regions=regions, overlays=overlays, raw=content)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_designer.py -q`
+Expected: PASS (existing designer tests + 5 new). Then full suite green (expect 265).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/designer.py tests/layout/test_designer.py
+git commit -m "feat(layout): designer parses overlays (region-relative + raw-pixel)"
+```
+
+---
+
+### Task 3: `parse_response` geometry — SVG-path regions, bleed/stroke, tiling presets
+
+**Files:**
+- Modify: `core/layout/designer.py`
+- Test: `tests/layout/test_designer.py` (extend)
+
+**Interfaces:**
+- Consumes: `svg_to_segments` (`core.layout.svg_path`, Task 1); the tiling presets + `tile()` (`core.layout.tiling`); the Task-2 `parse_response`.
+- Produces: `_regions_from_tiling(tspec, page_px) -> List[Region]`; `_normalize_region_dict(rd) -> dict`. `parse_response` now expands `layout["tiling"]` to panels and converts `shape:"path"` + `svg` regions (plus `stroke_px` → image_style).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/layout/test_designer.py`:
+
+```python
+def test_parse_svg_path_region():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","shape":"path",'
+               ' "svg":"M10 10 L90 10 L90 90 Z","bleed":true}]}}')
+    res = designer.parse_response(content, (200, 200))
+    r = res.regions[0]
+    assert r.shape == "path"
+    assert [s.type for s in r.segments] == ["move", "line", "line", "close"]
+    assert r.bleed is True
+
+
+def test_parse_region_stroke_px_maps_to_image_style():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","shape":"rect",'
+               ' "bbox":[0,0,100,100],"stroke_px":6}]}}')
+    res = designer.parse_response(content, (200, 200))
+    assert res.regions[0].image_style is not None
+    assert res.regions[0].image_style.stroke_px == 6
+
+
+def test_parse_tiling_preset_expands_to_panels():
+    content = '{"layout": {"tiling": {"preset":"grid","params":{"rows":2,"cols":2,"gutter_px":10}}}}'
+    res = designer.parse_response(content, (400, 400))
+    assert res.regions is not None and len(res.regions) == 4
+    assert all(r.shape == "path" for r in res.regions)
+
+
+def test_unknown_tiling_preset_degrades_keeps_explicit_regions():
+    content = ('{"layout": {"tiling": {"preset":"spiral"},'
+               ' "regions":[{"id":"a","kind":"image","bbox":[0,0,50,50]}]}}')
+    res = designer.parse_response(content, (200, 200))
+    assert [r.id for r in res.regions] == ["a"]  # unknown preset ignored; explicit region kept
+
+
+def test_tiling_and_explicit_regions_coexist():
+    content = ('{"layout": {"tiling": {"preset":"three_tiers"},'
+               ' "regions":[{"id":"x","kind":"text","bbox":[0,0,40,20],"role":"caption"}]}}')
+    res = designer.parse_response(content, (300, 300))
+    ids = [r.id for r in res.regions]
+    assert "x" in ids and len(ids) == 4  # 3 tiers + 1 explicit region
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_designer.py -k "svg or tiling or stroke" -q`
+Expected: FAIL — the `svg` key is ignored (region falls back to bbox so it has no segments) and `tiling` is ignored (no panels generated).
+
+- [ ] **Step 3: Implement geometry handling in `designer.py`**
+
+Add the two helpers (place them above `parse_response`, near the Task-2 helpers):
+
+```python
+def _regions_from_tiling(tspec, page_px: Tuple[int, int]) -> List[Region]:
+    """Expand a tiling-preset request into gap-free panel Regions (or [] on failure)."""
+    if not isinstance(tspec, dict):
+        return []
+    from core.layout import tiling
+    preset = tspec.get("preset")
+    params = tspec.get("params") or {}
+    pw, ph = page_px
+    try:
+        if preset == "grid":
+            tree = tiling.grid(int(params.get("rows", 2)), int(params.get("cols", 2)))
+        elif preset == "three_tiers":
+            tree = tiling.three_tiers()
+        elif preset == "splash_with_strip":
+            tree = tiling.splash_with_strip()
+        elif preset == "diagonal_action":
+            tree = tiling.diagonal_action()
+        elif preset == "feature_L":
+            tree = tiling.feature_L()
+        else:
+            logger.warning("Designer: unknown tiling preset %r; ignored", preset)
+            return []
+        gutter = float(params.get("gutter_px", 12))
+        margin = float(params.get("margin_px", 24))
+        return tiling.tile(tree, (0, 0, pw, ph), gutter=gutter, margin=margin)
+    except Exception as e:  # noqa: BLE001 - degrade, never crash
+        logger.warning("Designer: tiling preset %r failed: %s", preset, e)
+        return []
+
+
+def _normalize_region_dict(rd: Dict) -> Dict:
+    """Map LLM region shorthands onto schema.region_from_dict's expected keys.
+
+    "svg" -> shape="path" + "segments"; top-level "stroke_px" -> image_style.stroke_px.
+    Returns a new dict; the caller's parsed dict is not mutated.
+    """
+    rd = dict(rd)
+    svg = rd.pop("svg", None)
+    if svg:
+        from core.layout.svg_path import svg_to_segments
+        segs = svg_to_segments(str(svg))
+        rd["shape"] = "path"
+        rd["segments"] = [{"type": s.type, "pts": [list(p) for p in s.pts]} for s in segs]
+    stroke = rd.pop("stroke_px", None)
+    if stroke is not None:
+        istyle = dict(rd.get("image_style") or {})
+        istyle.setdefault("stroke_px", stroke)
+        rd["image_style"] = istyle
+    return rd
+```
+
+Then update the region-collection block inside `parse_response` (the `if isinstance(layout, dict):` body from Task 2). Replace the region collection so it (a) prepends tiled panels and (b) preprocesses each region dict:
+
+```python
+    if isinstance(layout, dict):
+        collected = []
+        collected.extend(_regions_from_tiling(layout.get("tiling"), page_px))
+        if isinstance(layout.get("regions"), list):
+            for i, rd in enumerate(layout["regions"]):
+                if not isinstance(rd, dict):
+                    continue
+                rd = _normalize_region_dict(rd)
+                rd.setdefault("id", f"region{i + 1}")
+                rd.setdefault("kind", "image")
+                region = schema.region_from_dict(rd)
+                collected.append(schema.normalize_region(region, page_px))
+        if collected:
+            regions = collected
+        if isinstance(layout.get("overlays"), list):
+            by_id = {r.id: r for r in (regions or [])}
+            for i, od in enumerate(layout["overlays"]):
+                if isinstance(od, dict):
+                    ov = _build_overlay(od, by_id, page_px, i)
+                    if ov is not None:
+                        overlays.append(ov)
+```
+
+(`_normalize_region_dict` already copies the dict, so the previous `rd = dict(rd)` line is replaced by the `rd = _normalize_region_dict(rd)` call.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_designer.py -q`
+Expected: PASS (all designer tests). Full suite green (expect 270). If `test_parse_tiling_preset_expands_to_panels` finds a count other than 4, confirm `tiling.grid(2, 2)` is built and `tile(...)` is called with `(0, 0, pw, ph)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/designer.py tests/layout/test_designer.py
+git commit -m "feat(layout): designer emits svg-path regions, bleed/stroke, tiling presets"
+```
+
+---
+
+### Task 4: `build_messages` prompt extension (document the new capabilities)
+
+**Files:**
+- Modify: `core/layout/designer.py`
+- Test: `tests/layout/test_designer.py` (extend)
+
+**Interfaces:**
+- Consumes: the existing `build_messages(content_kind, page_px, user_text, current_regions)` signature and its role-name listing.
+- Produces: same signature; the `<instructions>` now document `shape:"path"`+`svg`, `bleed`/`stroke_px`, the `tiling` block + preset names, and the `overlays` array (region-relative + raw-pixel).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/layout/test_designer.py`:
+
+```python
+def test_build_messages_documents_new_capabilities():
+    msgs = designer.build_messages("comic", (1000, 800), "a dynamic comic page")
+    joined = " ".join(m["content"] for m in msgs)
+    for token in ("svg", "tiling", "grid", "overlays", "speech", "anchor_region", "bleed"):
+        assert token in joined, token
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_designer.py::test_build_messages_documents_new_capabilities -q`
+Expected: FAIL — the current prompt mentions none of `svg`/`tiling`/`overlays`/etc.
+
+- [ ] **Step 3: Extend the prompt in `build_messages`**
+
+In `core/layout/designer.py`, replace the `user = ( ... )` instruction string in `build_messages` with the version below (keep everything above it — the `pw, ph` unpack, the `role_names`/`roles` lines, and the `current` block — unchanged):
+
+```python
+    user = (
+        f"<context>\n"
+        f"content_kind: {content_kind}\n"
+        f"page_pixels: {pw} x {ph} (x,y origin top-left; all coordinates in pixels)\n"
+        f"</context>\n"
+        f"{current}"
+        f"<request>\n{user_text}\n</request>\n"
+        f"<instructions>\n"
+        f"Return a SINGLE JSON object with optional keys:\n"
+        f'  "questions": [strings]   // ask for missing detail if needed\n'
+        f'  "layout": {{\n'
+        f'    "tiling": {{ "preset": "grid"|"three_tiers"|"splash_with_strip"|'
+        f'"diagonal_action"|"feature_L",\n'
+        f'                "params": {{ "rows": int, "cols": int, "gutter_px": number,'
+        f' "margin_px": number }} }},\n'
+        f"        // optional; generates gap-free panels. rows/cols apply to \"grid\".\n"
+        f'    "regions": [ {{ "id": string, "kind": "image"|"text",\n'
+        f'        "shape": "rect"|"polygon"|"path",\n'
+        f'        "bbox": [x,y,w,h], "points": [[x,y],...] (polygon only),\n'
+        f'        "svg": "M.. L.. C.. Z" (path only; SVG path data in page pixels),\n'
+        f'        "bleed": bool, "stroke_px": number,\n'
+        f'        "z": int, "role": string, "text": string (text only) }} ],\n'
+        f'    "overlays": [ {{ "id": string,\n'
+        f'        "kind": "speech"|"thought"|"caption"|"sfx", "text": string,\n'
+        f'        "anchor_region": string, "anchor_offset": [fx,fy] (0..1 within region),\n'
+        f'        "tail_to_region": string,            // tail points at that region center\n'
+        f'        "anchor": [x,y], "tail_target": [x,y], // raw-pixel alternative\n'
+        f'        "role": string }} ]\n'
+        f'  }}\n'
+        f"All coordinates MUST be within the page ({pw} x {ph}). Prefer \"rect\" for simple\n"
+        f"panels; use \"tiling\" for clean gap-free grids/strips; use \"shape\":\"path\" with\n"
+        f"\"svg\" for curved or angled panels; use \"polygon\" for straight-edged non-rect panels.\n"
+        f"Each text region MUST set \"role\" to one of: {roles}.\n"
+        f"Overlays float above panels: prefer \"anchor_region\"+\"anchor_offset\" (and\n"
+        f"\"tail_to_region\") so balloons sit inside a panel; use raw \"anchor\"/\"tail_target\"\n"
+        f"pixels only for free placement. You may return questions, a layout, or both.\n"
+        f"</instructions>"
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_designer.py -q`
+Expected: PASS — the new token test passes and the existing prompt tests (`...includes_context_and_json_instruction`, `...instructs_role_with_kind_roles`) still pass (the prompt still contains `regions`, `JSON`, the page size, the request text, `"role"`, and `dialogue`). Full suite green (expect 271).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/designer.py tests/layout/test_designer.py
+git commit -m "feat(layout): designer prompt documents svg/tiling/overlays capabilities"
+```
+
+---
+
+### Task 5: GUI apply wiring — write resolved overlays onto the page
+
+**Files:**
+- Modify: `gui/layout/layout_tab.py` (`apply_designer_result`, ~line 398) and `gui/layout/designer_panel.py` (`_on_proposed` log line, ~line 148)
+- Test: `tests/layout/test_layout_tab_designer_overlays.py` (create)
+
+**Interfaces:**
+- Consumes: `DesignerResult` with `.regions` and `.overlays` (Tasks 2–3); `PageSpec.overlays` (the field already exists); the existing `LayoutTab.apply_designer_result`.
+- Produces: `apply_designer_result` writes `result.overlays` into `pages[0].overlays` so the Qt renderer draws them.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_layout_tab_designer_overlays.py`:
+
+```python
+from gui.layout.layout_tab import LayoutTab
+from core.layout import designer
+from core.layout.models import Overlay
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def test_apply_designer_result_writes_overlays(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    res = designer.DesignerResult(
+        regions=[designer.Region(id="p1", kind="image", bbox=(0, 0, 200, 200))],
+        overlays=[Overlay(id="o1", kind="speech", text="Hi", anchor=(50.0, 40.0))],
+    )
+    tab.apply_designer_result(res, user_text="v1")
+    page = tab.document.pages[0]
+    assert [r.id for r in page.regions] == ["p1"]
+    assert [o.id for o in page.overlays] == ["o1"]
+
+
+def test_apply_designer_result_overlays_only(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    res = designer.DesignerResult(
+        regions=None,
+        overlays=[Overlay(id="o1", kind="sfx", text="BOOM", anchor=(20.0, 20.0))],
+    )
+    tab.apply_designer_result(res, user_text="add sfx")
+    assert [o.id for o in tab.document.pages[0].overlays] == ["o1"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_layout_tab_designer_overlays.py -q`
+Expected: FAIL — `apply_designer_result` ignores `result.overlays`, so `page.overlays` stays empty.
+
+- [ ] **Step 3: Wire overlays into `apply_designer_result`**
+
+In `gui/layout/layout_tab.py`, replace the tail of `apply_designer_result` (the `if result.regions: ... elif result.questions: ...` block) with:
+
+```python
+        applied = False
+        if result.regions:
+            self.document.pages[0].regions = list(result.regions)
+            applied = True
+        if getattr(result, "overlays", None):
+            self.document.pages[0].overlays = list(result.overlays)
+            applied = True
+        if applied:
+            self.history.append(user_text or "design")
+            self._refresh()
+        elif result.questions:
+            self.status.setText(
+                f"Designer asked {len(result.questions)} question(s) — see the Designer console.")
+```
+
+In `gui/layout/designer_panel.py`, update the `_on_proposed` summary log line to mention overlays. Replace:
+
+```python
+        n = len(result.regions) if result.regions else 0
+        self.console.log(f"Proposed layout: {n} regions; {len(result.questions)} question(s).",
+                         "SUCCESS")
+```
+
+with:
+
+```python
+        n = len(result.regions) if result.regions else 0
+        nov = len(getattr(result, "overlays", []) or [])
+        self.console.log(
+            f"Proposed layout: {n} regions; {nov} overlay(s); {len(result.questions)} question(s).",
+            "SUCCESS")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_layout_tab_designer_overlays.py -q`
+Expected: PASS (2 passed). Then the FULL suite: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` → all green (expect 273).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/layout/layout_tab.py gui/layout/designer_panel.py tests/layout/test_layout_tab_designer_overlays.py
+git commit -m "feat(layout): apply AI-designed overlays onto the page (rendered on canvas)"
+```
+
+---
+
+## Notes / deliberately deferred (not gaps)
+- **Manual drag-edit / authoring** of the emitted geometry is sub-project #5 (knife/split, vertex & curve-handle drag, bleed/borderless toggles, balloon placement, tail→region snapping, SFX rotation, contour-aware wrapping).
+- **Page-resize reflow** of resolved overlays: anchors resolve to pixels at parse time (same as regions today); reflow is an editor concern for #5.
+- **PIL export still bypasses overlays** (carried from #1–#3): AI-emitted overlays render in the live editor + Qt export, not the PIL `export_dialog.py`. Migrating export onto the Qt renderer is the biggest cross-cutting follow-up for the final feature PR (after #5).
+- **The live `run_completion` LLM call** stays network/untested, as today.
+- **`tiling`/explicit-region z overlap:** tiled panels get z 0..n and explicit regions carry their own z; z collisions are harmless (equal z = unspecified order). Not worth a z-offset pass now.
+
+## Self-Review (completed by plan author)
+- **Spec coverage:** `svg_path.py` converter (T1); overlays model field + region-relative/raw-pixel resolution (T2); svg-path regions + bleed/stroke + tiling presets, with free-draw/preset coexistence (T3); prompt documenting every new capability (T4); GUI apply wiring so AI output renders (T5). Every design §2–§7 decision and the §8 task list maps to a task; error-handling rows (§6) are each exercised by a degradation test (malformed svg in T1; unknown preset, unknown region, unknown kind in T2/T3).
+- **Placeholder scan:** no TBD/TODO; every code step shows complete code; degradation paths are concrete (`return []`, `return None`, `logger.warning`), not "handle errors."
+- **Type/name consistency:** `svg_to_segments`/`segments_to_svg` (T1) consumed by `_normalize_region_dict` (T3); `DesignerResult.overlays`, `_build_overlay`, `_resolve_overlay_anchor` (T2) consumed by `parse_response` (T2/T3) and the GUI (T5); `_regions_from_tiling`/`_normalize_region_dict` (T3) used in `parse_response`; `PathSegment(type=…, pts=…)`, `Region(... image_style=ImageStyle(stroke_px=…))`, `Overlay(id,kind,text,anchor,anchor_mode,tail_target,z,role)`, and `tiling.grid/three_tiers/splash_with_strip/diagonal_action/feature_L` + `tiling.tile(tree,(0,0,pw,ph),gutter=,margin=)` all match the real signatures in `core/layout/`.
+- **Test interpreter/baseline:** all tasks use `.venv_linux/bin/python` under `QT_QPA_PLATFORM=offscreen`; suite 250 → ~273 across tasks (10+5+5+1+2 = 23 new tests; counts are approximate and reconciled by the executor — the binding check is "all new tests pass and the full suite stays green").

--- a/Plans/2026-06-27-comic-layout-geometry-core-design.md
+++ b/Plans/2026-06-27-comic-layout-geometry-core-design.md
@@ -1,0 +1,209 @@
+# Comic Layout — Sub-project #1: Geometry & Render Core (Design) ⏳
+**Last Updated:** 2026-06-27 10:28
+**Author:** Leland Green + Claude (Opus 4.8)
+**Status:** Design — awaiting user review before implementation plan
+**Branch:** `feat/comic-layout-geometry-core`
+**Design source:** Brainstorming session 2026-06-27 (this doc)
+**Related:** `Plans/2026-06-24-layout-ai-designer-design.md` (Layout AI Designer)
+
+---
+
+## 0. Why this exists
+
+The Layout engine today represents a panel/frame as a **rectangle** (`Region.bbox`,
+`core/layout/models.py:94`) placed on a **fixed-gutter grid**
+(`compute_panel_grid`, `core/layout/layout_algorithms.py:187`), rendered with Qt
+(`core/layout/qt_renderer.py:196`). A `shape="polygon"` exists but is shallow:
+
+- **Images are not clipped to the shape** — a pixmap is scaled to the rectangular
+  bbox and pasted at the bbox origin (`qt_renderer.py:104`), so a "triangle frame"
+  shows a rectangular photo.
+- **Borders are a hard-coded 1px pen** (`qt_renderer.py:104`); the `stroke_px` /
+  `stroke_color` fields on `ImageStyle` (`models.py:54`) are **defined but ignored**.
+- **There is no bleed / borderless concept** per region.
+
+The user's goal is **arbitrary comic-style page layouts** (à la *Understanding
+Comics*): non-rectangular and concave panels, angled gutters, curved edges, bleed
+and borderless frames, with both AI-designed and manually-edited authoring, plus a
+full comic text toolkit (balloons/captions/SFX).
+
+That full goal is **several independent subsystems** and too large for one spec. It
+is decomposed below; **this document specifies only sub-project #1**, the geometry
+& render foundation every other piece depends on.
+
+## 1. Decomposition (full comic-layout goal)
+
+Build order, dependency-first. Each sub-project gets its own spec → plan → build
+cycle.
+
+1. **Geometry & render core** — *this spec.* Path-based region geometry (straight
+   **and** curved); clip the image to the panel shape; per-region stroke incl.
+   `stroke=0` borderless; page-bleed extension. Delivers shaped/borderless frames
+   that actually render as shapes.
+2. **Page-partition / tiling engine** — divide the page into a gap-free tiling with
+   shared edges; gutters by **inset**, not grid gaps; free-floating + bleed panels
+   layered on top. *Decision: tiling cuts are straight-edge only; curved edges stay
+   available for floating/bleed panels and balloons. Curved-edge tiling with inset
+   gutters is out of scope (research-grade).* Kills the whitespace problem.
+3. **Comic text overlays** — shaped, tailed, styled text elements (speech balloons,
+   thought bubbles, caption boxes, SFX) with tail-anchoring and text-fit-in-shape.
+   Depends on #1; largely independent of #2.
+4. **AI designer extension** — teach `core/layout/designer.py` to emit the new
+   geometry (panels + gutters + bleed + balloons). Includes an `svg⇄segments`
+   converter for LLM I/O.
+5. **Manual editor UI** — knife/split tool, vertex & curve-handle dragging, edge
+   dragging, bleed/borderless toggles, balloon + tail placement. Largest GUI piece.
+
+*(Serialization/export — `Region`, schema, `.iaibundle`, PNG/PDF/multi-page —
+evolves across all of them.)*
+
+### Decisions captured from brainstorming
+- **Authoring:** AI-first **+** manual refine (hybrid) — drives #4 and #5.
+- **Panel model:** tiled grid **+** floating panels — drives #2.
+- **Edge fidelity:** straight **+** curved — drives the path model here in #1.
+- **Content scope:** full comic toolkit (overall) — drives #3.
+- **Image fit in a shaped panel:** **cover + clip-to-shape** by default, per-panel
+  **contain** toggle (reuses `ImageStyle.fit`).
+- **No legacy projects exist** — no migration machinery, no golden-file
+  round-trip tests. `rect`/`polygon` are retained only as compact shape kinds so we
+  don't churn the existing designer prompt and tests inside #1.
+
+## 2. Scope of sub-project #1
+
+**In scope**
+- A path-based geometry representation supporting straight and curved edges.
+- Clipping a placed image to the exact panel shape (cover/contain).
+- Per-region stroke control, including `stroke_px=0` ⇒ borderless.
+- A per-region `bleed` flag honored by the renderer.
+- Serialization of the new fields; JSON schema + `normalize_region` updates.
+- Defensive validation + logging; tests.
+
+**Out of scope (later sub-projects)**
+- Page-partition/tiling and inset gutters (#2).
+- Auto edge-snap of a bleed panel to the page edge (#2).
+- Comic text overlays / balloons / tails / SFX (#3).
+- `svg⇄segments` converter and designer prompt changes (#4).
+- Manual editor / knife tool / vertex dragging (#5).
+- Curved-edge **tiling** with inset gutters (explicitly not planned).
+- The legacy rect-only `template_schema.json` export (unchanged).
+
+## 3. Data model (`core/layout/models.py`)
+
+- `Region.shape: Literal["rect","polygon","path"]` — add `"path"`.
+- New `PathSegment` dataclass (kept in `models.py`, Qt-free):
+  ```python
+  @dataclass
+  class PathSegment:
+      type: Literal["move", "line", "quad", "cubic", "close"]
+      pts: List[Tuple[float, float]] = field(default_factory=list)  # page px
+  ```
+  Point-count contract: `move` = 1, `line` = 1, `quad` = 2 (control, end),
+  `cubic` = 3 (c1, c2, end), `close` = 0. Arcs are expressed as cubics — the type
+  set stays minimal. A valid path starts with `move`.
+- New fields on `Region`:
+  - `segments: List[PathSegment] = field(default_factory=list)` — used when
+    `shape="path"`.
+  - `bleed: bool = False`.
+- `bbox` is retained. For `shape="path"` it is **derived** (bounding box of segment
+  points) and used only for positioning/hit-testing — **never** for clipping.
+- **Stroke & fit reuse existing fields:** `ImageStyle.stroke_px` /
+  `ImageStyle.stroke_color` become live (`stroke_px=0` ⇒ borderless); the
+  cover/contain toggle is the existing `ImageStyle.fit`. No new style fields.
+
+## 4. Geometry helpers (`core/layout/geometry.py` — NEW, pure, no Qt)
+
+- `validate_segments(segments) -> list[str]` — returns a list of problem strings
+  (empty = valid). Checks: starts with `move`; each segment's `pts` length matches
+  its type; coordinates are finite (no NaN/inf).
+- `segments_bbox(segments) -> tuple[float,float,float,float]` — `(x, y, w, h)`
+  bounding box of all segment points. *Note: for curves this is the bounding box of
+  control points, i.e. a safe superset of the visual extent; documented as such and
+  acceptable because bbox is positioning-only.*
+
+Pure so it unit-tests headless without a display.
+
+## 5. Rendering (`core/layout/qt_renderer.py`)
+
+- `region_to_painter_path(region) -> QPainterPath` — builds the path from whichever
+  applies: `rect` → 4 lines from bbox; `polygon` → polyline from `points`; `path` →
+  walk `segments` (`moveTo`/`lineTo`/`quadTo`/`cubicTo`/`closeSubpath`). Concave and
+  curved paths are native to `QPainterPath`.
+- **Image clip-to-shape:** scale the pixmap **cover** (or **contain** per
+  `ImageStyle.fit`) to the path's bbox, paint it through `painter.setClipPath(path)`
+  into an ARGB `QImage`, and place that QImage. Guarantees exact clipping for
+  concave + curved panels (bbox corners outside the shape are transparent). Keeps
+  the current two-item structure: a **shape path item** (stroke + selection +
+  empty-placeholder fill) plus a **clipped pixmap item**, replacing today's
+  `_RegionPolygonItem`/`_RegionPixmapItem` (`qt_renderer.py:86`).
+- **Stroke:** outline pen = `QPen(stroke_color, stroke_px)`; `stroke_px=0` ⇒ no pen
+  ⇒ borderless. Replaces the hard-coded 1px pen (`qt_renderer.py:104`).
+- **Bleed:** when `region.bleed`, clip/extend rendering against the page **bleed
+  box** (`PageSpec.bleed_px`, `models.py:138`) instead of the trim box. Bleed
+  governs only the clip box; the border is governed independently by `stroke_px`,
+  so a classic full-bleed borderless panel is `bleed=True` + `stroke_px=0` (no
+  page-edge detection needed). (Auto edge-snap of a panel to the page edge is #2;
+  #1 only honors the flag + bleed box.)
+- **Text regions** are clipped to the path too (text cannot spill past a shaped
+  panel). Full text-reflow-inside-an-arbitrary-shape stays with #3.
+
+## 6. Serialization (`core/layout/schema.py`)
+
+- `region_to_dict` / `region_from_dict` gain `segments` (`[{type, pts}]`) and
+  `bleed`. Confirm `image_style` round-trips `stroke_px` / `stroke_color`.
+- `REGION_JSON_SCHEMA` (`schema.py:20`) — add `"path"` to the shape enum, a
+  `segments` array schema, and `bleed`.
+- `normalize_region` (`schema.py:160`) — for `shape="path"`, set
+  `bbox = segments_bbox(segments)`.
+- `.iaibundle` writes regions through `region_to_dict`, so it inherits the new
+  fields automatically — no bundle-format work.
+- The legacy rect-only `template_schema.json` is left unchanged.
+
+## 7. Error handling (repo rule: all errors logged, platform-independent)
+
+- `validate_segments` runs at **load** (`schema.py`) and at **path-build**
+  (`qt_renderer.py`). A malformed segment is logged and the region **falls back to
+  its `bbox` rectangle** so a panel never silently disappears.
+- Unknown `shape` value → treat as `rect` + log.
+- Image load/scale failure → draw the empty shaped placeholder clipped to shape +
+  log.
+- `bleed` with `PageSpec.bleed_px == 0` → no-op (debug log).
+- Degenerate / duplicate curve control points → Qt renders tolerantly; no crash.
+- All via the existing layout file logger.
+
+## 8. Testing
+
+- **`tests/layout/test_geometry.py`** *(NEW, pure)* — `validate_segments`
+  accept/reject (bad point counts, missing leading `move`, NaN); `segments_bbox`
+  for a straight polygon and for a cubic.
+- **`tests/layout/test_qt_renderer.py`** *(offscreen, extend existing)* —
+  - triangle path: bbox-corner pixels transparent/page-bg, interior = image;
+  - concave L-shape: a pixel in the notch is background (clip is true-shape, not
+    convex hull);
+  - borderless (`stroke_px=0`) → no border pixels along an edge; stroked
+    (`stroke_px=3` + color) → edge pixels match the stroke color;
+  - `bleed=True` extends/clips to the bleed box (border independent, via stroke_px);
+  - cover vs contain fit (contain shows panel bg in the letterbox area; cover fills);
+  - cubic-edge smoke render (no exception; image pixels present).
+- **Serialization round-trip** — `shape="path"` region with `bleed` → dict →
+  region equal; `image_style` stroke fields round-trip.
+- The existing **166 layout tests stay green** (rect/polygon paths unchanged).
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q`.
+
+## 9. Cross-cutting compliance
+- All errors logged (file + console), platform-independent (AGENTS.md §6, §8).
+- Images **scaled, not cropped at generation/save**; layout placement still uses
+  fit modes (cover crops overflow at placement — already the engine's behavior).
+- No size/ratio tokens injected into prompts (N/A here; geometry-only).
+
+## 10. Acceptance criteria (definition of done for #1)
+1. A `shape="path"` region with straight, concave, and curved (`cubic`/`quad`)
+   segments renders with the image clipped to the exact shape.
+2. `stroke_px=0` produces a borderless panel; `stroke_px>0` draws a border in
+   `stroke_color`.
+3. A `bleed=True` region clips to the page bleed box; its border is controlled
+   independently by `stroke_px` (full-bleed borderless = `bleed=True` + `stroke_px=0`).
+4. `cover` (default) fills + clips; `contain` letterboxes inside the shape.
+5. New fields round-trip through `schema.py` and `.iaibundle`.
+6. Malformed segments fall back to the bbox rectangle and are logged; no crash.
+7. All new tests pass and the existing 166 layout tests remain green.

--- a/Plans/2026-06-27-comic-layout-geometry-core-design.md
+++ b/Plans/2026-06-27-comic-layout-geometry-core-design.md
@@ -143,6 +143,13 @@ Pure so it unit-tests headless without a display.
   so a classic full-bleed borderless panel is `bleed=True` + `stroke_px=0` (no
   page-edge detection needed). (Auto edge-snap of a panel to the page edge is #2;
   #1 only honors the flag + bleed box.)
+  - **Decision (canvas growth):** the **export canvas** grows to include the bleed
+    margin whenever `PageSpec.bleed_px > 0` — standard print-bleed semantics, where
+    the bleed area is a property of the *page*, not of any one panel. The per-region
+    `bleed` flag then decides which regions may paint into that margin. (With no
+    legacy projects this changes nothing observed; it is a deliberate print default,
+    not incidental. Alternative considered: grow only when some region has
+    `bleed=True` — rejected as less print-correct.)
 - **Text regions** are clipped to the path too (text cannot spill past a shaped
   panel). Full text-reflow-inside-an-arbitrary-shape stays with #3.
 

--- a/Plans/2026-06-27-comic-layout-geometry-core-plan.md
+++ b/Plans/2026-06-27-comic-layout-geometry-core-plan.md
@@ -954,8 +954,11 @@ git commit -m "feat(layout): bleed-aware rendering on an extended canvas"
 
 ## Notes / deliberately deferred (not gaps)
 - **PDF bleed:** `export_document_pdf` is left at trim size in #1; applying bleed to the PDF path is folded into the later page/export work. (PNG/`QImage` bleed — the testable acceptance criterion — is implemented here.)
+- **GUI export still uses the PIL engine, not this Qt renderer (whole-branch review, Important #2).** `gui/layout/export_dialog.py` renders PNG/PDF via `core/layout/engine.py` (`LayoutEngine.render_page`), which has **none** of #1's shape-clipping / per-region stroke / bleed. The live editor canvas (`gui/layout/canvas_widget.py`) *does* use the Qt `build_scene`, so the new rendering is visible in-editor — but real exports diverge. **Sub-project #2 (or a dedicated export task) must consciously pick the source of truth:** migrate export to the Qt path or port the features. This is the single biggest follow-up for the renderer to actually reach exported output.
+- **Canvas growth on `PageSpec.bleed_px`:** `render_page_to_image` grows the export canvas whenever `bleed_px > 0` (print-bleed semantics — see the design doc's bleed decision), independent of whether any region is `bleed=True`. Deliberate; revisit only if a "grow only when a region bleeds" semantics is preferred.
 - **Editor authoring** of curves/vertices, **tiling/inset gutters**, **balloons**, and the **AI designer** emitting `path`/`segments` are sub-projects #2–#5 per the spec.
 - **`contain` centering:** the scaled pixmap is centered in the bbox for both fits; arbitrary alignment is not in scope.
+- **Path-region drag writeback (#5):** `_writeback_move` persists drags into `bbox`/`points` only, not `segments`; image frames are `movable=False` today so this is not a live bug, but the manual editor (#5) must handle segment writeback.
 
 ## Self-Review (completed by plan author)
 - **Spec coverage:** path geometry (T1), pure helpers (T2), serialization + normalize (T3), path builder (T4), image clip-to-shape + stroke/borderless (T5), text clip (T6), bleed (T7). All §3–§8 spec items map to a task; acceptance criteria 1–7 are each covered by a test.

--- a/Plans/2026-06-27-comic-layout-geometry-core-plan.md
+++ b/Plans/2026-06-27-comic-layout-geometry-core-plan.md
@@ -1,0 +1,963 @@
+# Comic Layout — Geometry & Render Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give layout regions a path-based geometry (straight **and** curved edges) that clips placed images to the panel's exact shape, with per-region stroke control (incl. borderless) and a bleed flag — the foundation for comic-style pages.
+
+**Architecture:** Add a `PathSegment` model and `Region.shape="path"`/`segments`/`bleed`. A pure `core/layout/geometry.py` validates segments and computes a bbox. The Qt renderer (`core/layout/qt_renderer.py`) builds a `QPainterPath` per region and uses `ItemClipsChildrenToShape` so the image/text child is clipped to the panel interior; stroke comes from `ImageStyle.stroke_px`/`stroke_color` (0 ⇒ borderless); bleed renders onto an extended canvas. Serialization round-trips the new fields.
+
+**Tech Stack:** Python 3.12, PySide6 (Qt Graphics), pytest. Renderer tests run headless under `QT_QPA_PLATFORM=offscreen`.
+
+## Global Constraints
+
+- Python interpreter for tests: `.venv_linux/bin/python` (WSL). Run tests with `QT_QPA_PLATFORM=offscreen`.
+- Full layout suite must stay green: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` (currently **166 passed**).
+- **All errors must be logged** (platform-independent) — use `logging.getLogger(__name__)`; a malformed path falls back to the bbox rectangle and logs.
+- Images are **scaled, not cropped at generation/save**; at *layout placement* the fit modes apply (`cover` crops overflow via the shape clip — this is existing engine behavior).
+- Reuse existing `ImageStyle.fit` / `stroke_px` / `stroke_color` — **do not** add new style fields.
+- No backward-compat machinery for old projects (none exist); keep `rect`/`polygon` shape kinds working so existing tests/designer are untouched.
+- Conventional Commits (`feat(layout): …`). Commit after each task.
+- **Do NOT open a pull request.** This is sub-project #1 of 5; per the project rule, the PR is opened only after all five comic-layout sub-projects are finished. Keep all work on branch `feat/comic-layout-geometry-core`.
+
+---
+
+### Task 1: Region path geometry model
+
+**Files:**
+- Modify: `core/layout/models.py` (add `PathSegment`; extend `Region`)
+- Test: `tests/layout/test_region_path_fields.py` (create)
+
+**Interfaces:**
+- Produces: `PathSegment(type: Literal["move","line","quad","cubic","close"], pts: List[Tuple[float,float]])`; `Region.shape` now includes `"path"`; `Region.segments: List[PathSegment]`; `Region.bleed: bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_region_path_fields.py`:
+
+```python
+from core.layout.models import Region, PathSegment
+
+
+def test_region_defaults_have_empty_segments_and_no_bleed():
+    r = Region(id="r", kind="image")
+    assert r.shape == "rect"
+    assert r.segments == []
+    assert r.bleed is False
+
+
+def test_region_accepts_path_shape_and_segments():
+    segs = [
+        PathSegment(type="move", pts=[(0.0, 0.0)]),
+        PathSegment(type="line", pts=[(10.0, 0.0)]),
+        PathSegment(type="cubic", pts=[(10.0, 5.0), (5.0, 10.0), (0.0, 10.0)]),
+        PathSegment(type="close", pts=[]),
+    ]
+    r = Region(id="r", kind="image", shape="path", segments=segs, bleed=True)
+    assert r.shape == "path"
+    assert r.segments[2].type == "cubic"
+    assert len(r.segments[2].pts) == 3
+    assert r.bleed is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_path_fields.py -q`
+Expected: FAIL — `ImportError: cannot import name 'PathSegment'`.
+
+- [ ] **Step 3: Implement the model changes**
+
+In `core/layout/models.py`, add the `PathSegment` dataclass immediately **before** `class Region` (after `ImageBlock`):
+
+```python
+@dataclass
+class PathSegment:
+    """One command of a region's vector outline (page-pixel coords).
+
+    Point counts by type: move=1, line=1, quad=2 (control, end),
+    cubic=3 (c1, c2, end), close=0. A valid path starts with a 'move'.
+    """
+
+    type: Literal["move", "line", "quad", "cubic", "close"]
+    pts: List[Tuple[float, float]] = field(default_factory=list)
+```
+
+In `class Region`, change the `shape` annotation and add two fields right after `points`:
+
+```python
+    shape: Literal["rect", "polygon", "path"] = "rect"
+    bbox: Rect = (0, 0, 100, 100)
+    points: List[Tuple[int, int]] = field(default_factory=list)  # polygon vertices, page px
+    segments: List["PathSegment"] = field(default_factory=list)  # used when shape == "path"
+    bleed: bool = False
+```
+
+(All Region call sites use keyword arguments, so inserting fields is safe.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_path_fields.py -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/models.py tests/layout/test_region_path_fields.py
+git commit -m "feat(layout): add PathSegment model + Region path/segments/bleed fields"
+```
+
+---
+
+### Task 2: Pure geometry helpers (`geometry.py`)
+
+**Files:**
+- Create: `core/layout/geometry.py`
+- Test: `tests/layout/test_geometry.py` (create)
+
+**Interfaces:**
+- Consumes: `PathSegment` (Task 1).
+- Produces: `validate_segments(segments) -> list[str]` (empty = valid); `segments_bbox(segments) -> tuple[float,float,float,float]` `(x,y,w,h)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_geometry.py`:
+
+```python
+import math
+from core.layout.models import PathSegment
+from core.layout.geometry import validate_segments, segments_bbox
+
+
+def _triangle():
+    return [
+        PathSegment(type="move", pts=[(0.0, 0.0)]),
+        PathSegment(type="line", pts=[(10.0, 0.0)]),
+        PathSegment(type="line", pts=[(5.0, 8.0)]),
+        PathSegment(type="close", pts=[]),
+    ]
+
+
+def test_valid_path_has_no_issues():
+    assert validate_segments(_triangle()) == []
+
+
+def test_empty_is_invalid():
+    assert validate_segments([]) == ["empty segment list"]
+
+
+def test_must_start_with_move():
+    segs = [PathSegment(type="line", pts=[(1.0, 1.0)])]
+    assert any("must start with a 'move'" in m for m in validate_segments(segs))
+
+
+def test_wrong_point_count_flagged():
+    segs = [PathSegment(type="move", pts=[(0.0, 0.0)]),
+            PathSegment(type="cubic", pts=[(1.0, 1.0)])]  # cubic needs 3
+    assert any("cubic expects 3" in m for m in validate_segments(segs))
+
+
+def test_non_finite_flagged():
+    segs = [PathSegment(type="move", pts=[(0.0, float("nan"))])]
+    assert any("non-finite" in m for m in validate_segments(segs))
+
+
+def test_bbox_of_triangle():
+    assert segments_bbox(_triangle()) == (0.0, 0.0, 10.0, 8.0)
+
+
+def test_bbox_includes_cubic_control_points():
+    segs = [PathSegment(type="move", pts=[(0.0, 0.0)]),
+            PathSegment(type="cubic", pts=[(0.0, 20.0), (20.0, 20.0), (10.0, 0.0)])]
+    # superset using control points: x in [0,20], y in [0,20]
+    assert segments_bbox(segs) == (0.0, 0.0, 20.0, 20.0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_geometry.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'core.layout.geometry'`.
+
+- [ ] **Step 3: Implement `geometry.py`**
+
+Create `core/layout/geometry.py`:
+
+```python
+"""Pure geometry helpers for path-based regions (no Qt dependency)."""
+from __future__ import annotations
+
+import math
+from typing import List, Tuple
+
+from core.layout.models import PathSegment
+
+_EXPECTED_PTS = {"move": 1, "line": 1, "quad": 2, "cubic": 3, "close": 0}
+
+
+def validate_segments(segments: List[PathSegment]) -> List[str]:
+    """Return a list of problem descriptions; empty list means valid."""
+    if not segments:
+        return ["empty segment list"]
+    issues: List[str] = []
+    if segments[0].type != "move":
+        issues.append("path must start with a 'move' segment")
+    for i, seg in enumerate(segments):
+        expected = _EXPECTED_PTS.get(seg.type)
+        if expected is None:
+            issues.append(f"segment {i}: unknown type {seg.type!r}")
+            continue
+        if len(seg.pts) != expected:
+            issues.append(
+                f"segment {i}: {seg.type} expects {expected} point(s), got {len(seg.pts)}"
+            )
+        for (px, py) in seg.pts:
+            if not (math.isfinite(px) and math.isfinite(py)):
+                issues.append(f"segment {i}: non-finite coordinate")
+                break
+    return issues
+
+
+def segments_bbox(segments: List[PathSegment]) -> Tuple[float, float, float, float]:
+    """Bounding box (x, y, w, h) of all segment points.
+
+    For curves this uses the control points, i.e. a safe superset of the visual
+    extent. bbox is positioning-only, never used for clipping, so the superset is
+    acceptable.
+    """
+    xs: List[float] = []
+    ys: List[float] = []
+    for seg in segments:
+        for (px, py) in seg.pts:
+            xs.append(px)
+            ys.append(py)
+    if not xs:
+        return (0.0, 0.0, 0.0, 0.0)
+    return (min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_geometry.py -q`
+Expected: PASS (7 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/geometry.py tests/layout/test_geometry.py
+git commit -m "feat(layout): pure geometry helpers (validate_segments, segments_bbox)"
+```
+
+---
+
+### Task 3: Serialize segments + bleed; schema + normalize
+
+**Files:**
+- Modify: `core/layout/schema.py` (`REGION_JSON_SCHEMA`, `region_to_dict`, `region_from_dict`, `normalize_region`)
+- Test: `tests/layout/test_schema_path.py` (create)
+
+**Interfaces:**
+- Consumes: `PathSegment` (Task 1), `segments_bbox` (Task 2).
+- Produces: `region_to_dict`/`region_from_dict` round-trip `segments` (`[{"type","pts"}]`) and `bleed`; `normalize_region` derives bbox from segments for `shape="path"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_schema_path.py`:
+
+```python
+from core.layout.models import Region, PathSegment
+from core.layout.schema import (
+    region_to_dict, region_from_dict, normalize_region, REGION_JSON_SCHEMA,
+)
+
+
+def _segs():
+    return [
+        PathSegment(type="move", pts=[(10.0, 10.0)]),
+        PathSegment(type="line", pts=[(90.0, 10.0)]),
+        PathSegment(type="line", pts=[(50.0, 80.0)]),
+        PathSegment(type="close", pts=[]),
+    ]
+
+
+def test_path_region_round_trips():
+    r = Region(id="p", kind="image", shape="path", segments=_segs(), bleed=True)
+    r2 = region_from_dict(region_to_dict(r))
+    assert r2.shape == "path"
+    assert r2.bleed is True
+    assert [s.type for s in r2.segments] == ["move", "line", "line", "close"]
+    assert r2.segments[1].pts == [(90.0, 10.0)]
+
+
+def test_schema_advertises_path_segments_bleed():
+    assert "path" in REGION_JSON_SCHEMA["properties"]["shape"]["enum"]
+    assert "segments" in REGION_JSON_SCHEMA["properties"]
+    assert "bleed" in REGION_JSON_SCHEMA["properties"]
+
+
+def test_normalize_region_derives_bbox_from_segments():
+    r = Region(id="p", kind="image", shape="path", segments=_segs())
+    n = normalize_region(r, (200, 200))
+    # bbox = bounding box of points (10,10)-(90,80)
+    assert n.bbox == (10, 10, 80, 70)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_schema_path.py -q`
+Expected: FAIL — round-trip drops `segments`/`bleed`; schema lacks the new keys.
+
+- [ ] **Step 3: Implement schema changes**
+
+In `core/layout/schema.py`, add `PathSegment` to the model import:
+
+```python
+from core.layout.models import (
+    Region, PageSpec, DocumentSpec, PageSize, TextStyle, ImageStyle, Snapshot, ProjectStyle,
+    migrate_legacy_blocks, TextBlock, ImageBlock, PathSegment,
+)
+```
+
+Update `REGION_JSON_SCHEMA` `shape` enum and add `segments`/`bleed` properties:
+
+```python
+        "shape": {"enum": ["rect", "polygon", "path"]},
+        "bbox": {"type": "array", "items": {"type": "number"}, "minItems": 4, "maxItems": 4},
+        "points": {"type": "array", "items": {"type": "array", "items": {"type": "number"}}},
+        "segments": {"type": "array", "items": {
+            "type": "object",
+            "required": ["type", "pts"],
+            "properties": {
+                "type": {"enum": ["move", "line", "quad", "cubic", "close"]},
+                "pts": {"type": "array", "items": {
+                    "type": "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2}},
+            },
+        }},
+        "bleed": {"type": "boolean"},
+        "z": {"type": "integer"},
+```
+
+In `region_to_dict`, add the two keys (before `text_style`):
+
+```python
+        "image_ref": r.image_ref, "prompt": r.prompt, "gen_settings": dict(r.gen_settings),
+        "segments": [{"type": s.type, "pts": [list(p) for p in s.pts]} for s in r.segments],
+        "bleed": r.bleed,
+        "text_style": _style_to_dict(r.text_style),
+        "image_style": _style_to_dict(r.image_style),
+```
+
+In `region_from_dict`, parse them (before the `text_style=` line):
+
+```python
+        gen_settings=dict(d.get("gen_settings", {})),
+        segments=[PathSegment(type=s.get("type", "line"),
+                              pts=[tuple(p) for p in s.get("pts", [])])
+                  for s in d.get("segments", [])],
+        bleed=bool(d.get("bleed", False)),
+        text_style=TextStyle(**_filtered(TextStyle, ts)) if ts else None,
+```
+
+In `normalize_region`, add a `path` branch and round to int:
+
+```python
+def normalize_region(r: Region, page_px: Tuple[int, int]) -> Region:
+    pw, ph = page_px
+    if r.shape == "polygon" and r.points:
+        xs = [p[0] for p in r.points]
+        ys = [p[1] for p in r.points]
+        bbox = (min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys))
+    elif r.shape == "path" and r.segments:
+        from core.layout.geometry import segments_bbox
+        bbox = tuple(round(v) for v in segments_bbox(r.segments))
+    else:
+        bbox = r.bbox
+    x, y, w, h = bbox
+    x = max(0, min(x, pw - 1))
+    y = max(0, min(y, ph - 1))
+    w = max(1, min(w, pw - x))
+    h = max(1, min(h, ph - y))
+    return replace(r, bbox=(x, y, w, h))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_schema_path.py -q`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/schema.py tests/layout/test_schema_path.py
+git commit -m "feat(layout): serialize path segments + bleed; bbox-from-segments in normalize"
+```
+
+---
+
+### Task 4: `region_to_painter_path` builder
+
+**Files:**
+- Modify: `core/layout/qt_renderer.py` (imports, module logger, new function)
+- Test: `tests/layout/test_region_path_builder.py` (create)
+
+**Interfaces:**
+- Consumes: `validate_segments` (Task 2), `Region` (Task 1).
+- Produces: `qt_renderer.region_to_painter_path(region) -> QPainterPath` (rect/polygon/path; invalid path falls back to bbox rect + logs).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_region_path_builder.py`:
+
+```python
+from core.layout.models import Region, PathSegment
+from core.layout import qt_renderer
+
+
+def test_rect_region_path_matches_bbox(qapp):
+    r = Region(id="r", kind="image", shape="rect", bbox=(10, 20, 30, 40))
+    p = qt_renderer.region_to_painter_path(r)
+    b = p.boundingRect()
+    assert (round(b.x()), round(b.y()), round(b.width()), round(b.height())) == (10, 20, 30, 40)
+
+
+def test_polygon_region_path_matches_points(qapp):
+    r = Region(id="r", kind="image", shape="polygon", points=[(0, 0), (50, 0), (25, 40)])
+    b = qt_renderer.region_to_painter_path(r).boundingRect()
+    assert (round(b.x()), round(b.y()), round(b.width()), round(b.height())) == (0, 0, 50, 40)
+
+
+def test_path_region_builds_from_segments(qapp):
+    segs = [PathSegment(type="move", pts=[(0.0, 0.0)]),
+            PathSegment(type="line", pts=[(60.0, 0.0)]),
+            PathSegment(type="line", pts=[(30.0, 50.0)]),
+            PathSegment(type="close", pts=[])]
+    b = qt_renderer.region_to_painter_path(
+        Region(id="r", kind="image", shape="path", segments=segs)).boundingRect()
+    assert (round(b.x()), round(b.y()), round(b.width()), round(b.height())) == (0, 0, 60, 50)
+
+
+def test_invalid_segments_fall_back_to_bbox(qapp):
+    # cubic with too few points -> invalid -> bbox rect
+    segs = [PathSegment(type="move", pts=[(0.0, 0.0)]),
+            PathSegment(type="cubic", pts=[(1.0, 1.0)])]
+    r = Region(id="r", kind="image", shape="path", segments=segs, bbox=(5, 5, 20, 20))
+    b = qt_renderer.region_to_painter_path(r).boundingRect()
+    assert (round(b.x()), round(b.y()), round(b.width()), round(b.height())) == (5, 5, 20, 20)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_path_builder.py -q`
+Expected: FAIL — `AttributeError: module 'core.layout.qt_renderer' has no attribute 'region_to_painter_path'`.
+
+- [ ] **Step 3: Implement the builder**
+
+In `core/layout/qt_renderer.py`, extend the `QtGui` import to include `QPainterPath`, add a logger, import the validator, and add the function. Update the import line:
+
+```python
+from PySide6.QtGui import (
+    QColor, QBrush, QPen, QPolygonF, QImage, QPainter, QFont, QPixmap,
+    QPdfWriter, QPageSize, QPageLayout, QPainterPath,
+)
+```
+
+Add near the top (after the existing imports):
+
+```python
+import logging
+
+from core.layout.geometry import validate_segments
+
+logger = logging.getLogger(__name__)
+```
+
+Add the builder (place it after `_resolve_bg`):
+
+```python
+def region_to_painter_path(r: Region) -> QPainterPath:
+    """Build a QPainterPath for a region (rect | polygon | path).
+
+    Invalid path segments are logged and the region falls back to its bbox
+    rectangle, so a region never renders as nothing.
+    """
+    path = QPainterPath()
+    if r.shape == "path" and r.segments:
+        issues = validate_segments(r.segments)
+        if issues:
+            logger.error("Region %s has invalid path segments; falling back to bbox: %s",
+                         r.id, "; ".join(issues))
+        else:
+            for seg in r.segments:
+                if seg.type == "move":
+                    path.moveTo(*seg.pts[0])
+                elif seg.type == "line":
+                    path.lineTo(*seg.pts[0])
+                elif seg.type == "quad":
+                    (cx, cy), (ex, ey) = seg.pts
+                    path.quadTo(cx, cy, ex, ey)
+                elif seg.type == "cubic":
+                    (c1x, c1y), (c2x, c2y), (ex, ey) = seg.pts
+                    path.cubicTo(c1x, c1y, c2x, c2y, ex, ey)
+                elif seg.type == "close":
+                    path.closeSubpath()
+            if not path.isEmpty():
+                return path
+    elif r.shape == "polygon" and r.points:
+        path.addPolygon(QPolygonF([QPointF(px, py) for px, py in r.points]))
+        path.closeSubpath()
+        return path
+    x, y, w, h = r.bbox
+    path.addRect(QRectF(x, y, w, h))
+    return path
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_path_builder.py -q`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/qt_renderer.py tests/layout/test_region_path_builder.py
+git commit -m "feat(layout): region_to_painter_path builder (rect/polygon/path + fallback)"
+```
+
+---
+
+### Task 5: Clip image to shape + honor stroke (borderless)
+
+**Files:**
+- Modify: `core/layout/qt_renderer.py` (`_RegionPathItem` class; rewrite `_add_image_region`)
+- Test: `tests/layout/test_image_clip_stroke.py` (create)
+
+**Interfaces:**
+- Consumes: `region_to_painter_path` (Task 4).
+- Produces: image regions render via a clip-parent `_RegionPathItem` (filled = clipped pixmap child; empty = placeholder fill); stroke from `ImageStyle.stroke_px`/`stroke_color` (0 ⇒ `Qt.NoPen`); fit `cover` (default) vs `contain`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_image_clip_stroke.py`:
+
+```python
+from PySide6.QtGui import QImage
+from PySide6.QtWidgets import QGraphicsItem, QGraphicsPixmapItem
+from PySide6.QtCore import Qt
+
+from core.layout.models import Region, PageSpec, PathSegment, ImageStyle
+from core.layout import qt_renderer
+
+
+def _solid_png(tmp_path, color, name="src.png", size=(80, 80)):
+    im = QImage(size[0], size[1], QImage.Format_RGB32)
+    im.fill(color)
+    p = tmp_path / name
+    assert im.save(str(p))
+    return str(p)
+
+
+def _triangle_segments():
+    # apex at bottom-center, wide top edge; bbox (100,10,90,80)
+    return [PathSegment(type="move", pts=[(100.0, 10.0)]),
+            PathSegment(type="line", pts=[(190.0, 10.0)]),
+            PathSegment(type="line", pts=[(145.0, 90.0)]),
+            PathSegment(type="close", pts=[])]
+
+
+def test_image_is_clipped_to_triangle(qapp, tmp_path):
+    ref = _solid_png(tmp_path, Qt.red, size=(90, 80))
+    page = PageSpec(page_size_px=(200, 150), background="#FFFFFF", regions=[
+        Region(id="t", kind="image", shape="path", segments=_triangle_segments(),
+               bbox=(100, 10, 90, 80), image_ref=ref)])
+    img = qt_renderer.render_page_to_image(page)
+    inside = img.pixelColor(145, 30)     # near top-center of triangle
+    outside = img.pixelColor(105, 85)    # bbox corner OUTSIDE the triangle
+    assert inside.red() > 200 and inside.green() < 80      # red image
+    assert outside.red() > 200 and outside.green() > 200   # white page bg (clipped away)
+
+
+def test_concave_notch_is_background(qapp, tmp_path):
+    ref = _solid_png(tmp_path, Qt.red, size=(100, 100))
+    # L-shape (concave): outer 0..100 square with a notch cut out of the top-right
+    segs = [PathSegment(type="move", pts=[(0.0, 0.0)]),
+            PathSegment(type="line", pts=[(50.0, 0.0)]),
+            PathSegment(type="line", pts=[(50.0, 50.0)]),
+            PathSegment(type="line", pts=[(100.0, 50.0)]),
+            PathSegment(type="line", pts=[(100.0, 100.0)]),
+            PathSegment(type="line", pts=[(0.0, 100.0)]),
+            PathSegment(type="close", pts=[])]
+    page = PageSpec(page_size_px=(120, 120), background="#FFFFFF", regions=[
+        Region(id="L", kind="image", shape="path", segments=segs,
+               bbox=(0, 0, 100, 100), image_ref=ref)])
+    img = qt_renderer.render_page_to_image(page)
+    notch = img.pixelColor(75, 25)   # inside bbox, inside the removed notch
+    body = img.pixelColor(25, 25)    # solid part of the L
+    assert notch.red() > 200 and notch.green() > 200   # background
+    assert body.red() > 200 and body.green() < 80      # red image
+
+
+def test_borderless_when_stroke_zero(qapp, tmp_path):
+    page = PageSpec(page_size_px=(200, 150), regions=[
+        Region(id="e", kind="image", bbox=(10, 10, 80, 80),
+               image_style=ImageStyle(stroke_px=0))])
+    scene = qt_renderer.build_scene(page)
+    frame = [it for it in scene.items()
+             if it.data(0) == "e" and hasattr(it, "path")][0]
+    assert frame.pen().style() == Qt.NoPen
+
+
+def test_stroke_pen_when_stroke_positive(qapp):
+    page = PageSpec(page_size_px=(200, 150), regions=[
+        Region(id="e", kind="image", bbox=(10, 10, 80, 80),
+               image_style=ImageStyle(stroke_px=4, stroke_color="#FF0000"))])
+    scene = qt_renderer.build_scene(page)
+    frame = [it for it in scene.items()
+             if it.data(0) == "e" and hasattr(it, "path")][0]
+    assert frame.pen().widthF() == 4
+    assert frame.pen().color().red() == 255
+
+
+def test_filled_image_region_still_selectable(qapp, tmp_path):
+    ref = _solid_png(tmp_path, Qt.white)
+    page = PageSpec(page_size_px=(200, 150), regions=[
+        Region(id="img1", kind="image", bbox=(10, 10, 80, 80), image_ref=ref)])
+    scene = qt_renderer.build_scene(page, selectable=True)
+    pix = [it for it in scene.items() if isinstance(it, QGraphicsPixmapItem)]
+    assert pix and (pix[0].flags() & QGraphicsItem.ItemIsSelectable)
+    assert pix[0].data(0) == "img1"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_image_clip_stroke.py -q`
+Expected: FAIL — current `_add_image_region` does not clip to shape (triangle/notch assertions fail) and ignores `stroke_px`.
+
+- [ ] **Step 3: Implement clip-parent rendering**
+
+In `core/layout/qt_renderer.py`, add `QGraphicsPathItem` to the widgets import:
+
+```python
+from PySide6.QtWidgets import (
+    QGraphicsScene, QGraphicsRectItem, QGraphicsPolygonItem,
+    QGraphicsSimpleTextItem, QGraphicsItem, QGraphicsPixmapItem, QGraphicsPathItem,
+)
+```
+
+Add the clip-parent item class after `_RegionPixmapItem`:
+
+```python
+class _RegionPathItem(_RegionMoveMixin, QGraphicsPathItem):
+    def __init__(self, path: QPainterPath, region: Region):
+        super().__init__(path)
+        self._bind_region(region)
+
+    def shape(self):
+        # Clip children to the FILLED interior, not the stroked outline (the
+        # default QGraphicsPathItem.shape() would return just the pen outline).
+        return self.path()
+```
+
+Replace the entire `_add_image_region` function with:
+
+```python
+def _add_image_region(scene: QGraphicsScene, r: Region, selectable: bool,
+                      *, locked: bool = True) -> None:
+    # Image frames are ALWAYS locked in position (only text follows the lock
+    # toggle); they stay selectable so the region can be picked.
+    movable = False
+    istyle = r.image_style
+    stroke_px = istyle.stroke_px if istyle else 0
+    stroke_color = istyle.stroke_color if istyle else "#000000"
+    fit = istyle.fit if istyle else "cover"
+
+    path = region_to_painter_path(r)
+    frame = _RegionPathItem(path, r)
+    frame.setFlag(QGraphicsItem.ItemClipsChildrenToShape, True)
+    frame.setPen(QPen(QColor(stroke_color), stroke_px) if stroke_px > 0 else QPen(Qt.NoPen))
+
+    pix = QPixmap(r.image_ref) if r.image_ref else None
+    filled = pix is not None and not pix.isNull()
+
+    if filled:
+        frame.setBrush(QBrush(Qt.transparent))
+        x, y, w, h = r.bbox
+        mode = Qt.KeepAspectRatioByExpanding if fit == "cover" else Qt.KeepAspectRatio
+        scaled = pix.scaled(int(w), int(h), mode, Qt.SmoothTransformation)
+        child = _RegionPixmapItem(scaled, r)
+        # Center the scaled pixmap in the bbox; the parent shape clip crops the
+        # overflow (cover) or reveals panel bg in the letterbox (contain).
+        child.setOffset(x + (w - scaled.width()) / 2.0, y + (h - scaled.height()) / 2.0)
+        child.setParentItem(frame)
+        _apply_flags(child, selectable, r.id, movable=movable)
+    else:
+        frame.setBrush(QBrush(_PLACEHOLDER_FILL))
+        lx, ly, _, _ = r.bbox
+        label = QGraphicsSimpleTextItem(r.name or "[image]", frame)
+        label.setPos(lx + 4, ly + 4)
+        label.setBrush(QBrush(QColor("#6C757D")))
+
+    _apply_flags(frame, selectable, r.id, movable=movable)
+    scene.addItem(frame)
+```
+
+- [ ] **Step 4: Run the new test, then the full suite**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_image_clip_stroke.py -q`
+Expected: PASS (6 passed).
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q`
+Expected: PASS (all green; `test_filled_image_region_is_selectable` in `test_qt_renderer.py` still passes — the pixmap child is selectable and carries the id).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/qt_renderer.py tests/layout/test_image_clip_stroke.py
+git commit -m "feat(layout): clip image regions to shape + honor stroke (0=borderless)"
+```
+
+---
+
+### Task 6: Clip text to the region shape
+
+**Files:**
+- Modify: `core/layout/qt_renderer.py` (rewrite `_add_text_region`)
+- Test: `tests/layout/test_text_clip.py` (create)
+
+**Interfaces:**
+- Consumes: `region_to_painter_path` (Task 4), `_RegionPathItem` (Task 5).
+- Produces: text is a child of a clip `_RegionPathItem` (with `ItemClipsChildrenToShape`), so it cannot spill past a shaped panel; the editor-only dashed guide box and font resolution are preserved.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_text_clip.py`:
+
+```python
+from PySide6.QtWidgets import QGraphicsItem, QGraphicsSimpleTextItem
+from core.layout.models import Region, PageSpec
+from core.layout import qt_renderer
+
+
+def test_text_is_child_of_a_clipping_path_item(qapp):
+    page = PageSpec(page_size_px=(400, 200), regions=[
+        Region(id="t", kind="text", bbox=(0, 0, 100, 40), text="Hello world")])
+    scene = qt_renderer.build_scene(page)  # export path (selectable=False)
+    texts = [it for it in scene.items() if isinstance(it, QGraphicsSimpleTextItem)]
+    assert texts, "expected a text item"
+    parent = texts[0].parentItem()
+    assert parent is not None
+    assert bool(parent.flags() & QGraphicsItem.ItemClipsChildrenToShape)
+
+
+def test_guide_box_still_editor_only(qapp):
+    from PySide6.QtWidgets import QGraphicsRectItem
+    page = PageSpec(page_size_px=(400, 200), regions=[
+        Region(id="t", kind="text", bbox=(0, 0, 100, 40), text="Hi")])
+    editor = qt_renderer.build_scene(page, selectable=True)
+    assert any(isinstance(it, QGraphicsRectItem) and it.data(0) == "t" for it in editor.items())
+    export = qt_renderer.build_scene(page, selectable=False)
+    assert not any(isinstance(it, QGraphicsRectItem) and it.data(0) == "t" for it in export.items())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_text_clip.py -q`
+Expected: FAIL — text is currently top-level (export) or a child of the rect box, not a clip path item.
+
+- [ ] **Step 3: Rewrite `_add_text_region`**
+
+Replace the entire `_add_text_region` function in `core/layout/qt_renderer.py` with:
+
+```python
+def _add_text_region(scene: QGraphicsScene, r: Region, selectable: bool, project_style=None,
+                     *, locked: bool = True) -> None:
+    x, y, w, h = r.bbox
+
+    # Editor-only dashed guide box doubles as the region's selectable/movable
+    # handle; export paths (selectable=False) omit it.
+    box = None
+    if selectable:
+        box = _RegionRectItem(QRectF(x, y, w, h), r)
+        box.setBrush(QBrush(Qt.transparent))
+        pen = QPen(_TEXT_GUIDE_PEN, 1.5, Qt.DashLine)
+        pen.setCosmetic(True)
+        box.setPen(pen)
+        _apply_flags(box, selectable, r.id, movable=(selectable and not locked))
+        scene.addItem(box)
+
+    # Clip item: text is parented here so it cannot spill past the panel shape.
+    # When a guide box exists, the clip rides under it so a drag moves both.
+    clip = _RegionPathItem(region_to_painter_path(r), r)
+    clip.setPen(QPen(Qt.NoPen))
+    clip.setBrush(QBrush(Qt.transparent))
+    clip.setFlag(QGraphicsItem.ItemClipsChildrenToShape, True)
+    if box is not None:
+        clip.setParentItem(box)
+    else:
+        scene.addItem(clip)
+
+    text = QGraphicsSimpleTextItem(r.text or "")
+    ts = effective_text_style(r, project_style)
+    font = QFont()
+    if ts:
+        if ts.family:
+            font.setFamily(ts.family[0])
+        font.setBold(ts.weight in ("bold", "black", "semibold"))
+        font.setItalic(ts.italic)
+        text.setBrush(QBrush(QColor(ts.color)))
+    font.setPixelSize(ts.size_px if ts and ts.size_px else _DEFAULT_TEXT_PX)
+    text.setFont(font)
+    text.setParentItem(clip)
+    text.setPos(x + 2, y + 2)
+```
+
+- [ ] **Step 4: Run the new test, then the full suite**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_text_clip.py -q`
+Expected: PASS (2 passed).
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q`
+Expected: PASS (all green; the font-resolution and guide-box tests in `test_qt_renderer.py` still pass — the text item and the editor-only rect box are both still present).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/qt_renderer.py tests/layout/test_text_clip.py
+git commit -m "feat(layout): clip text regions to the panel shape"
+```
+
+---
+
+### Task 7: Bleed rendering (extended canvas)
+
+**Files:**
+- Modify: `core/layout/qt_renderer.py` (`build_scene` gains `region_filter`; `render_page_to_image` honors `bleed_px`)
+- Test: `tests/layout/test_bleed_render.py` (create)
+
+**Interfaces:**
+- Consumes: existing `build_scene`/`render_page_to_image`.
+- Produces: when `page.bleed_px > 0`, the rendered image is `(pw+2b)×(ph+2b)`; non-`bleed` regions are clipped to the trim box, `bleed` regions may paint into the surrounding margin. `b == 0` is unchanged (all existing tests).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_bleed_render.py`:
+
+```python
+from PySide6.QtGui import QImage
+from PySide6.QtCore import Qt
+from core.layout.models import Region, PageSpec
+from core.layout import qt_renderer
+
+
+def _solid_png(tmp_path, color, size=(200, 60)):
+    im = QImage(size[0], size[1], QImage.Format_RGB32)
+    im.fill(color)
+    p = tmp_path / "ref.png"
+    assert im.save(str(p))
+    return str(p)
+
+
+def test_canvas_grows_by_bleed(qapp):
+    page = PageSpec(page_size_px=(200, 150), bleed_px=20, background="#FFFFFF")
+    img = qt_renderer.render_page_to_image(page)
+    assert img.width() == 240 and img.height() == 190
+
+
+def test_bleed_region_paints_into_margin(qapp, tmp_path):
+    ref = _solid_png(tmp_path, Qt.red)
+    # geometry spans y in [-20, 20] (into the top bleed) across the full width
+    page = PageSpec(page_size_px=(200, 150), bleed_px=20, background="#FFFFFF", regions=[
+        Region(id="b", kind="image", bbox=(0, -20, 200, 40), image_ref=ref, bleed=True)])
+    img = qt_renderer.render_page_to_image(page)
+    # device (100, 5) is inside the top bleed band [0,20)
+    c = img.pixelColor(100, 5)
+    assert c.red() > 200 and c.green() < 80
+
+
+def test_non_bleed_region_is_clipped_at_trim(qapp, tmp_path):
+    ref = _solid_png(tmp_path, Qt.red)
+    page = PageSpec(page_size_px=(200, 150), bleed_px=20, background="#FFFFFF", regions=[
+        Region(id="n", kind="image", bbox=(0, -20, 200, 40), image_ref=ref, bleed=False)])
+    img = qt_renderer.render_page_to_image(page)
+    margin = img.pixelColor(100, 5)    # top bleed band -> clipped away -> bg
+    inside = img.pixelColor(100, 25)   # within trim (device y >= 20) -> red
+    assert margin.red() > 200 and margin.green() > 200
+    assert inside.red() > 200 and inside.green() < 80
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_bleed_render.py -q`
+Expected: FAIL — canvas is currently `200×150` and bleed is ignored.
+
+- [ ] **Step 3: Implement bleed-aware rendering**
+
+In `core/layout/qt_renderer.py`, give `build_scene` an optional `region_filter`:
+
+```python
+def build_scene(page: PageSpec, *, selectable: bool = False, style=None,
+                locked: bool = True, region_filter=None) -> QGraphicsScene:
+    pw, ph = page.page_size_px
+    scene = QGraphicsScene(0, 0, pw, ph)
+    scene.setBackgroundBrush(QBrush(QColor(_resolve_bg(page))))
+    regions = page.regions if region_filter is None else [r for r in page.regions if region_filter(r)]
+    for r in sorted(regions, key=lambda rr: rr.z):
+        if r.kind == "image":
+            _add_image_region(scene, r, selectable, locked=locked)
+        else:
+            _add_text_region(scene, r, selectable, project_style=style, locked=locked)
+    return scene
+```
+
+Replace `render_page_to_image` with a bleed-aware version:
+
+```python
+def render_page_to_image(page: PageSpec, *, style=None) -> QImage:
+    pw, ph = page.page_size_px
+    b = max(0, int(getattr(page, "bleed_px", 0) or 0))
+    cw, ch = pw + 2 * b, ph + 2 * b
+    img = QImage(cw, ch, QImage.Format_ARGB32)
+    img.fill(QColor(_resolve_bg(page)))
+    painter = QPainter(img)
+    painter.setRenderHint(QPainter.Antialiasing, True)
+    if b == 0:
+        scene = build_scene(page, style=style)
+        scene.render(painter, QRectF(0, 0, pw, ph), QRectF(0, 0, pw, ph))
+        painter.end()
+        return img
+    # Non-bleed regions are clipped to the trim box, offset into the bleed canvas.
+    painter.save()
+    painter.setClipRect(QRectF(b, b, pw, ph))
+    non_bleed = build_scene(page, style=style, region_filter=lambda r: not r.bleed)
+    non_bleed.render(painter, QRectF(b, b, pw, ph), QRectF(0, 0, pw, ph))
+    painter.restore()
+    # Bleed regions may extend into the surrounding margin: map the full bleed box
+    # in scene coords onto the whole canvas.
+    bleed_scene = build_scene(page, style=style, region_filter=lambda r: r.bleed)
+    bleed_scene.render(painter, QRectF(0, 0, cw, ch), QRectF(-b, -b, cw, ch))
+    painter.end()
+    return img
+```
+
+- [ ] **Step 4: Run the new test, then the full suite**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_bleed_render.py -q`
+Expected: PASS (3 passed).
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q`
+Expected: PASS — all green, including the original 166 (existing pages default `bleed_px=0`, so they hit the unchanged `b == 0` branch).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/qt_renderer.py tests/layout/test_bleed_render.py
+git commit -m "feat(layout): bleed-aware rendering on an extended canvas"
+```
+
+---
+
+## Notes / deliberately deferred (not gaps)
+- **PDF bleed:** `export_document_pdf` is left at trim size in #1; applying bleed to the PDF path is folded into the later page/export work. (PNG/`QImage` bleed — the testable acceptance criterion — is implemented here.)
+- **Editor authoring** of curves/vertices, **tiling/inset gutters**, **balloons**, and the **AI designer** emitting `path`/`segments` are sub-projects #2–#5 per the spec.
+- **`contain` centering:** the scaled pixmap is centered in the bbox for both fits; arbitrary alignment is not in scope.
+
+## Self-Review (completed by plan author)
+- **Spec coverage:** path geometry (T1), pure helpers (T2), serialization + normalize (T3), path builder (T4), image clip-to-shape + stroke/borderless (T5), text clip (T6), bleed (T7). All §3–§8 spec items map to a task; acceptance criteria 1–7 are each covered by a test.
+- **Placeholder scan:** none — every code/test step contains full content.
+- **Type/name consistency:** `PathSegment(type, pts)`, `Region.shape/segments/bleed`, `validate_segments`, `segments_bbox`, `region_to_painter_path`, `_RegionPathItem` are used identically across tasks.

--- a/Plans/2026-06-27-comic-layout-manual-editor-design.md
+++ b/Plans/2026-06-27-comic-layout-manual-editor-design.md
@@ -1,0 +1,186 @@
+# Comic Layout — Manual Editor: Region Geometry (sub-project #5a of 5)
+
+**Status:** Design approved 2026-06-27. Ready for implementation plan.
+**Branch:** `feat/comic-layout-geometry-core` (all comic-layout sub-projects share one branch).
+**PR gate:** Do NOT open a PR — the single PR comes only after the whole comic-layout feature (the last #5 phase) is done.
+
+## 1. Goal
+
+Give the Layout tab a **manual region-geometry editor** so a user can refine the
+panels that the AI designer (#4) or a tiling preset (#2) produced — without
+re-running the AI. #5a delivers the smallest useful editor plus the interactive-
+editing **foundation** that later phases build on:
+
+- **Move-only vertex & curve-handle drag** on existing `path` and `polygon`
+  panels — reshape a corner, bend a curved edge.
+- **Per-panel bleed / borderless toggles** (model-ready today; just needs UI).
+- **Editing foundation**: edit handles that survive the full-scene rebuild,
+  segment write-back, undo hooks, and a geometry inspector.
+
+Sub-project #5 is **phased**. This spec is **#5a (region geometry)**. Split/knife,
+merge, and delete are **#5b**; all overlay editing (balloon placement,
+tail→region snapping, SFX rotation, contour-aware wrapping) is **#5c**.
+
+## 2. Scope decisions (user-approved)
+
+| Decision | Choice |
+|----------|--------|
+| #5 decomposition | **Phase it — region geometry first** (#5a); overlay editing later (#5c) |
+| #5a workflow | **Refine existing layouts** — edit panels that already exist; no hand-drawing of new panels |
+| Vertex editing depth | **Move only** — drag existing anchor points and bezier control handles; segment count/types unchanged (no insert/delete, no line↔curve convert) |
+| Panel ops in #5a | **Bleed/borderless toggle only**; split/knife, merge, delete → **#5b** |
+| Live-editing model | **Editor-overlay controller** — a `GeometryEditor` layered on `CanvasWidget`; the pure renderer stays display-only |
+
+## 3. Current architecture (verified, with anchors)
+
+- **Scene is fully rebuilt on every change.** `LayoutTab._refresh` (`gui/layout/layout_tab.py:129`) → `CanvasWidget.load_page` (`gui/layout/canvas_widget.py:23`) → `qt_renderer.build_scene` (`core/layout/qt_renderer.py:359`). `load_page` calls `old.deleteLater()`, so **any handle item attached to the scene is destroyed on every refresh** — the central constraint #5a designs around.
+- **Coordinates: scene == page pixels.** `build_scene` creates `QGraphicsScene(0,0,pw,ph)`; `Region.bbox`/`points`/`segments` are page pixels. `CanvasWidget` applies a view transform via `fitInView` (`canvas_widget.py:37`), called **only on load** (not on resize). Mouse↔scene via `QGraphicsView.mapToScene`/`mapFromScene`.
+- **What is draggable today:** only text-region guide boxes (`_RegionRectItem`) when `selectable and not locked`. Image frames are `movable=False`. Overlays are not even selectable.
+- **Write-back gap (the deferred #5 carry-forward):** `_writeback_move` (`core/layout/qt_renderer.py:107`) persists a drag delta into `region.bbox` and (for polygons) `region.points`, but **never touches `region.segments`**. So translating a `path` region visually reverts on the next refresh (`region_to_painter_path` re-reads `segments`). The code comment tags this as #5's job.
+- **Reusable, Qt-free geometry:** `core/layout/geometry.py` — `segments_bbox(segments)`, `validate_segments(segments)`. `core/layout/qt_renderer.py` — `segments_to_painter_path`, `region_to_painter_path` (used to rebuild a panel's `QPainterPath` from the model). `PathSegment` point semantics: `move`/`line` = 1 anchor; `quad` = [control, end]; `cubic` = [c1, c2, end]; `close` = [].
+- **Undo:** `core/layout/history.py` — `History.append(prompt)` snapshots the current document; `LayoutTab.restore_snapshot` (`gui/layout/layout_tab.py:422`) restores + `_refresh`. The editor only needs to snapshot at the right moments.
+- **Model fields already present:** `Region.bbox/points/segments/shape/bleed/z/image_style` (`core/layout/models.py:116`); `ImageStyle.stroke_px` (`models.py:66`, `0` = borderless). No new model fields are needed for #5a.
+
+## 4. Architecture — `GeometryEditor` controller
+
+A new controller **`gui/layout/geometry_editor.py`**, owned by `LayoutTab`, layered
+on `CanvasWidget`. The renderer (`qt_renderer.py`) stays **display-only** — it gains
+no interaction logic. The controller owns all edit handles and drag handling.
+
+**Why a controller (not renderer-baked or incremental-scene):** keeps the pure
+renderer pure, isolates editing in one testable unit, and survives the full-scene
+rebuild by **regenerating handles from the model** after each build rather than
+trying to preserve scene state.
+
+**Lifecycle:**
+1. **Selection / activation.** Selecting a `path` or `polygon` region surfaces an
+   **"Edit shape"** toggle in the geometry inspector (§6). Toggling it on sets the
+   controller's `edit_region_id` and shows handles.
+2. **Handle (re)generation.** After every scene build (`_refresh` → `load_page`),
+   `LayoutTab` calls `geometry_editor.rebuild_handles()`. If an `edit_region_id`
+   is active, the controller looks up that region's `_RegionPathItem` (items carry
+   `setData(0, region_id)`), builds an **edit-point list** from the model, and adds
+   one `QGraphicsEllipseItem` handle per edit point (plus thin connector lines for
+   curve control points). Because handles are rebuilt from the model, they **survive
+   the rebuild**.
+3. **Drag (live).** On handle drag, the controller mutates the bound model point
+   (`region.segments[i].pts[j]` or `region.points[i]`) and updates the panel's path
+   item **in place** via `region_to_painter_path(region)` — **without** a full
+   `_refresh()`. A re-entrancy guard (`LayoutTab._suspend_refresh`, §7) blocks any
+   `_refresh` triggered mid-drag.
+4. **Commit (release).** On mouse-release: recompute `region.bbox`
+   (`geometry.segments_bbox` for path; bbox-of-points for polygon), run
+   `geometry.validate_segments` (path) and skip the commit + log if it returns
+   errors (degrade, never corrupt), **snapshot undo** (`history.append("edit shape:
+   <region>")`), then one `_refresh()` (which calls `rebuild_handles()` and so
+   re-lays the handles at their new positions).
+
+**Edit-point model.** The controller maps handles to model writes via a small list
+of edit-point descriptors `{scene_xy, kind, write(new_xy)}`:
+- **polygon** region → one anchor handle per `points[i]`.
+- **path** region → per segment: `move`/`line` → 1 anchor handle (`pts[0]`);
+  `quad` → anchor handle (`pts[1]` end) + 1 control handle (`pts[0]`); `cubic` →
+  anchor handle (`pts[2]` end) + 2 control handles (`pts[0]`, `pts[1]`). Control
+  handles render with a thin connector line to their associated anchor and are
+  visually distinct (e.g. hollow vs filled). `close` contributes no handle.
+Move-only: the list length and segment types never change during a #5a edit.
+
+## 5. Segment write-back foundation
+
+Close the deferred gap so a **whole-panel translate** drag of a `path` region also
+moves its `segments` (today only `bbox`/`points` are written, so path drags revert).
+
+- Add a pure, Qt-free helper to `core/layout/geometry.py`:
+  `translate_segments(segments, dx, dy) -> List[PathSegment]` (offsets every point
+  of every segment).
+- Extend `_writeback_move` (`qt_renderer.py:107`): when `region.shape == "path"` and
+  `region.segments`, set `region.segments = translate_segments(item._base_segments,
+  dx, dy)`. `_bind_region` captures `_base_segments` alongside `_base_bbox`/
+  `_base_points`. `bbox` continues to be updated from the translated geometry.
+
+This makes path panels translatable and gives the vertex tool a tested mutation
+primitive. (Whole-panel translate of a path region remains gated by the existing
+lock/`movable` rules — unchanged here.)
+
+## 6. Geometry inspector + bleed/borderless
+
+A new small widget **`gui/layout/geometry_inspector.py`**, shown when a region is
+selected (near the existing `ContentInspector`, which stays content/text-style only
+— clean separation). It exposes, for the selected region:
+- **Shape** (read-only label: rect / polygon / path).
+- **Bleed** checkbox → `Region.bleed`.
+- **Borderless** checkbox → `ImageStyle.stroke_px` (`0` when checked, a sensible
+  default when unchecked; creates a default `ImageStyle` if the region has none).
+- **Z-order** spin → `Region.z`.
+- **"Edit shape"** toggle (path/polygon only) → drives the `GeometryEditor`.
+
+Each control change writes the model, **snapshots undo** (`history.append`), and
+`_refresh()`es. The widget emits signals; `LayoutTab` performs the model writes
+(so the widget stays Qt-only UI with no model-mutation logic baked in).
+
+## 7. Coordinate / refresh handling
+
+- **Mouse↔model**: `QGraphicsView.mapToScene` / `mapFromScene` (scene == page px).
+- **Resize re-fit**: add a `resizeEvent` override to `CanvasWidget` that re-runs
+  `fitInView(scene.sceneRect(), Qt.KeepAspectRatio)` so handles stay aligned when
+  the widget resizes.
+- **Mid-drag refresh suppression**: a `LayoutTab._suspend_refresh` flag; `_refresh`
+  early-returns while set. The controller sets it on drag-start, clears it on
+  release (after the commit `_refresh`).
+
+## 8. Error handling / edge cases
+
+- **Invalid edit** — if a committed segment edit fails `validate_segments`, skip the
+  write-back, log via `logging.getLogger(__name__)`, and leave the model unchanged
+  (the live preview reverts on the commit `_refresh`). Never persist invalid
+  geometry; never crash.
+- **Stale `edit_region_id`** — if the active edit region is gone after a rebuild
+  (deleted by another path, snapshot restore), `rebuild_handles()` clears edit mode
+  and adds no handles.
+- **Non-path/polygon selection** — the "Edit shape" toggle is hidden/disabled for
+  `rect` regions (they keep their existing translate-drag; bbox is shown read-only).
+- **Empty / degenerate region** — a region whose `segments` produce an empty bbox is
+  left untouched and logged.
+
+## 9. Testing (headless, `QT_QPA_PLATFORM=offscreen`)
+
+Interaction logic lives in **directly-callable controller methods** (not synthetic
+Qt mouse events), so tests drive the model transitions, not the event loop:
+- `geometry.translate_segments` — pure unit tests (offsets all point types; round-trip).
+- `_writeback_move` for a `path` region — a translate updates `segments` (regression
+  for the deferred gap) and recomputes `bbox`.
+- `GeometryEditor` edit-point generation — a `path` region yields the right handle
+  count/positions (anchors + controls); a `polygon` yields one per vertex.
+- A handle-move method mutates the correct `segments[i].pts[j]` / `points[i]` and the
+  commit recomputes `bbox`; an edit that fails `validate_segments` is rejected.
+- `GeometryInspector` signals flip `Region.bleed` / `ImageStyle.stroke_px` / `Region.z`.
+- Undo: a committed edit appends exactly one `History` snapshot; restore returns the
+  pre-edit geometry.
+- Full layout suite stays green (baseline **276**; +N).
+
+## 10. Out of scope (deferred, not gaps)
+
+- **Split/knife, merge, delete** → **#5b** (reuses `polygon.clip_halfplane` /
+  `union_polygons`; the editor foundation from #5a carries over).
+- **Overlay editing** — balloon placement/drag, tail→region snapping, SFX rotation
+  (needs a new `Overlay.rotation` field), contour-aware wrapping → **#5c**.
+- **Stranded pixel-anchored overlays on a regions-only redesign** (carried from #4)
+  → lands with #5c overlay editing.
+- **PIL export still bypasses the Qt renderer/overlays** (carried from #1–#3) — the
+  biggest cross-cutting follow-up, after the editor phases.
+- **Vertex insert/delete, line↔curve conversion, rect-corner resize** — possible
+  #5b additions; not in #5a.
+
+## 11. Self-review (completed by author)
+
+- **Placeholder scan:** no TBD/TODO; every component names a concrete file, interface,
+  and the existing helper it reuses.
+- **Internal consistency:** the editor-overlay-controller choice (§4) is the answer to
+  the full-rebuild constraint (§3); handles regenerate from the model after each
+  rebuild, so "survive rebuild" is achieved by reconstruction, not preservation —
+  consistent throughout. Undo (§6/§9) reuses `History`; no second undo system.
+- **Scope check:** focused on one phase (region geometry, move-only, no split/merge/
+  delete); decomposition into #5a/#5b/#5c is explicit. Sized for a single plan.
+- **Ambiguity check:** vertex tool targets `path` + `polygon` only (rect keeps
+  translate-drag) — stated explicitly; "move only" defined as no insert/delete/convert;
+  borderless defined as `stroke_px == 0`.

--- a/Plans/2026-06-27-comic-layout-manual-editor-plan.md
+++ b/Plans/2026-06-27-comic-layout-manual-editor-plan.md
@@ -1,0 +1,1054 @@
+# Comic Layout — Manual Editor: Region Geometry (#5a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a manual region-geometry editor to the Layout tab — move-only vertex/curve-handle drag on existing `path`/`polygon` panels, per-panel bleed/borderless toggles — on top of an editing foundation (handles that survive the full-scene rebuild, segment write-back, a geometry inspector, undo via `History`).
+
+**Architecture:** A new `GeometryEditor` controller (`gui/layout/geometry_editor.py`) layered on `CanvasWidget`. The pure renderer stays display-only. Because `LayoutTab._refresh` rebuilds the whole scene on every change, the controller **regenerates edit handles from the model after each rebuild** — so handles survive refreshes by reconstruction, not preservation. A handle drag mutates the bound `region.segments[i].pts[j]`/`region.points[i]`, updates the panel's path item in place (no full refresh mid-drag), and the commit recomputes `bbox`, validates, snapshots undo, and refreshes.
+
+**Tech Stack:** Python 3.12, PySide6 (GUI), pytest. Reuses `core/layout/geometry.py` (`validate_segments`, `segments_bbox`), `core/layout/qt_renderer.py` (`region_to_painter_path`, `_RegionPathItem`, `_writeback_move`, `build_scene`), `core/layout/history.py` (`History.append`), and `core/layout/models.py` (`Region`, `PathSegment`, `ImageStyle`).
+
+## Global Constraints
+
+- Test interpreter: `.venv_linux/bin/python`. Run with `QT_QPA_PLATFORM=offscreen` prefixed (required for the GUI tests; harmless for the pure tests).
+- Full layout suite must stay green: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` (currently **276 passed** on branch `feat/comic-layout-geometry-core`).
+- **No new third-party dependency.**
+- `core/layout/geometry.py` stays **Qt-free** (importable headless). Qt code lives only in `gui/layout/` and `core/layout/qt_renderer.py`.
+- **All errors logged** (`logging.getLogger(__name__)`): an edit that fails `validate_segments` is reverted + logged, never persisted, never crashes.
+- **Scope:** move-only vertex/curve editing on `path`+`polygon` regions; rect regions keep their existing translate-drag. **No** vertex insert/delete, **no** line↔curve conversion, **no** split/knife/merge/delete (those are #5b), **no** overlay editing (#5c).
+- **Inspector/controller split:** UI widgets emit intent signals; `LayoutTab` owns all model mutation (same pattern as `ContentInspector`).
+- **Coordinates:** scene == page pixels. Handles carry their model point as `item.pos()`.
+- Conventional Commits (`feat(layout): …`). Commit after each task.
+- **Branch:** continue on `feat/comic-layout-geometry-core`. **Do NOT open a pull request** — the single PR comes only after the whole comic-layout feature is done.
+
+### Names used across tasks (keep identical)
+- `geometry.translate_segments(segments, dx, dy) -> List[PathSegment]` (Task 1).
+- `GeometryInspector` with signals `bleedToggled(str,bool)`, `borderlessToggled(str,bool)`, `zChanged(str,int)` (Task 3), plus `editShapeToggled(str,bool)` (Task 4); method `set_region(region)`. Module const `gui/layout/layout_tab.py:_DEFAULT_STROKE_PX = 4`.
+- `GeometryEditor(canvas, layout_tab)` with `set_edit_region(region_id|None)`, `rebuild_handles()`, `edit_points()`, `active_region_id()` (Task 4); `begin_edit()`, `move_handle(index, x, y)`, `commit()` (Task 5). Module fn `edit_points_for_region(region) -> List[_EditPoint]` (Task 4).
+- `LayoutTab.set_refresh_suspended(bool)` and `LayoutTab.snapshot_and_refresh(prompt)` (Task 5); `LayoutTab._find_region(region_id)` (exists).
+
+---
+
+### Task 1: `geometry.translate_segments` — pure segment-offset helper
+
+**Files:**
+- Modify: `core/layout/geometry.py`
+- Test: `tests/layout/test_geometry.py` (append; create if missing)
+
+**Interfaces:**
+- Consumes: `PathSegment` (`core.layout.models`).
+- Produces: `translate_segments(segments: List[PathSegment], dx: float, dy: float) -> List[PathSegment]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/layout/test_geometry.py` (create the file with this content if it does not exist — start it with `from core.layout.models import PathSegment` and `from core.layout.geometry import translate_segments`):
+
+```python
+from core.layout.models import PathSegment
+from core.layout.geometry import translate_segments
+
+
+def test_translate_segments_offsets_all_point_types():
+    segs = [
+        PathSegment(type="move", pts=[(10.0, 10.0)]),
+        PathSegment(type="line", pts=[(90.0, 10.0)]),
+        PathSegment(type="cubic", pts=[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]),
+        PathSegment(type="close", pts=[]),
+    ]
+    out = translate_segments(segs, 5.0, -2.0)
+    assert out[0].pts == [(15.0, 8.0)]
+    assert out[1].pts == [(95.0, 8.0)]
+    assert out[2].pts == [(6.0, 0.0), (8.0, 2.0), (10.0, 4.0)]
+    assert out[3].pts == []
+    assert [s.type for s in out] == ["move", "line", "cubic", "close"]
+
+
+def test_translate_segments_does_not_mutate_input():
+    segs = [PathSegment(type="move", pts=[(0.0, 0.0)])]
+    out = translate_segments(segs, 1.0, 1.0)
+    assert out[0] is not segs[0]
+    assert segs[0].pts == [(0.0, 0.0)]
+
+
+def test_translate_segments_zero_delta_keeps_values():
+    segs = [PathSegment(type="line", pts=[(3.0, 4.0)])]
+    assert translate_segments(segs, 0.0, 0.0)[0].pts == [(3.0, 4.0)]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_geometry.py -k translate -q`
+Expected: FAIL — `ImportError: cannot import name 'translate_segments'`.
+
+- [ ] **Step 3: Implement `translate_segments`**
+
+Append to `core/layout/geometry.py` (after `segments_bbox`):
+
+```python
+def translate_segments(segments: List[PathSegment], dx: float, dy: float) -> List[PathSegment]:
+    """Return NEW PathSegments with every point offset by (dx, dy).
+
+    Pure/Qt-free. The manual editor uses this to persist a whole-panel translate
+    drag into a path region's ``segments`` (the write-back gap deferred from #5)
+    and as the offset primitive for geometry edits. The input is never mutated.
+    """
+    return [
+        PathSegment(type=seg.type, pts=[(px + dx, py + dy) for (px, py) in seg.pts])
+        for seg in segments
+    ]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_geometry.py -q`
+Expected: PASS. Then full suite green: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` (expect ~279).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/geometry.py tests/layout/test_geometry.py
+git commit -m "feat(layout): translate_segments pure offset helper"
+```
+
+---
+
+### Task 2: segment write-back on a path-region translate drag
+
+**Files:**
+- Modify: `core/layout/qt_renderer.py` (`_RegionMoveMixin._bind_region` ~136, `_writeback_move` ~107)
+- Test: `tests/layout/test_writeback_move.py` (create)
+
+**Interfaces:**
+- Consumes: `geometry.translate_segments` (Task 1); `_RegionPathItem`, `region_to_painter_path` (`core.layout.qt_renderer`).
+- Produces: `_writeback_move` now persists a path region's `segments` (and `bbox`) on a translate; `_bind_region` captures `_base_segments`.
+
+Closes the gap flagged in `_writeback_move`'s NOTE: a `path` region drag currently writes only `bbox`, so it visually reverts on the next refresh (`region_to_painter_path` re-reads `segments`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_writeback_move.py`:
+
+```python
+from PySide6.QtWidgets import QGraphicsItem
+
+from core.layout.models import Region, PathSegment
+from core.layout import qt_renderer
+
+
+def _triangle():
+    return [
+        PathSegment(type="move", pts=[(10.0, 10.0)]),
+        PathSegment(type="line", pts=[(50.0, 10.0)]),
+        PathSegment(type="line", pts=[(50.0, 50.0)]),
+        PathSegment(type="close", pts=[]),
+    ]
+
+
+def test_writeback_translates_path_segments(qapp):
+    r = Region(id="p1", kind="image", shape="path", segments=_triangle(), bbox=(10, 10, 40, 40))
+    item = qt_renderer._RegionPathItem(qt_renderer.region_to_painter_path(r), r)
+    item.setFlag(QGraphicsItem.ItemSendsGeometryChanges, True)
+    item.setPos(5.0, -3.0)  # fires itemChange -> _writeback_move
+
+    assert r.segments[0].pts == [(15.0, 7.0)]
+    assert r.segments[1].pts == [(55.0, 7.0)]
+    assert r.segments[2].pts == [(55.0, 47.0)]
+    assert r.bbox == (15, 7, 40, 40)
+
+
+def test_writeback_rect_region_unchanged_behavior(qapp):
+    r = Region(id="t1", kind="text", shape="rect", bbox=(0, 0, 100, 40))
+    from PySide6.QtCore import QRectF
+    item = qt_renderer._RegionRectItem(QRectF(0, 0, 100, 40), r)
+    item.setFlag(QGraphicsItem.ItemSendsGeometryChanges, True)
+    item.setPos(7.0, 9.0)
+    assert r.bbox == (7, 9, 100, 40)  # translate-only, size unchanged
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_writeback_move.py -q`
+Expected: FAIL — `test_writeback_translates_path_segments` fails because `r.segments` is unchanged (only `bbox` is written today).
+
+- [ ] **Step 3: Capture `_base_segments` and write segments back for path regions**
+
+In `core/layout/qt_renderer.py`, extend `_bind_region` (currently ~136):
+
+```python
+    def _bind_region(self, region: Region) -> None:
+        self._region = region
+        self._base_bbox = tuple(region.bbox)
+        self._base_points = list(region.points)
+        self._base_segments = list(region.segments)
+```
+
+Replace `_writeback_move` (currently ~107) with (note the NOTE about the deferred gap is removed because it is now handled):
+
+```python
+def _writeback_move(item) -> None:
+    """Persist a drag into the bound region's geometry.
+
+    Handles carry their geometry in item-local coords with the item at scene
+    (0,0), so a drag shows up purely as ``item.pos()`` — the delta to apply to
+    the region's original geometry. For ``shape="path"`` regions the delta is
+    applied to ``segments`` (the geometry the renderer reads); rect/polygon
+    regions translate ``bbox`` and ``points``.
+    """
+    region = getattr(item, "_region", None)
+    if region is None:
+        return
+    dx, dy = item.x(), item.y()
+    bx, by, bw, bh = item._base_bbox
+    if region.shape == "path" and getattr(item, "_base_segments", None):
+        from core.layout.geometry import translate_segments
+        region.segments = translate_segments(item._base_segments, dx, dy)
+        region.bbox = (round(bx + dx), round(by + dy), bw, bh)
+        return
+    region.bbox = (round(bx + dx), round(by + dy), bw, bh)
+    if item._base_points:
+        region.points = [(round(px + dx), round(py + dy)) for px, py in item._base_points]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_writeback_move.py -q`
+Expected: PASS (2 passed). Full suite green: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` (expect ~281). Confirm the existing region/drag tests still pass (rect/polygon behavior unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/qt_renderer.py tests/layout/test_writeback_move.py
+git commit -m "feat(layout): writeback translates path-region segments on drag"
+```
+
+---
+
+### Task 3: `GeometryInspector` — bleed / borderless / z toggles
+
+**Files:**
+- Create: `gui/layout/geometry_inspector.py`
+- Modify: `gui/layout/layout_tab.py` (`_build` ~46, `_on_region_selected` ~224; add handlers + `_DEFAULT_STROKE_PX`)
+- Test: `tests/layout/test_geometry_inspector.py` (create)
+
+**Interfaces:**
+- Consumes: `Region`, `ImageStyle` (`core.layout.models`); `LayoutTab._find_region`, `LayoutTab.history`.
+- Produces: `GeometryInspector` with `set_region(region)` and signals `bleedToggled(str,bool)`, `borderlessToggled(str,bool)`, `zChanged(str,int)`; `LayoutTab._on_region_bleed_toggled/_on_region_borderless_toggled/_on_region_z_changed`; module const `_DEFAULT_STROKE_PX = 4`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_geometry_inspector.py`:
+
+```python
+from gui.layout.geometry_inspector import GeometryInspector
+from gui.layout.layout_tab import LayoutTab
+from core.layout.models import Region, ImageStyle
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def test_inspector_reflects_region_and_emits(qapp):
+    insp = GeometryInspector()
+    r = Region(id="p1", kind="image", shape="path", bbox=(0, 0, 100, 100),
+               bleed=True, z=3, image_style=ImageStyle(stroke_px=6))
+    insp.set_region(r)
+    assert insp.bleed_chk.isChecked() is True
+    assert insp.borderless_chk.isChecked() is False  # stroke 6 -> not borderless
+    assert insp.z_spin.value() == 3
+
+    seen = []
+    insp.bleedToggled.connect(lambda rid, b: seen.append(("bleed", rid, b)))
+    insp.bleed_chk.setChecked(False)
+    assert seen == [("bleed", "p1", False)]
+
+
+def test_layout_tab_geometry_handlers_write_model(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    page = tab.document.pages[0]
+    page.regions = [Region(id="p1", kind="image", shape="path", bbox=(0, 0, 100, 100),
+                           image_style=ImageStyle(stroke_px=6))]
+
+    tab._on_region_bleed_toggled("p1", True)
+    assert page.regions[0].bleed is True
+
+    tab._on_region_borderless_toggled("p1", True)
+    assert page.regions[0].image_style.stroke_px == 0
+    tab._on_region_borderless_toggled("p1", False)
+    assert page.regions[0].image_style.stroke_px == 4
+
+    tab._on_region_z_changed("p1", 12)
+    assert page.regions[0].z == 12
+
+
+def test_borderless_creates_image_style_when_absent(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    page = tab.document.pages[0]
+    page.regions = [Region(id="p1", kind="image", shape="path", bbox=(0, 0, 100, 100))]
+    tab._on_region_borderless_toggled("p1", False)
+    assert page.regions[0].image_style is not None
+    assert page.regions[0].image_style.stroke_px == 4
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_geometry_inspector.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'gui.layout.geometry_inspector'`.
+
+- [ ] **Step 3: Create `GeometryInspector`**
+
+Create `gui/layout/geometry_inspector.py`:
+
+```python
+"""Geometry inspector: per-region bleed / borderless / z toggles.
+
+Emits intent signals; ``LayoutTab`` owns the model mutation (same split as
+ContentInspector). The "Edit shape" toggle is added in #5a Task 4.
+"""
+from typing import Optional
+
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QCheckBox, QSpinBox,
+)
+from PySide6.QtCore import Signal
+
+from core.layout.models import Region
+
+
+class GeometryInspector(QWidget):
+    bleedToggled = Signal(str, bool)        # (region_id, bleed)
+    borderlessToggled = Signal(str, bool)   # (region_id, borderless)
+    zChanged = Signal(str, int)             # (region_id, z)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._region: Optional[Region] = None
+        self._build()
+        self.set_region(None)
+
+    def _build(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        self.header = QLabel("No region selected")
+        self.header.setStyleSheet("font-weight: bold;")
+        root.addWidget(self.header)
+
+        self.shape_label = QLabel("")
+        self.shape_label.setStyleSheet("color: #666; font-size: 11px;")
+        root.addWidget(self.shape_label)
+
+        self.bleed_chk = QCheckBox("Bleed (extend to page edge)")
+        self.bleed_chk.toggled.connect(self._on_bleed)
+        root.addWidget(self.bleed_chk)
+
+        self.borderless_chk = QCheckBox("Borderless (no panel stroke)")
+        self.borderless_chk.toggled.connect(self._on_borderless)
+        root.addWidget(self.borderless_chk)
+
+        z_row = QHBoxLayout()
+        z_row.addWidget(QLabel("Z-order:"))
+        self.z_spin = QSpinBox()
+        self.z_spin.setRange(-1000, 1000)
+        self.z_spin.valueChanged.connect(self._on_z)
+        z_row.addWidget(self.z_spin)
+        z_row.addStretch(1)
+        root.addLayout(z_row)
+
+    def set_region(self, region: Optional[Region]):
+        self._region = region
+        enabled = region is not None
+        for w in (self.bleed_chk, self.borderless_chk, self.z_spin):
+            w.setEnabled(enabled)
+        if region is None:
+            self.header.setText("No region selected")
+            self.shape_label.setText("")
+            return
+        self.header.setText(f"Geometry: {region.name or region.id}")
+        self.shape_label.setText(f"shape: {region.shape}")
+        stroke = region.image_style.stroke_px if region.image_style else 0
+        self.bleed_chk.blockSignals(True)
+        self.bleed_chk.setChecked(bool(region.bleed))
+        self.bleed_chk.blockSignals(False)
+        self.borderless_chk.blockSignals(True)
+        self.borderless_chk.setChecked(stroke == 0)
+        self.borderless_chk.blockSignals(False)
+        self.z_spin.blockSignals(True)
+        self.z_spin.setValue(int(region.z))
+        self.z_spin.blockSignals(False)
+
+    def _on_bleed(self, checked: bool):
+        if self._region is not None:
+            self.bleedToggled.emit(self._region.id, bool(checked))
+
+    def _on_borderless(self, checked: bool):
+        if self._region is not None:
+            self.borderlessToggled.emit(self._region.id, bool(checked))
+
+    def _on_z(self, value: int):
+        if self._region is not None:
+            self.zChanged.emit(self._region.id, int(value))
+```
+
+- [ ] **Step 4: Wire it into `LayoutTab`**
+
+In `gui/layout/layout_tab.py`:
+
+(a) Add a module-level constant near the top (after the imports block):
+
+```python
+_DEFAULT_STROKE_PX = 4  # panel stroke applied when "borderless" is unchecked
+```
+
+(b) In `_build`, after the `self.inspector = ContentInspector(...)` block and its `root.addWidget(self.inspector)` line, add:
+
+```python
+        from gui.layout.geometry_inspector import GeometryInspector
+        self.geometry_inspector = GeometryInspector()
+        self.geometry_inspector.bleedToggled.connect(self._on_region_bleed_toggled)
+        self.geometry_inspector.borderlessToggled.connect(self._on_region_borderless_toggled)
+        self.geometry_inspector.zChanged.connect(self._on_region_z_changed)
+        root.addWidget(self.geometry_inspector)
+```
+
+(c) In `_on_region_selected`, after the existing `self.inspector.set_region(region, text_style=ts)` line, add:
+
+```python
+        self.geometry_inspector.set_region(region)
+```
+
+(d) Add the three handlers (place them after `_on_region_text_style_changed`):
+
+```python
+    def _on_region_bleed_toggled(self, region_id: str, bleed: bool):
+        region = self._find_region(region_id)
+        if region is None:
+            return
+        region.bleed = bool(bleed)
+        if self.history is not None:
+            self.history.append(f"bleed: {region.name or region.id}")
+        self._refresh()
+
+    def _on_region_borderless_toggled(self, region_id: str, borderless: bool):
+        region = self._find_region(region_id)
+        if region is None:
+            return
+        from core.layout.models import ImageStyle
+        if region.image_style is None:
+            region.image_style = ImageStyle()
+        region.image_style.stroke_px = 0 if borderless else _DEFAULT_STROKE_PX
+        if self.history is not None:
+            self.history.append(f"borderless: {region.name or region.id}")
+        self._refresh()
+
+    def _on_region_z_changed(self, region_id: str, z: int):
+        region = self._find_region(region_id)
+        if region is None:
+            return
+        region.z = int(z)
+        if self.history is not None:
+            self.history.append(f"z: {region.name or region.id}")
+        self._refresh()
+```
+
+- [ ] **Step 5: Run tests + commit**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_geometry_inspector.py -q` → PASS (3 passed). Then full suite: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` → green (expect ~284), confirming the existing `test_layout_tab_designer_overlays.py` still constructs `LayoutTab` cleanly.
+
+```bash
+git add gui/layout/geometry_inspector.py gui/layout/layout_tab.py tests/layout/test_geometry_inspector.py
+git commit -m "feat(layout): geometry inspector with bleed/borderless/z toggles"
+```
+
+---
+
+### Task 4: `GeometryEditor` controller — edit handles that survive the rebuild
+
+**Files:**
+- Create: `gui/layout/geometry_editor.py`
+- Modify: `gui/layout/geometry_inspector.py` (add the "Edit shape" toggle + signal)
+- Modify: `gui/layout/layout_tab.py` (`_build`: create the editor + connect toggle; `_refresh`: call `rebuild_handles`; `_on_region_selected`: exit edit mode on selection change)
+- Test: `tests/layout/test_geometry_editor.py` (create)
+
+**Interfaces:**
+- Consumes: `region_to_painter_path` (`core.layout.qt_renderer`); `LayoutTab._find_region`, `LayoutTab.canvas`, `CanvasWidget.scene()`.
+- Produces: `edit_points_for_region(region) -> List[_EditPoint]` (each `_EditPoint` has `.x`, `.y`, `.is_control`, `.apply(x,y)`); `GeometryEditor(canvas, layout_tab)` with `set_edit_region(region_id|None)`, `rebuild_handles()`, `edit_points()`, `active_region_id()`; `_HandleItem` (visual handle; made draggable in Task 5). `GeometryInspector.editShapeToggled(str,bool)` signal + `edit_shape_chk`.
+
+This task makes handles **appear** at the right positions for the selected `path`/`polygon` region and survive a scene rebuild. Dragging is Task 5.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_geometry_editor.py`:
+
+```python
+from gui.layout.layout_tab import LayoutTab
+from gui.layout.geometry_editor import edit_points_for_region
+from core.layout.models import Region, PathSegment
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _diamond_path():
+    return Region(id="p1", kind="image", shape="path", bbox=(0, 0, 100, 100), segments=[
+        PathSegment(type="move", pts=[(50.0, 0.0)]),
+        PathSegment(type="line", pts=[(100.0, 50.0)]),
+        PathSegment(type="cubic", pts=[(80.0, 80.0), (60.0, 100.0), (50.0, 100.0)]),
+        PathSegment(type="close", pts=[]),
+    ])
+
+
+def test_edit_points_for_path_region():
+    pts = edit_points_for_region(_diamond_path())
+    # move(1 anchor) + line(1 anchor) + cubic(2 controls + 1 anchor) + close(0) = 5
+    assert len(pts) == 5
+    assert (pts[0].x, pts[0].y) == (50.0, 0.0)
+    assert pts[2].is_control is True and pts[3].is_control is True
+    assert pts[4].is_control is False and (pts[4].x, pts[4].y) == (50.0, 100.0)
+
+
+def test_edit_points_for_polygon_region():
+    r = Region(id="q1", kind="image", shape="polygon", points=[(0, 0), (40, 0), (40, 30)],
+               bbox=(0, 0, 40, 30))
+    pts = edit_points_for_region(r)
+    assert len(pts) == 3
+    assert all(not p.is_control for p in pts)
+    assert (pts[1].x, pts[1].y) == (40.0, 0.0)
+
+
+def test_edit_points_rect_region_empty():
+    r = Region(id="t1", kind="text", shape="rect", bbox=(0, 0, 50, 20))
+    assert edit_points_for_region(r) == []
+
+
+def test_handles_appear_and_survive_refresh(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = [_diamond_path()]
+    tab._refresh()
+    tab.geometry_editor.set_edit_region("p1")
+    assert len(tab.geometry_editor._handles) == 5
+    tab._refresh()  # full scene rebuild
+    assert len(tab.geometry_editor._handles) == 5  # regenerated, not lost
+
+
+def test_edit_mode_off_clears_handles(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = [_diamond_path()]
+    tab._refresh()
+    tab.geometry_editor.set_edit_region("p1")
+    tab.geometry_editor.set_edit_region(None)
+    assert tab.geometry_editor._handles == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_geometry_editor.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'gui.layout.geometry_editor'`.
+
+- [ ] **Step 3: Create `GeometryEditor`**
+
+Create `gui/layout/geometry_editor.py`:
+
+```python
+"""Manual region-geometry editor: vertex/curve handles layered on the canvas.
+
+The renderer rebuilds the whole scene on every refresh, so handles are
+regenerated from the model after each rebuild (see LayoutTab._refresh) rather
+than preserved. Move-only: handle generation here; dragging/commit is #5a Task 5.
+"""
+from typing import Callable, List, Optional
+
+from PySide6.QtWidgets import QGraphicsEllipseItem, QGraphicsItem
+from PySide6.QtGui import QBrush, QPen, QColor
+from PySide6.QtCore import QRectF
+
+from core.layout.qt_renderer import region_to_painter_path
+
+_HANDLE_R = 6.0  # handle radius in scene (page-pixel) units
+
+
+class _EditPoint:
+    """One draggable model point: its current position + how to write a new one."""
+    __slots__ = ("x", "y", "is_control", "apply")
+
+    def __init__(self, x: float, y: float, is_control: bool,
+                 apply: Callable[[float, float], None]):
+        self.x = x
+        self.y = y
+        self.is_control = is_control
+        self.apply = apply
+
+
+def edit_points_for_region(region) -> List["_EditPoint"]:
+    """Ordered editable points for a path|polygon region (rect -> [])."""
+    pts: List[_EditPoint] = []
+    if region.shape == "polygon":
+        for i in range(len(region.points)):
+            pts.append(_polygon_point(region, i))
+    elif region.shape == "path":
+        for seg in region.segments:
+            if seg.type in ("move", "line"):
+                pts.append(_seg_point(seg, 0, is_control=False))
+            elif seg.type == "quad":
+                pts.append(_seg_point(seg, 0, is_control=True))
+                pts.append(_seg_point(seg, 1, is_control=False))
+            elif seg.type == "cubic":
+                pts.append(_seg_point(seg, 0, is_control=True))
+                pts.append(_seg_point(seg, 1, is_control=True))
+                pts.append(_seg_point(seg, 2, is_control=False))
+            # close -> no handle
+    return pts
+
+
+def _polygon_point(region, i: int) -> "_EditPoint":
+    px, py = region.points[i]
+
+    def apply(x: float, y: float):
+        region.points[i] = (round(x), round(y))
+
+    return _EditPoint(float(px), float(py), False, apply)
+
+
+def _seg_point(seg, j: int, *, is_control: bool) -> "_EditPoint":
+    px, py = seg.pts[j]
+
+    def apply(x: float, y: float):
+        seg.pts[j] = (x, y)
+
+    return _EditPoint(float(px), float(py), is_control, apply)
+
+
+class _HandleItem(QGraphicsEllipseItem):
+    """A vertex/control handle. Visual in Task 4; made draggable in Task 5."""
+
+    def __init__(self, editor: "GeometryEditor", index: int):
+        super().__init__()
+        self._editor = editor
+        self._index = index
+
+
+class GeometryEditor:
+    """Owns the edit handles for one selected path/polygon region on a canvas."""
+
+    def __init__(self, canvas, layout_tab):
+        self._canvas = canvas
+        self._tab = layout_tab
+        self._edit_region_id: Optional[str] = None
+        self._points: List[_EditPoint] = []
+        self._handles: List[_HandleItem] = []
+        self._shape_item = None
+
+    def active_region_id(self) -> Optional[str]:
+        return self._edit_region_id
+
+    def edit_points(self) -> List[_EditPoint]:
+        return self._points
+
+    def set_edit_region(self, region_id: Optional[str]) -> None:
+        self._edit_region_id = region_id or None
+        self.rebuild_handles()
+
+    def rebuild_handles(self) -> None:
+        """Re-create handles from the model for the active region.
+
+        Call after every scene rebuild — handles are not preserved across the
+        renderer's full-scene rebuild, they are reconstructed here.
+        """
+        self._clear()
+        if not self._edit_region_id:
+            return
+        region = self._tab._find_region(self._edit_region_id)
+        if region is None or region.shape not in ("path", "polygon"):
+            self._edit_region_id = None
+            return
+        scene = self._canvas.scene()
+        if scene is None:
+            return
+        self._shape_item = self._find_shape_item(scene, region)
+        self._points = edit_points_for_region(region)
+        for idx, ep in enumerate(self._points):
+            h = _HandleItem(self, idx)
+            h.setRect(QRectF(-_HANDLE_R, -_HANDLE_R, 2 * _HANDLE_R, 2 * _HANDLE_R))
+            h.setPos(ep.x, ep.y)
+            h.setZValue(1_000_000)
+            h.setBrush(QBrush(QColor("#FFFFFF") if ep.is_control else QColor("#2D7DD2")))
+            h.setPen(QPen(QColor("#2D7DD2"), 1.5))
+            scene.addItem(h)
+            self._handles.append(h)
+
+    def _find_shape_item(self, scene, region):
+        for it in scene.items():
+            if getattr(it, "_region", None) is region and hasattr(it, "setPath"):
+                return it
+        return None
+
+    def _clear(self) -> None:
+        scene = self._canvas.scene()
+        if scene is not None:
+            for h in self._handles:
+                scene.removeItem(h)
+        self._handles = []
+        self._points = []
+        self._shape_item = None
+```
+
+- [ ] **Step 4: Add the "Edit shape" toggle to `GeometryInspector` and wire the editor in `LayoutTab`**
+
+(a) In `gui/layout/geometry_inspector.py`, add the signal (next to the other signals):
+
+```python
+    editShapeToggled = Signal(str, bool)    # (region_id, on)
+```
+
+In `_build`, after the z-order row, add an edit-shape checkbox:
+
+```python
+        self.edit_shape_chk = QCheckBox("Edit shape (drag vertices)")
+        self.edit_shape_chk.toggled.connect(self._on_edit_shape)
+        root.addWidget(self.edit_shape_chk)
+```
+
+Replace the **entire** `set_region` method (from Task 3) with the version below — it resets/enables the edit-shape toggle on every selection change (enabled only for path/polygon) and otherwise behaves identically to Task 3:
+
+```python
+    def set_region(self, region: Optional[Region]):
+        self._region = region
+        enabled = region is not None
+        for w in (self.bleed_chk, self.borderless_chk, self.z_spin):
+            w.setEnabled(enabled)
+        # Edit-shape applies only to vertex-bearing shapes; reset on every change.
+        self.edit_shape_chk.blockSignals(True)
+        self.edit_shape_chk.setChecked(False)
+        self.edit_shape_chk.setEnabled(bool(region and region.shape in ("path", "polygon")))
+        self.edit_shape_chk.blockSignals(False)
+        if region is None:
+            self.header.setText("No region selected")
+            self.shape_label.setText("")
+            return
+        self.header.setText(f"Geometry: {region.name or region.id}")
+        self.shape_label.setText(f"shape: {region.shape}")
+        stroke = region.image_style.stroke_px if region.image_style else 0
+        self.bleed_chk.blockSignals(True)
+        self.bleed_chk.setChecked(bool(region.bleed))
+        self.bleed_chk.blockSignals(False)
+        self.borderless_chk.blockSignals(True)
+        self.borderless_chk.setChecked(stroke == 0)
+        self.borderless_chk.blockSignals(False)
+        self.z_spin.blockSignals(True)
+        self.z_spin.setValue(int(region.z))
+        self.z_spin.blockSignals(False)
+```
+
+Add the handler:
+
+```python
+    def _on_edit_shape(self, checked: bool):
+        if self._region is not None:
+            self.editShapeToggled.emit(self._region.id, bool(checked))
+```
+
+(b) In `gui/layout/layout_tab.py` `_build`, immediately after the `self.canvas = CanvasWidget()` / `root.addWidget(self.canvas, 1)` lines, create the editor (it needs the canvas):
+
+```python
+        from gui.layout.geometry_editor import GeometryEditor
+        self.geometry_editor = GeometryEditor(self.canvas, self)
+```
+
+In the geometry-inspector wiring block (Task 3), add:
+
+```python
+        self.geometry_inspector.editShapeToggled.connect(self._on_region_edit_shape_toggled)
+```
+
+Add the handler (after the other geometry handlers):
+
+```python
+    def _on_region_edit_shape_toggled(self, region_id: str, on: bool):
+        self.geometry_editor.set_edit_region(region_id if on else None)
+```
+
+(c) In `_refresh`, after `self.canvas.load_page(...)`, regenerate handles (guarded so it is safe before the editor exists):
+
+```python
+    def _refresh(self):
+        if self.document and self.document.pages:
+            self.canvas.load_page(self.document.pages[0], self.document.style,
+                                  locked=self._locked)
+            self.status.setText(f"{self.document.title} — {self.document.pages[0].page_size_px}")
+            ge = getattr(self, "geometry_editor", None)
+            if ge is not None:
+                ge.rebuild_handles()
+        self.documentChanged.emit()
+```
+
+(d) In `_on_region_selected`, exit edit mode on any selection change (the inspector also unchecks its toggle in `set_region`). After `self.geometry_inspector.set_region(region)`:
+
+```python
+        self.geometry_editor.set_edit_region(None)
+```
+
+- [ ] **Step 5: Run tests + commit**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_geometry_editor.py -q` → PASS (5 passed). Full suite: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` → green (expect ~289).
+
+```bash
+git add gui/layout/geometry_editor.py gui/layout/geometry_inspector.py gui/layout/layout_tab.py tests/layout/test_geometry_editor.py
+git commit -m "feat(layout): geometry editor handles (regenerated across scene rebuild)"
+```
+
+---
+
+### Task 5: handle drag → live edit + commit (bbox, validate, undo, refresh)
+
+**Files:**
+- Modify: `gui/layout/geometry_editor.py` (`_HandleItem` drag events; `GeometryEditor.begin_edit/move_handle/commit`)
+- Modify: `gui/layout/layout_tab.py` (`set_refresh_suspended`, `snapshot_and_refresh`, `_refresh` suspend guard)
+- Modify: `gui/layout/canvas_widget.py` (`resizeEvent` re-fit)
+- Test: `tests/layout/test_geometry_editor_drag.py` (create)
+
+**Interfaces:**
+- Consumes: `geometry.validate_segments`, `geometry.segments_bbox`; `region_to_painter_path`; `LayoutTab._find_region`, `LayoutTab._refresh`, `LayoutTab.history`.
+- Produces: `GeometryEditor.begin_edit()`, `GeometryEditor.move_handle(index, x, y)`, `GeometryEditor.commit()`; `LayoutTab.set_refresh_suspended(bool)`, `LayoutTab.snapshot_and_refresh(prompt)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_geometry_editor_drag.py`:
+
+```python
+from gui.layout.layout_tab import LayoutTab
+from core.layout.models import Region, PathSegment
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tri():
+    return Region(id="p1", kind="image", shape="path", bbox=(10, 10, 40, 40), segments=[
+        PathSegment(type="move", pts=[(10.0, 10.0)]),
+        PathSegment(type="line", pts=[(50.0, 10.0)]),
+        PathSegment(type="line", pts=[(50.0, 50.0)]),
+        PathSegment(type="close", pts=[]),
+    ])
+
+
+def _editing_tab():
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = [_tri()]
+    tab._refresh()
+    tab.geometry_editor.set_edit_region("p1")
+    return tab
+
+
+def test_move_handle_mutates_segment_point(qapp):
+    tab = _editing_tab()
+    tab.geometry_editor.begin_edit()
+    tab.geometry_editor.move_handle(0, 20.0, 5.0)  # drag the 'move' anchor
+    seg0 = tab.document.pages[0].regions[0].segments[0]
+    assert seg0.pts == [(20.0, 5.0)]
+
+
+def test_commit_recomputes_bbox_and_snapshots(qapp):
+    tab = _editing_tab()
+    before = len(tab.history.snapshots())
+    tab.geometry_editor.begin_edit()
+    tab.geometry_editor.move_handle(2, 90.0, 90.0)  # move the 2nd line endpoint out
+    tab.geometry_editor.commit()
+    r = tab.document.pages[0].regions[0]
+    assert r.segments[2].pts == [(90.0, 90.0)]
+    assert r.bbox == (10, 10, 80, 80)  # segments_bbox over (10,10),(50,10),(90,90)
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_begin_edit_suspends_refresh_commit_resumes(qapp):
+    tab = _editing_tab()
+    tab.geometry_editor.begin_edit()
+    assert tab._suspend_refresh is True
+    tab.geometry_editor.commit()
+    assert tab._suspend_refresh is False
+
+
+def test_polygon_vertex_edit_commits(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = [Region(id="q1", kind="image", shape="polygon",
+                                            points=[(0, 0), (40, 0), (40, 30)], bbox=(0, 0, 40, 30))]
+    tab._refresh()
+    tab.geometry_editor.set_edit_region("q1")
+    tab.geometry_editor.begin_edit()
+    tab.geometry_editor.move_handle(2, 60.0, 50.0)
+    tab.geometry_editor.commit()
+    r = tab.document.pages[0].regions[0]
+    assert r.points[2] == (60, 50)
+    assert r.bbox == (0, 0, 60, 50)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_geometry_editor_drag.py -q`
+Expected: FAIL — `AttributeError: 'GeometryEditor' object has no attribute 'begin_edit'`.
+
+- [ ] **Step 3: Add the `LayoutTab` refresh plumbing**
+
+In `gui/layout/layout_tab.py`:
+
+(a) At the top of `_refresh`, honor a suspend flag:
+
+```python
+    def _refresh(self):
+        if getattr(self, "_suspend_refresh", False):
+            return
+        if self.document and self.document.pages:
+            self.canvas.load_page(self.document.pages[0], self.document.style,
+                                  locked=self._locked)
+            self.status.setText(f"{self.document.title} — {self.document.pages[0].page_size_px}")
+            ge = getattr(self, "geometry_editor", None)
+            if ge is not None:
+                ge.rebuild_handles()
+        self.documentChanged.emit()
+```
+
+(b) Add the two helpers (after `_refresh`):
+
+```python
+    def set_refresh_suspended(self, on: bool):
+        """Block scene rebuilds during an active handle drag (else handles vanish)."""
+        self._suspend_refresh = bool(on)
+
+    def snapshot_and_refresh(self, prompt: str):
+        if self.history is not None:
+            self.history.append(prompt)
+        self._refresh()
+```
+
+- [ ] **Step 4: Add drag + commit to `GeometryEditor` and make `_HandleItem` interactive**
+
+In `gui/layout/geometry_editor.py`:
+
+(a) Make `_HandleItem` draggable and route its events to the editor:
+
+```python
+class _HandleItem(QGraphicsEllipseItem):
+    """A vertex/control handle. Dragging mutates the bound model point."""
+
+    def __init__(self, editor: "GeometryEditor", index: int):
+        super().__init__()
+        self._editor = editor
+        self._index = index
+        self.setFlag(QGraphicsItem.ItemIsMovable, True)
+        self.setFlag(QGraphicsItem.ItemSendsGeometryChanges, True)
+
+    def mousePressEvent(self, event):
+        self._editor.begin_edit()
+        super().mousePressEvent(event)
+
+    def itemChange(self, change, value):
+        if change == QGraphicsItem.ItemPositionHasChanged:
+            self._editor.move_handle(self._index, self.x(), self.y())
+        return super().itemChange(change, value)
+
+    def mouseReleaseEvent(self, event):
+        super().mouseReleaseEvent(event)
+        self._editor.commit()
+```
+
+(b) Add `begin_edit`, `move_handle`, and `commit` to `GeometryEditor` (and an `_pre` field — initialize `self._pre = None` in `__init__`):
+
+```python
+    def begin_edit(self) -> None:
+        """Snapshot pre-edit geometry (for validation revert) and freeze refreshes."""
+        region = self._tab._find_region(self._edit_region_id) if self._edit_region_id else None
+        if region is None:
+            self._pre = None
+            return
+        self._pre = (
+            [type(s)(type=s.type, pts=list(s.pts)) for s in region.segments],
+            list(region.points),
+            tuple(region.bbox),
+        )
+        self._tab.set_refresh_suspended(True)
+
+    def move_handle(self, index: int, x: float, y: float) -> None:
+        """Apply a handle's new scene position to the model + live-update the path."""
+        if not (0 <= index < len(self._points)):
+            return
+        self._points[index].apply(x, y)
+        region = self._tab._find_region(self._edit_region_id) if self._edit_region_id else None
+        if region is not None and self._shape_item is not None:
+            self._shape_item.setPath(region_to_painter_path(region))
+
+    def commit(self) -> None:
+        """Persist the edit: validate, recompute bbox, snapshot, refresh."""
+        self._tab.set_refresh_suspended(False)
+        region = self._tab._find_region(self._edit_region_id) if self._edit_region_id else None
+        if region is None:
+            self._pre = None
+            return
+        from core.layout.geometry import validate_segments, segments_bbox
+        if region.shape == "path":
+            issues = validate_segments(region.segments)
+            if issues:
+                import logging
+                logging.getLogger(__name__).warning(
+                    "Geometry edit on %s produced invalid segments; reverting: %s",
+                    region.id, "; ".join(issues))
+                if self._pre is not None:
+                    region.segments, region.points, region.bbox = self._pre
+                self._pre = None
+                self._tab._refresh()
+                return
+            bx, by, bw, bh = segments_bbox(region.segments)
+            region.bbox = (round(bx), round(by), round(bw), round(bh))
+        elif region.shape == "polygon" and region.points:
+            xs = [p[0] for p in region.points]
+            ys = [p[1] for p in region.points]
+            region.bbox = (min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys))
+        self._pre = None
+        self._tab.snapshot_and_refresh(f"edit shape: {region.name or region.id}")
+```
+
+Also add `self._pre = None` to `GeometryEditor.__init__` (next to the other instance attrs).
+
+- [ ] **Step 5: Add `resizeEvent` re-fit to `CanvasWidget`**
+
+In `gui/layout/canvas_widget.py`, add (so handles stay aligned when the widget resizes):
+
+```python
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        scene = self.scene()
+        if scene is not None:
+            self.fitInView(scene.sceneRect(), Qt.KeepAspectRatio)
+```
+
+- [ ] **Step 6: Run tests + commit**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_geometry_editor_drag.py -q` → PASS (4 passed). Then the FULL suite: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` → all green (expect ~293).
+
+```bash
+git add gui/layout/geometry_editor.py gui/layout/layout_tab.py gui/layout/canvas_widget.py tests/layout/test_geometry_editor_drag.py
+git commit -m "feat(layout): vertex/curve handle drag with commit (bbox, validate, undo)"
+```
+
+---
+
+## Notes / deliberately deferred (not gaps)
+- **Split/knife, merge, delete** → **#5b** (reuse `polygon.clip_halfplane` / `union_polygons`; this task's editor foundation carries over).
+- **Overlay editing** — balloon placement/drag, tail→region snapping, SFX rotation (new `Overlay.rotation` field), contour-aware wrapping → **#5c**. The #4 carry-forward (stranded pixel-anchored overlays on a regions-only redesign) lands with #5c.
+- **PIL export still bypasses the Qt renderer/overlays** (carried from #1–#3) — biggest cross-cutting follow-up, after the editor phases.
+- **Vertex insert/delete, line↔curve conversion, rect-corner resize** — possible #5b additions; not #5a.
+- **Content/text-style edits still don't snapshot undo** (pre-existing). #5a adds snapshots for geometry edits only; harmonizing content-edit undo is out of scope.
+
+## Self-Review (completed by plan author)
+- **Spec coverage:** editing foundation = handle regeneration across rebuild (Task 4 `rebuild_handles` + `_refresh` hook) + segment write-back (Task 2) + undo (Task 5 `snapshot_and_refresh`) + geometry inspector (Task 3); move-only vertex/curve drag (Tasks 4–5, `edit_points_for_region` covers move/line/quad/cubic anchors + controls, polygon vertices); bleed/borderless toggles (Task 3). Every design §4–§9 item maps to a task; error path (invalid segments → revert + log) is Task 5 `commit`.
+- **Placeholder scan:** no TBD/TODO; every code step shows complete code; the degrade path is concrete (`validate_segments` → restore `self._pre` + `logger.warning`).
+- **Type/name consistency:** `translate_segments` (T1) consumed by `_writeback_move` (T2); `edit_points_for_region`/`_EditPoint.apply` (T4) consumed by `move_handle` (T5); `GeometryEditor.set_edit_region/rebuild_handles` (T4) called from `LayoutTab._refresh`/`_on_region_edit_shape_toggled`; `set_refresh_suspended`/`snapshot_and_refresh` (T5) called from `GeometryEditor.begin_edit`/`commit`; signal names (`bleedToggled`/`borderlessToggled`/`zChanged`/`editShapeToggled`) match between `GeometryInspector` and `LayoutTab` connects. `region_to_painter_path`, `_RegionPathItem`, `_writeback_move`, `segments_bbox`, `validate_segments`, `History.append`, `ImageStyle.stroke_px`, `Region.points/segments/bbox/bleed/z` all match the real signatures.
+- **Test interpreter/baseline:** all tasks use `.venv_linux/bin/python` under `QT_QPA_PLATFORM=offscreen`; suite 276 → ~293 (3+2+3+5+4 = 17 new tests; counts approximate — the binding check is "all new tests pass and the full suite stays green").

--- a/Plans/2026-06-27-comic-layout-text-overlays-design.md
+++ b/Plans/2026-06-27-comic-layout-text-overlays-design.md
@@ -1,0 +1,312 @@
+# Comic Layout — Text Overlays Design (sub-project #3 of 5)
+
+**Status:** Approved — ready for implementation plan
+**Last Updated:** 2026-06-27 15:37
+**Branch:** `feat/comic-layout-geometry-core` (all 5 comic-layout sub-projects share one branch)
+**PR gate:** Do **NOT** open a PR — the single PR comes only after sub-project #5.
+
+## 1. Overview
+
+Sub-project #3 adds **comic text overlays** — tailed speech balloons, thought
+bubbles, caption boxes, and SFX (sound-effect) lettering — that float above the
+panels produced by #1 (geometry/render core) and #2 (tiling engine).
+
+It is built as a **pure, testable core plus a thin Qt render layer**, exactly
+like #1 and #2. Authoring (AI generation, manual drag-editing) is **out of
+scope** and deferred to #4 (AI designer) and #5 (manual editor). #3 delivers the
+data model, the pure balloon-geometry module, the rendering pass, serialization,
+and tests.
+
+### Goals
+- A declarative `Overlay` data model (Qt-free, serializable) for the four
+  overlay kinds: `speech`, `thought`, `caption`, `sfx`.
+- A pure, Qt-free `core/layout/balloons.py` that compiles an overlay's inner
+  content rectangle (+ optional tail target) into `PathSegment` geometry that
+  the existing renderer draws unchanged.
+- A renderer overlay pass that auto-fits each balloon to its wrapped text
+  (measuring with Qt font metrics), draws the body fill + stroke + tail, and
+  draws the wrapped text clipped to the body.
+- Serialization round-trip and comprehensive tests (pure + headless Qt).
+
+### Non-goals (deferred)
+- **AI authoring (#4)** and **manual drag-editing UI (#5).**
+- **Tail-to-region/character snapping** — the tail points at a free target
+  point; snapping is #5.
+- **Contour-aware text wrapping** — text wraps within the inner *rectangle*
+  inside the body (the standard for the overwhelming majority of comic
+  balloons), not following the oval/cloud contour.
+- **SFX rotation / warping** — SFX is styled display text at its anchor; rotated
+  and path-warped SFX is #5.
+- **PIL export parity** — overlays render through the Qt renderer
+  (`qt_renderer.py`). The legacy PIL export path (`gui/layout/export_dialog.py`
+  → `core/layout/engine.py`) will **not** show overlays. This is the same
+  known PIL/Qt divergence carried from #1 and #2; #3 does not fix it (a future
+  export-migration task does).
+
+## 2. Architecture
+
+Three layers, mirroring #1/#2's pure-core + render split:
+
+| Layer | File | Qt? | Responsibility |
+|---|---|---|---|
+| **Model** | `core/layout/models.py` | No | `Overlay` + `OverlayStyle` dataclasses; `PageSpec.overlays: List[Overlay]` |
+| **Geometry** | `core/layout/balloons.py` *(new)* | No (pure) | Build body + tail `PathSegment`s from an explicit inner rect + tail target |
+| **Render** | `core/layout/qt_renderer.py` | Yes | Overlay pass: measure wrapped text → inner rect → `balloons` → draw fill/stroke/tail + wrapped text |
+| **Serialize** | `core/layout/schema.py` | No | `overlay_to_dict`/`overlay_from_dict`; `overlays` in PageSpec round-trip + JSON schema entry |
+
+### Data flow
+```
+Overlay (declarative)                          [Qt-free authoring artifact, on PageSpec.overlays]
+   │
+   ├─ renderer overlay pass (qt_renderer, has Qt):
+   │     1. resolve text style (effective_text_style: role / text_style)
+   │     2. MEASURE wrapped text at style.max_width_px  → (text_w, text_h)   [QFontMetrics/QTextLayout]
+   │     3. inner_rect = (text block + style.padding_px) placed at anchor (center|topleft)
+   │     4. segs = balloons.overlay_to_segments(kind, inner_rect, tail_target, style)   [PURE]
+   │     5. QPainterPath(segs) → fill style.fill, stroke stroke_px/stroke_color
+   │     6. draw wrapped text (QGraphicsTextItem, setTextWidth = inner width) clipped to body
+   │     7. z-order: overlays drawn after all regions, sorted by Overlay.z
+   ▼
+rendered page (overlays above panels)
+```
+
+The **pure/Qt boundary** is the central design decision (user-approved): font
+measurement (which needs Qt or PIL) lives in the renderer where Qt already
+exists; `balloons.py` takes an already-computed inner rectangle and stays
+Qt-free and unit-testable headless — exactly as `polygon.py`/`tiling.py` are.
+
+## 3. Data model (`core/layout/models.py`)
+
+New dataclasses (Qt-free, defaults set so `schema._filtered` keeps
+forward/backward compatibility):
+
+```python
+@dataclass
+class OverlayStyle:
+    fill: str = "#FFFFFF"          # body interior color
+    stroke_px: float = 2.0         # body outline width (0 = no outline)
+    stroke_color: str = "#000000"
+    padding_px: float = 10.0       # text inset between inner text box and body edge
+    radius_px: float = 16.0        # corner roundness (speech) / scallop radius (thought)
+    max_width_px: float = 240.0    # wrap-width cap for auto-fit measurement
+
+@dataclass
+class Overlay:
+    id: str
+    kind: Literal["speech", "thought", "caption", "sfx"]
+    text: str
+    anchor: Tuple[float, float]                        # body placement (page px)
+    anchor_mode: Literal["center", "topleft"] = "center"
+    tail_target: Optional[Tuple[float, float]] = None  # free point the tail points at; None = no tail
+    z: int = 0
+    role: str = ""                                     # "dialogue"/"caption"/"sfx" → styles.py roles
+    text_style: Optional[TextStyle] = None             # overrides role (reuse effective_text_style)
+    style: OverlayStyle = field(default_factory=OverlayStyle)
+```
+
+`PageSpec` gains one field:
+```python
+    overlays: List[Overlay] = field(default_factory=list)
+```
+
+**Style resolution** reuses the existing `styles.effective_text_style` logic.
+Because that resolver currently takes a `Region`, #3 adds a small overlay-aware
+variant (or generalizes the lookup) so an `Overlay`'s `role`/`text_style`
+resolve through the same precedence: `overlay.text_style` > role lookup >
+`project_style.default_text_role`. The four comic roles
+(`dialogue`, `sfx`, `caption`, `logo_title`) already exist in `styles.py`; a
+`thought` role is **not** added — thought bubbles reuse `dialogue` (italic can
+be set via `text_style` if desired).
+
+### Default role per kind
+When `overlay.role == ""`, the renderer applies a kind default:
+`speech`/`thought` → `dialogue`, `caption` → `caption`, `sfx` → `sfx`.
+
+## 4. `core/layout/balloons.py` — pure geometry
+
+All functions are pure, Qt-free, and return `List[PathSegment]` whose every
+element passes `geometry.validate_segments`. Coordinates are page pixels
+(floats). Reuses `polygon_to_segments` from `polygon.py`; adds curve emitters
+that produce `quad`/`cubic` segments (already supported by `PathSegment` and
+`region_to_painter_path`).
+
+```python
+Point = Tuple[float, float]
+Rect  = Tuple[float, float, float, float]   # (x, y, w, h)
+
+def caption_body(inner: Rect) -> List[PathSegment]:
+    """Plain rectangle (move + 3 lines + close) inset by nothing — caption box."""
+
+def speech_body(inner: Rect, *, radius: float) -> List[PathSegment]:
+    """Rounded rectangle around `inner`, corners as cubic beziers."""
+
+def thought_body(inner: Rect, *, scallop: float) -> List[PathSegment]:
+    """Scalloped 'cloud' around `inner`: a ring of outward quad-bezier bumps."""
+
+def speech_tail(body: List[Point], target: Point, *, base_width: float) -> List[Point]:
+    """Return body outline (as points) with a triangular tail spliced in at the
+    edge nearest `target`, so body+tail is ONE closed ring."""
+
+def thought_trail(body_center: Point, target: Point, *, count: int = 3) -> List[PathSegment]:
+    """A trail of `count` shrinking ellipses from body toward `target`, each a
+    closed subpath (move + cubics + close)."""
+
+def overlay_to_segments(kind: str, inner: Rect, tail_target: Optional[Point],
+                        style: "OverlayStyle") -> List[PathSegment]:
+    """Top-level: build the body for `kind`, splice/append the tail when
+    `tail_target` is set, and return the full PathSegment list.
+      - speech : rounded body with triangular tail spliced into the outline
+      - thought: cloud body + thought_trail ellipses appended as subpaths
+      - caption: rectangle, tail ignored
+      - sfx    : returns [] (no body; text-only)
+    """
+```
+
+### Tail construction
+- **Speech**: the tail is a triangle from two points on the body edge nearest
+  the target out to the target tip. To keep a clean single outline (one stroke
+  around the whole shape, no line across the join), the tail is **spliced into
+  the body ring**: the body is approximated as a point ring (curved corners
+  flattened only for the splice computation — the emitted body keeps its
+  curves), the nearest straight edge is found, and the two base points + tip are
+  inserted there. Because the speech body is a rounded rect, the tail attaches on
+  one of the four straight edge spans between corner arcs. The result is emitted
+  as a single closed path: straight/curved body spans + the tail detour.
+- **Thought**: no spliced tail; instead `thought_trail` emits separate small
+  closed ellipse subpaths marching toward the target (the classic "...oOo"
+  thought trail). Each ellipse is its own `move…cubic…close` subpath in the same
+  segment list (multiple subpaths are valid: each starts with `move`).
+
+### Validity guarantees
+- Every returned list starts with `move` and each subpath closes with `close`.
+- `inner ⊆ bbox(body)` (the body strictly contains the text rect; padding makes
+  this hold by construction).
+- Degenerate inputs (zero/negative inner size) are logged via
+  `logging.getLogger(__name__)` and produce an empty list rather than crashing.
+
+## 5. Rendering (`core/layout/qt_renderer.py`)
+
+A new `_add_overlay(scene, ov: Overlay, project_style, ...)` and an overlay loop
+appended to the existing scene build:
+
+1. Resolve `TextStyle` for the overlay (role/text_style precedence; kind default
+   role).
+2. **Measure** the wrapped text: lay `ov.text` into a `QTextLayout` (or
+   `QFontMetrics.boundingRect` with word wrap) at width
+   `min(style.max_width_px, …)`; obtain `(text_w, text_h)`.
+3. Compute `inner_rect = (text_w + 2·padding, text_h + 2·padding)` placed at
+   `ov.anchor` per `anchor_mode` (`center` centers the body on the anchor;
+   `topleft` puts the body's top-left at the anchor).
+4. `segs = balloons.overlay_to_segments(ov.kind, inner_rect, ov.tail_target, ov.style)`.
+5. Build a `QPainterPath` from `segs` (reuse the segment→path logic already in
+   `region_to_painter_path`; refactor a shared `segments_to_painter_path(segs)`
+   helper if cleaner). Fill with `style.fill`; stroke with
+   `QPen(style.stroke_color, style.stroke_px)` when `stroke_px > 0`.
+6. Draw the wrapped text: a `QGraphicsTextItem` with `setTextWidth(inner_w)`,
+   positioned inside the inner rect, clipped to the body path
+   (`ItemClipsChildrenToShape` on a path item parent — same pattern the region
+   text path already uses).
+7. **SFX**: skip the body; draw the display text at `ov.anchor` using the `sfx`
+   role style. An optional outline (common for SFX) is drawn with
+   `QPainterPathStroker` around the glyph path; if that proves heavy, MVP draws
+   filled text only and the outline is a Minor follow-up.
+8. **Z-order**: overlays are drawn **after** all regions and sorted by `ov.z`,
+   so they always sit above the panels.
+
+`render_page_to_image` and the live `build_scene` both iterate
+`page.overlays` after `page.regions`. No change to how regions render.
+
+**No new production geometry in the renderer** beyond the measure step and the
+overlay loop — the body/tail geometry all comes from the pure `balloons.py`.
+
+## 6. Serialization (`core/layout/schema.py`)
+
+- `overlay_to_dict(ov) -> dict` and `overlay_from_dict(d) -> Overlay`
+  (and nested `OverlayStyle`), mirroring `region_to_dict`/`region_from_dict`.
+- `PageSpec` serialization includes the `overlays` array.
+- A `OVERLAY_JSON_SCHEMA` fragment is added and referenced from the page schema.
+- `_filtered` keeps unknown-key tolerance; all new fields have defaults so older
+  files (no `overlays`) load as an empty overlay list.
+
+## 7. Testing
+
+All tests run under `QT_QPA_PLATFORM=offscreen` with `.venv_linux/bin/python`.
+The full layout suite must stay green (currently **222 passed** on the branch).
+
+- **`tests/layout/test_balloons.py`** (pure, no Qt):
+  - `caption_body` → exactly a rectangle (4 corners; `validate_segments == []`).
+  - `speech_body` → valid; `inner ⊆ bbox`; contains cubic segments (rounded).
+  - `thought_body` → valid; `inner ⊆ bbox`; contains quad segments (scallops).
+  - `overlay_to_segments("speech", …, target)` → single closed ring whose bbox
+    reaches toward the target (tail tip is the extreme point in the target's
+    direction); without a target → no tail.
+  - `overlay_to_segments("thought", …, target)` → body + N extra closed
+    subpaths (trail), each valid; trail marches toward target.
+  - `overlay_to_segments("sfx", …)` → `[]`.
+  - Degenerate inner rect → `[]` + a logged warning (caplog).
+- **`tests/layout/test_overlay_schema.py`**: `Overlay` (each kind, with/without
+  tail, custom `OverlayStyle`) round-trips byte-stable through
+  `overlay_to_dict`/`overlay_from_dict`; a `PageSpec` with overlays round-trips;
+  an old dict without `overlays` loads to `[]`.
+- **`tests/layout/test_overlay_render.py`** (Qt, offscreen, uses the existing
+  `qapp` fixture):
+  - A page with one speech overlay renders: a pixel inside the body is
+    `style.fill` (white-ish), a pixel well outside is page background, text
+    pixels are present (non-fill) inside the body.
+  - The tail extends toward `tail_target` (a body pixel exists between body
+    center and target).
+  - Two overlays with different `z` paint in the right order (higher z on top
+    where they overlap).
+  - A caption overlay renders as a filled rect with text; an SFX overlay renders
+    text with no body fill around it.
+
+## 8. Module/interface summary (for the plan)
+
+| Symbol | File | Signature |
+|---|---|---|
+| `OverlayStyle` | models.py | dataclass (fill, stroke_px, stroke_color, padding_px, radius_px, max_width_px) |
+| `Overlay` | models.py | dataclass (id, kind, text, anchor, anchor_mode, tail_target, z, role, text_style, style) |
+| `PageSpec.overlays` | models.py | `List[Overlay]` |
+| `caption_body` | balloons.py | `(inner) -> List[PathSegment]` |
+| `speech_body` | balloons.py | `(inner, *, radius) -> List[PathSegment]` |
+| `thought_body` | balloons.py | `(inner, *, scallop) -> List[PathSegment]` |
+| `thought_trail` | balloons.py | `(body_center, target, *, count) -> List[PathSegment]` |
+| `overlay_to_segments` | balloons.py | `(kind, inner, tail_target, style) -> List[PathSegment]` |
+| `_add_overlay` | qt_renderer.py | overlay render pass (measure → balloons → draw) |
+| `segments_to_painter_path` | qt_renderer.py | shared `(segs) -> QPainterPath` (refactor) |
+| `overlay_to_dict` / `overlay_from_dict` | schema.py | `Overlay ⇄ dict` |
+
+## 9. Acceptance criteria
+1. `Overlay`/`OverlayStyle` exist; `PageSpec.overlays` defaults to `[]`; all
+   Qt-free and serializable.
+2. `balloons.py` is Qt-free; each body/tail builder emits `validate_segments`-
+   clean `PathSegment`s; `inner ⊆ body bbox`; degenerate input logs + returns
+   `[]`.
+3. The four kinds render through `qt_renderer` (speech body+tail, thought
+   body+trail, caption rect, sfx text), with auto-fit to wrapped text.
+4. Overlays paint above panels, ordered by `z`.
+5. Overlays round-trip through `schema.py`; old files without `overlays` load
+   cleanly.
+6. No renderer change to how *regions* render; no new third-party dependency;
+   `balloons.py` and `models.py`/`schema.py` stay Qt-free.
+7. Full layout suite green (222 + new tests), pristine output.
+
+## 10. Self-review
+- **Placeholder scan:** none — every section is concrete; the only optional/MVP
+  items (SFX outline pen) are explicitly marked as Minor follow-ups, not gaps.
+- **Internal consistency:** the pure/Qt boundary is consistent throughout —
+  measurement is always in the renderer, geometry always in `balloons.py`. The
+  data model, geometry signatures, render steps, and serialization all reference
+  the same field names (`kind`, `anchor`, `tail_target`, `style.*`).
+- **Scope:** single sub-project, single implementation plan; authoring deferred
+  to #4/#5; export divergence explicitly out of scope.
+- **Ambiguity:** tail construction (spliced single path for speech; separate
+  trail subpaths for thought), wrap-within-rect, default-role-per-kind, and
+  z-order are each pinned to one interpretation.
+
+## 11. Relationship to the feature
+Builds on #1 (`Region`/`PathSegment`/`qt_renderer`/`schema`/`validate_segments`)
+and #2 (`polygon_to_segments`). Produces the overlay substrate that #4 (AI
+designer emits `Overlay`s) and #5 (manual editor authors/drag-edits `Overlay`s,
+adds tail snapping + SFX rotation + contour wrap) build on. Per the feature PR
+gate, no PR until all 5 sub-projects are done.

--- a/Plans/2026-06-27-comic-layout-text-overlays-plan.md
+++ b/Plans/2026-06-27-comic-layout-text-overlays-plan.md
@@ -1,0 +1,1063 @@
+# Comic Layout — Text Overlays Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add comic text overlays — tailed speech balloons, thought bubbles, caption boxes, and SFX lettering — as a pure data model + Qt-free geometry module + a Qt renderer pass, floating above the panels from sub-projects #1 and #2.
+
+**Architecture:** A declarative `Overlay`/`OverlayStyle` model lives on `PageSpec.overlays`. A new pure module `core/layout/balloons.py` compiles an overlay's inner bounding rectangle (+ optional tail target) into `PathSegment` geometry (rounded-rect cubics, scalloped-cloud quads, spliced tail). The renderer (`qt_renderer.py`) measures the wrapped text with Qt font metrics to size the balloon, then draws body fill + stroke + tail and the wrapped text clipped to the body. Authoring is deferred to #4/#5.
+
+**Tech Stack:** Python 3.12, pytest, PySide6 (renderer only). Reuses `PathSegment`/`Region`/`PageSpec`/`TextStyle` (`core/layout/models.py`), `validate_segments`/`segments_bbox` (`core/layout/geometry.py`), `polygon_to_segments` (`core/layout/polygon.py`), `region_to_painter_path`/`_add_text_region` patterns (`core/layout/qt_renderer.py`), `effective_text_style` (`core/layout/styles.py`), and `region_to_dict`/`region_from_dict` (`core/layout/schema.py`).
+
+## Global Constraints
+
+- Test interpreter: `.venv_linux/bin/python`. Run tests with `QT_QPA_PLATFORM=offscreen` prefixed (required for the Qt render tests; harmless for pure tests).
+- Full layout suite must stay green: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` (currently **222 passed** on branch `feat/comic-layout-geometry-core`).
+- **No new third-party dependency** — all balloon geometry is hand-rolled in `core/layout/balloons.py`.
+- `core/layout/balloons.py`, `core/layout/models.py`, and `core/layout/schema.py` must be **Qt-free** (importable headless). Only `qt_renderer.py` and the render tests touch Qt.
+- **All errors logged** (platform-independent `logging.getLogger(__name__)`): degenerate overlay rects (non-positive size) are logged and produce an empty segment list, never crash.
+- Every emitted overlay-body segment list must pass `validate_segments` (returns `[]`). No edits to how *regions* render.
+- `Overlay`/`OverlayStyle` serialize and round-trip through `core/layout/schema.py`; old page dicts without `overlays` load to an empty list.
+- Coordinates are page pixels (floats). `KAPPA = 0.5522847498307936` for circular-arc cubic approximation.
+- Conventional Commits (`feat(layout): …`). Commit after each task.
+- **Branch:** continue on `feat/comic-layout-geometry-core` (all 5 comic-layout sub-projects share one branch). **Do NOT open a pull request** — the single PR comes only after sub-project #5.
+
+### Naming convention used across tasks
+- `inner: Rect` (a `Tuple[float, float, float, float]` = `(x, y, w, h)`) is the **body's inner bounding rectangle** = text box + padding. The body must contain `inner` (its bbox equals or exceeds `inner`). The renderer computes `inner` from measured text; `balloons.py` only consumes it.
+- `Point = Tuple[float, float]`, `Rect = Tuple[float, float, float, float]`.
+
+---
+
+### Task 1: `Overlay` / `OverlayStyle` model + `PageSpec.overlays`
+
+**Files:**
+- Modify: `core/layout/models.py`
+- Test: `tests/layout/test_overlay_model.py` (create)
+
+**Interfaces:**
+- Consumes: `TextStyle` (existing, `core/layout/models.py`).
+- Produces:
+  - `@dataclass OverlayStyle(fill="#FFFFFF", stroke_px=2.0, stroke_color="#000000", padding_px=10.0, radius_px=16.0, max_width_px=240.0)`
+  - `@dataclass Overlay(id, kind: Literal["speech","thought","caption","sfx"], text, anchor: Tuple[float,float], anchor_mode: Literal["center","topleft"]="center", tail_target: Optional[Tuple[float,float]]=None, z=0, role="", text_style: Optional[TextStyle]=None, style: OverlayStyle=field(default_factory=OverlayStyle))`
+  - `PageSpec.overlays: List[Overlay] = field(default_factory=list)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_overlay_model.py`:
+
+```python
+from core.layout.models import Overlay, OverlayStyle, PageSpec, TextStyle
+
+
+def test_overlay_style_defaults():
+    s = OverlayStyle()
+    assert s.fill == "#FFFFFF"
+    assert s.stroke_px == 2.0
+    assert s.stroke_color == "#000000"
+    assert s.padding_px == 10.0
+    assert s.radius_px == 16.0
+    assert s.max_width_px == 240.0
+
+
+def test_overlay_defaults_and_fields():
+    ov = Overlay(id="o1", kind="speech", text="Hi!", anchor=(50.0, 40.0))
+    assert ov.kind == "speech"
+    assert ov.anchor == (50.0, 40.0)
+    assert ov.anchor_mode == "center"
+    assert ov.tail_target is None
+    assert ov.z == 0
+    assert ov.role == ""
+    assert ov.text_style is None
+    assert isinstance(ov.style, OverlayStyle)
+
+
+def test_overlay_independent_style_instances():
+    a = Overlay(id="a", kind="caption", text="x", anchor=(0.0, 0.0))
+    b = Overlay(id="b", kind="caption", text="y", anchor=(0.0, 0.0))
+    a.style.fill = "#FFEE00"
+    assert b.style.fill == "#FFFFFF"  # default_factory -> no shared mutable default
+
+
+def test_overlay_with_tail_and_text_style():
+    ts = TextStyle()
+    ov = Overlay(id="o2", kind="thought", text="hmm", anchor=(10.0, 10.0),
+                 tail_target=(5.0, 30.0), z=3, role="dialogue", text_style=ts)
+    assert ov.tail_target == (5.0, 30.0)
+    assert ov.z == 3
+    assert ov.role == "dialogue"
+    assert ov.text_style is ts
+
+
+def test_pagespec_overlays_default_empty():
+    page = PageSpec(page_size_px=(100, 100))
+    assert page.overlays == []
+    page.overlays.append(Overlay(id="o", kind="sfx", text="BOOM", anchor=(20.0, 20.0)))
+    assert len(page.overlays) == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_model.py -q`
+Expected: FAIL — `ImportError: cannot import name 'Overlay'`.
+
+- [ ] **Step 3: Implement the model**
+
+In `core/layout/models.py`, add the two dataclasses near `TextStyle`/`Region` (reuse the existing `from typing import ...` and `from dataclasses import dataclass, field` imports; add any missing names — `Literal`, `Optional`, `Tuple`, `List`, `field` — to the existing import lines, do not duplicate imports):
+
+```python
+@dataclass
+class OverlayStyle:
+    """Visual style for a comic text overlay's body (balloon/caption shell)."""
+    fill: str = "#FFFFFF"
+    stroke_px: float = 2.0
+    stroke_color: str = "#000000"
+    padding_px: float = 10.0        # inset between the text box and the body edge
+    radius_px: float = 16.0         # corner roundness (speech) / scallop radius (thought)
+    max_width_px: float = 240.0     # wrap-width cap used by the renderer's auto-fit
+
+
+@dataclass
+class Overlay:
+    """A declarative comic text overlay (speech/thought/caption/sfx).
+
+    Qt-free and serializable. The renderer measures the wrapped text to size the
+    body; balloons.py builds the body/tail geometry. `anchor` places the body
+    (center or top-left per `anchor_mode`); `tail_target` is a free page-pixel
+    point the tail points at (None = no tail).
+    """
+    id: str
+    kind: Literal["speech", "thought", "caption", "sfx"]
+    text: str
+    anchor: Tuple[float, float]
+    anchor_mode: Literal["center", "topleft"] = "center"
+    tail_target: Optional[Tuple[float, float]] = None
+    z: int = 0
+    role: str = ""
+    text_style: Optional[TextStyle] = None
+    style: OverlayStyle = field(default_factory=OverlayStyle)
+```
+
+In the `PageSpec` dataclass, add the field (place it after `regions`):
+
+```python
+    overlays: List[Overlay] = field(default_factory=list)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_model.py -q`
+Expected: PASS (5 passed). Then full suite stays green: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` (expect 227).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/models.py tests/layout/test_overlay_model.py
+git commit -m "feat(layout): Overlay/OverlayStyle model + PageSpec.overlays"
+```
+
+---
+
+### Task 2: `balloons.py` — caption + speech body (rounded rect) + dispatch skeleton
+
+**Files:**
+- Create: `core/layout/balloons.py`
+- Test: `tests/layout/test_balloons.py` (create)
+
+**Interfaces:**
+- Consumes: `PathSegment` (`core.layout.models`); `validate_segments`/`segments_bbox` (`core.layout.geometry`); `OverlayStyle` (`core.layout.models`).
+- Produces:
+  - `Point`, `Rect` aliases; `KAPPA` constant.
+  - `caption_body(inner: Rect) -> List[PathSegment]`
+  - `speech_body(inner: Rect, *, radius: float) -> List[PathSegment]`
+  - `overlay_to_segments(kind: str, inner: Rect, tail_target: Optional[Point], style: OverlayStyle) -> List[PathSegment]` — this task implements `caption`, `speech` (no-tail), and `sfx` (`[]`); degenerate `inner` → `[]` + log. `thought` and the speech tail are added in Tasks 3–4.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_balloons.py`:
+
+```python
+from core.layout.balloons import caption_body, speech_body, overlay_to_segments
+from core.layout.models import OverlayStyle
+from core.layout.geometry import validate_segments, segments_bbox
+
+
+INNER = (10.0, 20.0, 80.0, 40.0)  # x, y, w, h
+
+
+def _contains(bbox, inner, tol=1e-6):
+    bx, by, bw, bh = bbox
+    ix, iy, iw, ih = inner
+    return (bx <= ix + tol and by <= iy + tol
+            and bx + bw >= ix + iw - tol and by + bh >= iy + ih - tol)
+
+
+def test_caption_body_is_rectangle():
+    segs = caption_body(INNER)
+    assert validate_segments(segs) == []
+    assert [s.type for s in segs] == ["move", "line", "line", "line", "close"]
+    assert _contains(segments_bbox(segs), INNER)
+
+
+def test_speech_body_valid_rounded_and_contains_inner():
+    segs = speech_body(INNER, radius=12.0)
+    assert validate_segments(segs) == []
+    assert any(s.type == "cubic" for s in segs)        # rounded corners
+    bbox = segments_bbox(segs)
+    assert _contains(bbox, INNER)
+    # rounded rect bbox equals inner bounds (corner controls stay inside)
+    assert abs(bbox[2] - INNER[2]) < 1e-6 and abs(bbox[3] - INNER[3]) < 1e-6
+
+
+def test_speech_radius_clamped_to_half_extent():
+    # radius larger than half the smaller side must not invert the body
+    segs = speech_body((0.0, 0.0, 20.0, 10.0), radius=999.0)
+    assert validate_segments(segs) == []
+    assert segments_bbox(segs)[2:] == (20.0, 10.0)
+
+
+def test_overlay_to_segments_caption_and_speech_and_sfx():
+    style = OverlayStyle(radius_px=10.0)
+    assert overlay_to_segments("caption", INNER, None, style) == caption_body(INNER)
+    speech = overlay_to_segments("speech", INNER, None, style)
+    assert validate_segments(speech) == []
+    assert any(s.type == "cubic" for s in speech)      # speech uses rounded body
+    assert overlay_to_segments("sfx", INNER, None, style) == []  # sfx has no body
+
+
+def test_overlay_to_segments_degenerate_logs_and_empty(caplog):
+    import logging
+    style = OverlayStyle()
+    with caplog.at_level(logging.WARNING):
+        assert overlay_to_segments("speech", (0.0, 0.0, 0.0, 30.0), None, style) == []
+    assert any("degenerate" in r.message.lower() or "non-positive" in r.message.lower()
+               for r in caplog.records)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_balloons.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'core.layout.balloons'`.
+
+- [ ] **Step 3: Implement `balloons.py` foundation**
+
+Create `core/layout/balloons.py`:
+
+```python
+"""Pure (Qt-free) comic-overlay geometry: balloon/caption bodies + tails.
+
+Compiles an overlay's inner bounding rectangle (text box + padding) into
+PathSegment geometry that core.layout.qt_renderer draws unchanged. No Qt, no
+font metrics here — the renderer measures text and passes us `inner`.
+
+`inner` is (x, y, w, h); the produced body's bounding box contains `inner`.
+"""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Tuple
+
+from core.layout.models import OverlayStyle, PathSegment
+
+logger = logging.getLogger(__name__)
+
+Point = Tuple[float, float]
+Rect = Tuple[float, float, float, float]
+
+KAPPA = 0.5522847498307936  # control-point factor for a circular quarter-arc cubic
+
+
+def _valid_rect(inner: Rect) -> bool:
+    _, _, w, h = inner
+    return w > 0.0 and h > 0.0
+
+
+def caption_body(inner: Rect) -> List[PathSegment]:
+    """A plain rectangle (caption box) around `inner`."""
+    x, y, w, h = inner
+    return [
+        PathSegment(type="move", pts=[(x, y)]),
+        PathSegment(type="line", pts=[(x + w, y)]),
+        PathSegment(type="line", pts=[(x + w, y + h)]),
+        PathSegment(type="line", pts=[(x, y + h)]),
+        PathSegment(type="close", pts=[]),
+    ]
+
+
+def speech_body(inner: Rect, *, radius: float) -> List[PathSegment]:
+    """A rounded rectangle around `inner`; corners are circular cubic arcs.
+
+    Segment order (used by the tail splice in Task 3):
+      0 move, 1 TOP line, 2 TR cubic, 3 RIGHT line, 4 BR cubic,
+      5 BOTTOM line, 6 BL cubic, 7 LEFT line, 8 TL cubic, 9 close
+    """
+    x, y, w, h = inner
+    r = max(0.0, min(radius, w / 2.0, h / 2.0))
+    k = r * KAPPA
+    x2, y2 = x + w, y + h
+    return [
+        PathSegment(type="move", pts=[(x + r, y)]),
+        PathSegment(type="line", pts=[(x2 - r, y)]),
+        PathSegment(type="cubic", pts=[(x2 - r + k, y), (x2, y + r - k), (x2, y + r)]),
+        PathSegment(type="line", pts=[(x2, y2 - r)]),
+        PathSegment(type="cubic", pts=[(x2, y2 - r + k), (x2 - r + k, y2), (x2 - r, y2)]),
+        PathSegment(type="line", pts=[(x + r, y2)]),
+        PathSegment(type="cubic", pts=[(x + r - k, y2), (x, y2 - r + k), (x, y2 - r)]),
+        PathSegment(type="line", pts=[(x, y + r)]),
+        PathSegment(type="cubic", pts=[(x, y + r - k), (x + r - k, y), (x + r, y)]),
+        PathSegment(type="close", pts=[]),
+    ]
+
+
+def overlay_to_segments(kind: str, inner: Rect, tail_target: Optional[Point],
+                        style: OverlayStyle) -> List[PathSegment]:
+    """Compile an overlay body (+ tail) for `kind`.
+
+    caption -> rectangle (tail ignored); speech -> rounded body (tail spliced in
+    Task 3); thought -> cloud + trail (Task 4); sfx -> [] (text only).
+    Degenerate `inner` (non-positive size) logs a warning and returns [].
+    """
+    if kind == "sfx":
+        return []
+    if not _valid_rect(inner):
+        logger.warning("Overlay %r has a degenerate/non-positive inner rect %r; no body",
+                       kind, inner)
+        return []
+    if kind == "caption":
+        return caption_body(inner)
+    if kind == "speech":
+        return speech_body(inner, radius=style.radius_px)
+    if kind == "thought":
+        # Implemented in Task 4; until then fall back to a plain body so callers
+        # never crash. Replaced by thought_body + trail in Task 4.
+        return speech_body(inner, radius=style.radius_px)
+    logger.warning("Overlay has unknown kind %r; no body", kind)
+    return []
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_balloons.py -q`
+Expected: PASS (5 passed). Then full suite green (expect 232).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/balloons.py tests/layout/test_balloons.py
+git commit -m "feat(layout): balloons.py caption + speech body geometry + dispatch"
+```
+
+---
+
+### Task 3: `balloons.py` — speech tail splice (single closed path)
+
+**Files:**
+- Modify: `core/layout/balloons.py`
+- Test: `tests/layout/test_balloons.py` (extend)
+
+**Interfaces:**
+- Consumes: `speech_body`, `Point`, `Rect` (Task 2).
+- Produces: `overlay_to_segments("speech", inner, tail_target, style)` now splices a triangular tail into the rounded body's nearest straight edge, yielding ONE closed path whose outline includes the tail tip at `tail_target`. Helper `_splice_speech_tail(segs, inner, target, base_width) -> List[PathSegment]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/layout/test_balloons.py`:
+
+```python
+def _all_points(segs):
+    return [p for s in segs for p in s.pts]
+
+
+def test_speech_tail_reaches_target_below():
+    style = OverlayStyle(radius_px=10.0)
+    target = (50.0, 120.0)  # well below INNER (which ends at y=60)
+    segs = overlay_to_segments("speech", INNER, target, style)
+    assert validate_segments(segs) == []
+    # the tail tip is an exact vertex on the outline
+    assert any(abs(px - target[0]) < 1e-6 and abs(py - target[1]) < 1e-6
+               for px, py in _all_points(segs))
+    # bbox now extends below the body to reach the target
+    bbox = segments_bbox(segs)
+    assert bbox[1] + bbox[3] >= target[1] - 1e-6
+
+
+def test_speech_tail_target_above():
+    style = OverlayStyle(radius_px=10.0)
+    target = (50.0, -30.0)  # above the body
+    segs = overlay_to_segments("speech", INNER, target, style)
+    assert validate_segments(segs) == []
+    assert any(abs(py - target[1]) < 1e-6 for _, py in _all_points(segs))
+    assert segments_bbox(segs)[1] <= target[1] + 1e-6  # bbox reaches up to target
+
+
+def test_speech_no_target_has_no_tail():
+    style = OverlayStyle(radius_px=10.0)
+    segs = overlay_to_segments("speech", INNER, None, style)
+    # bbox stays within the inner bounds (no tail protrusion)
+    bbox = segments_bbox(segs)
+    assert bbox[1] >= INNER[1] - 1e-6
+    assert bbox[1] + bbox[3] <= INNER[1] + INNER[3] + 1e-6
+
+
+def test_speech_tail_single_closed_ring():
+    style = OverlayStyle(radius_px=10.0)
+    segs = overlay_to_segments("speech", INNER, (50.0, 120.0), style)
+    assert sum(1 for s in segs if s.type == "move") == 1   # one subpath
+    assert sum(1 for s in segs if s.type == "close") == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_balloons.py -k "tail or no_target or single_closed" -q`
+Expected: FAIL — speech currently ignores `tail_target`, so the tip vertex / extended bbox assertions fail.
+
+- [ ] **Step 3: Implement the tail splice**
+
+In `core/layout/balloons.py`, add the helpers and route speech through them. The four straight edges of `speech_body` are at segment indices TOP=1, RIGHT=3, BOTTOM=5, LEFT=7. Pick the edge whose outward direction faces the target (compare the target to the body center), compute two base points on that edge's straight span, and replace that edge's single `line` with `line(base_a) → line(tip) → line(base_b)` where `base_a` is the base point nearer the edge's start vertex (so the detour respects the outline's traversal direction). Append:
+
+```python
+def _edge_for_target(inner: Rect, target: Point) -> str:
+    x, y, w, h = inner
+    cx, cy = x + w / 2.0, y + h / 2.0
+    dx, dy = target[0] - cx, target[1] - cy
+    # choose the dominant direction; ties prefer vertical (bottom/top) — the
+    # conventional comic tail direction
+    if abs(dy) >= abs(dx):
+        return "bottom" if dy >= 0 else "top"
+    return "right" if dx >= 0 else "left"
+
+
+def _edge_span(inner: Rect, r: float, edge: str) -> Tuple[Point, Point, int]:
+    """Straight-edge start/end (in outline traversal order) + its segment index,
+    for a rounded body of `inner` with corner radius r."""
+    x, y, w, h = inner
+    x2, y2 = x + w, y + h
+    if edge == "top":     # left->right, segment index 1
+        return (x + r, y), (x2 - r, y), 1
+    if edge == "right":   # top->bottom, index 3
+        return (x2, y + r), (x2, y2 - r), 3
+    if edge == "bottom":  # right->left, index 5
+        return (x2 - r, y2), (x + r, y2), 5
+    return (x, y2 - r), (x, y + r), 7  # left: bottom->top, index 7
+
+
+def _splice_speech_tail(segs: List[PathSegment], inner: Rect, target: Point,
+                        base_width: float, radius: float) -> List[PathSegment]:
+    x, y, w, h = inner
+    r = max(0.0, min(radius, w / 2.0, h / 2.0))
+    edge = _edge_for_target(inner, target)
+    (sx, sy), (ex, ey), idx = _edge_span(inner, r, edge)
+    tip = (float(target[0]), float(target[1]))
+    if edge in ("top", "bottom"):
+        lo, hi = sorted((sx, ex))
+        mid = min(max(target[0], lo + 1e-6), hi - 1e-6)
+        half = min(base_width / 2.0, (hi - lo) / 2.0 - 1e-6)
+        p1, p2 = (mid - half, sy), (mid + half, sy)
+    else:  # left / right edges (vertical span)
+        lo, hi = sorted((sy, ey))
+        mid = min(max(target[1], lo + 1e-6), hi - 1e-6)
+        half = min(base_width / 2.0, (hi - lo) / 2.0 - 1e-6)
+        p1, p2 = (sx, mid - half), (sx, mid + half)
+    # order base points along the traversal start (sx,sy) -> end (ex,ey):
+    # `a` is the base point nearer the start vertex.
+    def _d2(p, q):
+        return (p[0] - q[0]) ** 2 + (p[1] - q[1]) ** 2
+    a, b = (p1, p2) if _d2(p1, (sx, sy)) <= _d2(p2, (sx, sy)) else (p2, p1)
+    out: List[PathSegment] = []
+    for i, seg in enumerate(segs):
+        if i == idx and seg.type == "line":
+            out.append(PathSegment(type="line", pts=[a]))
+            out.append(PathSegment(type="line", pts=[tip]))
+            out.append(PathSegment(type="line", pts=[b]))
+            out.append(seg)  # original edge endpoint completes the edge
+        else:
+            out.append(seg)
+    return out
+```
+
+Then update `overlay_to_segments`'s speech branch:
+
+```python
+    if kind == "speech":
+        body = speech_body(inner, radius=style.radius_px)
+        if tail_target is None:
+            return body
+        base_width = max(8.0, min(inner[2], inner[3]) * 0.35)
+        return _splice_speech_tail(body, inner, tail_target, base_width, style.radius_px)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_balloons.py -q`
+Expected: PASS (all balloon tests). Then full suite green (expect 236). If a tail test fails on the base-point ordering, confirm the inserted sequence `a → tip → b` matches the edge's traversal direction (start `sx,sy` → end `ex,ey`); the tip vertex must equal `tail_target` exactly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/balloons.py tests/layout/test_balloons.py
+git commit -m "feat(layout): speech-balloon tail splice (single closed outline)"
+```
+
+---
+
+### Task 4: `balloons.py` — thought cloud body + bubble trail
+
+**Files:**
+- Modify: `core/layout/balloons.py`
+- Test: `tests/layout/test_balloons.py` (extend)
+
+**Interfaces:**
+- Consumes: `Point`, `Rect`, `KAPPA` (Tasks 2–3).
+- Produces:
+  - `thought_body(inner: Rect, *, scallop: float) -> List[PathSegment]` — a closed scalloped cloud (quad bumps) on an ellipse circumscribing `inner`.
+  - `thought_trail(body_center: Point, target: Point, *, count: int = 3) -> List[PathSegment]` — `count` shrinking circle subpaths marching toward `target`.
+  - `overlay_to_segments("thought", …)` now returns `thought_body(...) + thought_trail(...)` (trail only when `tail_target` is set).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/layout/test_balloons.py`:
+
+```python
+from core.layout.balloons import thought_body, thought_trail
+
+
+def test_thought_body_is_valid_cloud_containing_inner():
+    segs = thought_body(INNER, scallop=8.0)
+    assert validate_segments(segs) == []
+    assert any(s.type == "quad" for s in segs)         # scalloped bumps
+    assert _contains(segments_bbox(segs), INNER)
+
+
+def test_thought_trail_marches_toward_target_with_count_subpaths():
+    trail = thought_trail((50.0, 40.0), (90.0, 90.0), count=3)
+    assert validate_segments(trail) == []
+    assert sum(1 for s in trail if s.type == "move") == 3   # 3 ellipse subpaths
+    # last (smallest) bubble is nearest the target
+    xs = [s.pts[0][0] for s in trail if s.type == "move"]
+    assert xs[-1] > xs[0]  # progressing toward target.x = 90
+
+
+def test_overlay_thought_has_body_plus_trail():
+    style = OverlayStyle(radius_px=10.0)
+    segs = overlay_to_segments("thought", INNER, (95.0, 95.0), style)
+    assert validate_segments(segs) == []
+    moves = sum(1 for s in segs if s.type == "move")
+    assert moves == 1 + 3   # body + 3 trail bubbles
+
+
+def test_overlay_thought_no_target_body_only():
+    style = OverlayStyle(radius_px=10.0)
+    segs = overlay_to_segments("thought", INNER, None, style)
+    assert sum(1 for s in segs if s.type == "move") == 1   # body only, no trail
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_balloons.py -k thought -q`
+Expected: FAIL — `ImportError: cannot import name 'thought_body'` (and thought currently falls back to speech body, so the body+trail count assertions fail).
+
+- [ ] **Step 3: Implement cloud + trail**
+
+Append to `core/layout/balloons.py`:
+
+```python
+import math
+
+
+def _circle_segments(cx: float, cy: float, r: float) -> List[PathSegment]:
+    """A closed circle approximated by four cubic quarter-arcs (move..close)."""
+    k = r * KAPPA
+    return [
+        PathSegment(type="move", pts=[(cx + r, cy)]),
+        PathSegment(type="cubic", pts=[(cx + r, cy + k), (cx + k, cy + r), (cx, cy + r)]),
+        PathSegment(type="cubic", pts=[(cx - k, cy + r), (cx - r, cy + k), (cx - r, cy)]),
+        PathSegment(type="cubic", pts=[(cx - r, cy - k), (cx - k, cy - r), (cx, cy - r)]),
+        PathSegment(type="cubic", pts=[(cx + k, cy - r), (cx + r, cy - k), (cx + r, cy)]),
+        PathSegment(type="close", pts=[]),
+    ]
+
+
+def thought_body(inner: Rect, *, scallop: float) -> List[PathSegment]:
+    """A scalloped 'cloud' on an ellipse circumscribing `inner`.
+
+    N outward quad bumps around the ellipse. The circumscribing ellipse
+    (semi-axes 1.42x the rect half-extents) contains `inner`'s corners; the
+    bumps extend further, so bbox(cloud) contains `inner`.
+    """
+    x, y, w, h = inner
+    cx, cy = x + w / 2.0, y + h / 2.0
+    ax, ay = (w / 2.0) * 1.42, (h / 2.0) * 1.42  # circumscribe the corners
+    bumps = max(8, int(((w + h) / 40.0)) * 2)    # even count, scales with size
+    pts = [(cx + ax * math.cos(2 * math.pi * i / bumps),
+            cy + ay * math.sin(2 * math.pi * i / bumps)) for i in range(bumps)]
+    segs = [PathSegment(type="move", pts=[pts[0]])]
+    for i in range(bumps):
+        nxt = pts[(i + 1) % bumps]
+        mid_ang = 2 * math.pi * (i + 0.5) / bumps
+        ctrl = (cx + (ax + scallop) * math.cos(mid_ang),
+                cy + (ay + scallop) * math.sin(mid_ang))
+        segs.append(PathSegment(type="quad", pts=[ctrl, nxt]))
+    segs.append(PathSegment(type="close", pts=[]))
+    return segs
+
+
+def thought_trail(body_center: Point, target: Point, *, count: int = 3) -> List[PathSegment]:
+    """`count` shrinking circles from near `body_center` toward `target`."""
+    out: List[PathSegment] = []
+    for i in range(count):
+        t = (i + 1) / (count + 1)
+        cx = body_center[0] + (target[0] - body_center[0]) * t
+        cy = body_center[1] + (target[1] - body_center[1]) * t
+        r = max(1.0, 6.0 * (1.0 - t))   # shrink toward the target
+        out.extend(_circle_segments(cx, cy, r))
+    return out
+```
+
+Update the `thought` branch in `overlay_to_segments` (replace the Task-2 fallback):
+
+```python
+    if kind == "thought":
+        body = thought_body(inner, scallop=max(4.0, style.radius_px * 0.5))
+        if tail_target is None:
+            return body
+        cx, cy = inner[0] + inner[2] / 2.0, inner[1] + inner[3] / 2.0
+        return body + thought_trail((cx, cy), tail_target, count=3)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_balloons.py -q`
+Expected: PASS (all balloon tests). Full suite green (expect 240). If `_contains` fails for the cloud, confirm the circumscribing factor (1.42 ≈ √2) keeps the ellipse outside the rect corners.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/balloons.py tests/layout/test_balloons.py
+git commit -m "feat(layout): thought-bubble cloud body + shrinking bubble trail"
+```
+
+---
+
+### Task 5: Serialize `Overlay` through `schema.py`
+
+**Files:**
+- Modify: `core/layout/schema.py`
+- Test: `tests/layout/test_overlay_schema.py` (create)
+
+**Interfaces:**
+- Consumes: `Overlay`, `OverlayStyle`, `TextStyle`, `PageSpec` (`core.layout.models`); existing `region_to_dict`/`region_from_dict` patterns and any `text_style` (de)serialization already in `schema.py`.
+- Produces:
+  - `overlay_to_dict(ov: Overlay) -> dict` and `overlay_from_dict(d: dict) -> Overlay` (incl. nested `OverlayStyle` and optional `TextStyle`).
+  - `PageSpec` (de)serialization includes `overlays` (wire into the existing page-level functions — find how `regions` is serialized and mirror it for `overlays`). Old dicts without `overlays` → `[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_overlay_schema.py`:
+
+```python
+from core.layout.models import Overlay, OverlayStyle, TextStyle
+from core.layout.schema import overlay_to_dict, overlay_from_dict
+
+
+def _roundtrip(ov):
+    return overlay_from_dict(overlay_to_dict(ov))
+
+
+def test_speech_overlay_roundtrip_with_tail_and_style():
+    ov = Overlay(id="o1", kind="speech", text="Hi!", anchor=(50.0, 40.0),
+                 anchor_mode="center", tail_target=(50.0, 90.0), z=2, role="dialogue",
+                 style=OverlayStyle(fill="#FFEE00", stroke_px=3.0, padding_px=12.0,
+                                    radius_px=20.0, max_width_px=180.0))
+    r = _roundtrip(ov)
+    assert r.id == "o1" and r.kind == "speech" and r.text == "Hi!"
+    assert r.anchor == (50.0, 40.0) and r.tail_target == (50.0, 90.0)
+    assert r.z == 2 and r.role == "dialogue"
+    assert r.style.fill == "#FFEE00" and r.style.stroke_px == 3.0
+    assert r.style.padding_px == 12.0 and r.style.radius_px == 20.0
+    assert r.style.max_width_px == 180.0
+
+
+def test_overlay_roundtrip_each_kind():
+    for kind in ("speech", "thought", "caption", "sfx"):
+        ov = Overlay(id=kind, kind=kind, text="x", anchor=(1.0, 2.0))
+        assert _roundtrip(ov).kind == kind
+
+
+def test_overlay_roundtrip_with_text_style():
+    ov = Overlay(id="t", kind="caption", text="cap", anchor=(0.0, 0.0),
+                 text_style=TextStyle(size_px=30, color="#112233"))
+    r = _roundtrip(ov)
+    assert r.text_style is not None
+    assert r.text_style.size_px == 30 and r.text_style.color == "#112233"
+
+
+def test_overlay_from_dict_defaults_when_missing_optionals():
+    r = overlay_from_dict({"id": "m", "kind": "sfx", "text": "BOOM", "anchor": [5.0, 6.0]})
+    assert r.anchor == (5.0, 6.0)
+    assert r.tail_target is None and r.role == ""
+    assert isinstance(r.style, OverlayStyle) and r.style.fill == "#FFFFFF"
+```
+
+Then add a `PageSpec` round-trip test using whatever page (de)serialization `schema.py`/`project_io.py` exposes (mirror the existing region round-trip test in the suite). At minimum:
+
+```python
+def test_pagespec_without_overlays_loads_empty():
+    # an older page dict (no "overlays" key) must deserialize to overlays == []
+    from core.layout.schema import page_from_dict  # use the actual page loader name
+    page = page_from_dict({"page_size_px": [100, 100], "regions": []})
+    assert page.overlays == []
+```
+
+> Note: if the page-level loader is named differently (e.g. in `project_io.py`), import and call that one instead; the requirement is "a page dict without `overlays` yields `overlays == []`".
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_schema.py -q`
+Expected: FAIL — `ImportError: cannot import name 'overlay_to_dict'`.
+
+- [ ] **Step 3: Implement serialization**
+
+In `core/layout/schema.py`, add overlay (de)serializers modeled on `region_to_dict`/`region_from_dict`. Reuse the module's existing `TextStyle` (de)serialization helper if one exists; otherwise serialize `text_style` with `dataclasses.asdict` and reconstruct with `TextStyle(**d)`. Tuples serialize as lists and are restored as tuples:
+
+```python
+from core.layout.models import Overlay, OverlayStyle  # add to existing models import
+
+
+def _overlay_style_to_dict(s: OverlayStyle) -> dict:
+    return {"fill": s.fill, "stroke_px": s.stroke_px, "stroke_color": s.stroke_color,
+            "padding_px": s.padding_px, "radius_px": s.radius_px,
+            "max_width_px": s.max_width_px}
+
+
+def _overlay_style_from_dict(d: dict) -> OverlayStyle:
+    return OverlayStyle(**_filtered(d, OverlayStyle)) if d else OverlayStyle()
+
+
+def overlay_to_dict(ov: Overlay) -> dict:
+    d = {
+        "id": ov.id, "kind": ov.kind, "text": ov.text,
+        "anchor": [ov.anchor[0], ov.anchor[1]], "anchor_mode": ov.anchor_mode,
+        "tail_target": (None if ov.tail_target is None
+                        else [ov.tail_target[0], ov.tail_target[1]]),
+        "z": ov.z, "role": ov.role,
+        "style": _overlay_style_to_dict(ov.style),
+    }
+    if ov.text_style is not None:
+        d["text_style"] = text_style_to_dict(ov.text_style)  # reuse existing helper
+    return d
+
+
+def overlay_from_dict(d: dict) -> Overlay:
+    anchor = tuple(d["anchor"])
+    tt = d.get("tail_target")
+    text_style = None
+    if d.get("text_style") is not None:
+        text_style = text_style_from_dict(d["text_style"])  # reuse existing helper
+    return Overlay(
+        id=d["id"], kind=d["kind"], text=d.get("text", ""),
+        anchor=(float(anchor[0]), float(anchor[1])),
+        anchor_mode=d.get("anchor_mode", "center"),
+        tail_target=(None if tt is None else (float(tt[0]), float(tt[1]))),
+        z=int(d.get("z", 0)), role=d.get("role", ""),
+        text_style=text_style,
+        style=_overlay_style_from_dict(d.get("style", {})),
+    )
+```
+
+> If `schema.py` has no `text_style_to_dict`/`text_style_from_dict` helpers, replace those two calls with `dataclasses.asdict(ov.text_style)` and `TextStyle(**_filtered(d["text_style"], TextStyle))` respectively. If there is no `_filtered` helper for dataclasses, construct directly with the known fields. Inspect the existing `region_*` (de)serializers first and match their idiom exactly.
+
+Then wire `overlays` into the page-level (de)serialization: locate where `PageSpec.regions` is written/read (in `schema.py` or `project_io.py`) and add the parallel `overlays` handling:
+- serialize: `d["overlays"] = [overlay_to_dict(o) for o in page.overlays]`
+- deserialize: `overlays=[overlay_from_dict(o) for o in d.get("overlays", [])]`
+
+Add an `OVERLAY_JSON_SCHEMA` fragment alongside `REGION_JSON_SCHEMA` describing the overlay object (kind enum, required `id`/`kind`/`text`/`anchor`), and reference it from the page schema's properties (`"overlays": {"type": "array", "items": OVERLAY_JSON_SCHEMA}`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_schema.py -q`
+Expected: PASS. Full suite green (expect 244).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/schema.py tests/layout/test_overlay_schema.py
+git commit -m "feat(layout): serialize Overlay/OverlayStyle + PageSpec.overlays round-trip"
+```
+
+---
+
+### Task 6: Renderer overlay pass (measure → balloons → draw)
+
+**Files:**
+- Modify: `core/layout/qt_renderer.py`
+- Test: `tests/layout/test_overlay_render.py` (create — basic render smoke; full pixel assertions in Task 7)
+
+**Interfaces:**
+- Consumes: `Overlay`/`OverlayStyle` (`core.layout.models`); `overlay_to_segments` (`core.layout.balloons`); `effective_text_style` (`core.layout.styles`); the existing `region_to_painter_path` segment-handling logic.
+- Produces:
+  - `segments_to_painter_path(segments) -> QPainterPath` — shared helper extracted from `region_to_painter_path` (the move/line/quad/cubic/close switch), reused by both regions and overlays.
+  - `_add_overlay(scene, ov, project_style, base_z)` — measures wrapped text, sizes `inner`, builds the body via `overlay_to_segments`, draws body fill+stroke and the wrapped text clipped to the body. SFX → text only.
+  - `render_page_to_image`/`build_scene` iterate `page.overlays` (sorted by `z`) after regions.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_overlay_render.py`:
+
+```python
+from core.layout.models import PageSpec, Overlay, OverlayStyle
+from core.layout import qt_renderer
+
+
+def test_speech_overlay_renders_body_and_text(qapp):
+    page = PageSpec(page_size_px=(200, 160), background="#FFFFFF")
+    page.overlays.append(Overlay(
+        id="b1", kind="speech", text="Hello there friend",
+        anchor=(100.0, 70.0), tail_target=(100.0, 150.0),
+        style=OverlayStyle(fill="#FFFFFF", stroke_px=3.0, stroke_color="#000000")))
+    img = qt_renderer.render_page_to_image(page)
+    assert img.width() == 200 and img.height() == 160
+    # a black stroked outline pixel exists somewhere on the body perimeter
+    found_stroke = any(
+        qt_renderer_pixel_is_dark(img, x, y)
+        for x in range(40, 160) for y in range(40, 110)
+    )
+    assert found_stroke
+
+
+def qt_renderer_pixel_is_dark(img, x, y):
+    c = img.pixelColor(x, y)
+    return c.red() < 80 and c.green() < 80 and c.blue() < 80
+
+
+def test_overlays_render_count_and_kinds(qapp):
+    page = PageSpec(page_size_px=(200, 200), background="#FFFFFF")
+    page.overlays.append(Overlay(id="cap", kind="caption", text="Narration",
+                                 anchor=(10.0, 10.0), anchor_mode="topleft"))
+    page.overlays.append(Overlay(id="sfx", kind="sfx", text="BOOM", anchor=(120.0, 120.0)))
+    img = qt_renderer.render_page_to_image(page)
+    assert img.width() == 200 and img.height() == 200  # renders without error
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_render.py -q`
+Expected: FAIL — `render_page_to_image` ignores `page.overlays`, so no stroked body renders and `found_stroke` is False.
+
+- [ ] **Step 3: Implement the overlay pass**
+
+In `core/layout/qt_renderer.py`:
+
+1. **Extract** the segment→path switch from `region_to_painter_path` into a module-level helper, and call it from `region_to_painter_path`:
+
+```python
+def segments_to_painter_path(segments) -> "QPainterPath":
+    from PySide6.QtGui import QPainterPath
+    path = QPainterPath()
+    for seg in segments:
+        if seg.type == "move":
+            path.moveTo(*seg.pts[0])
+        elif seg.type == "line":
+            path.lineTo(*seg.pts[0])
+        elif seg.type == "quad":
+            (cx, cy), (ex, ey) = seg.pts
+            path.quadTo(cx, cy, ex, ey)
+        elif seg.type == "cubic":
+            (c1x, c1y), (c2x, c2y), (ex, ey) = seg.pts
+            path.cubicTo(c1x, c1y, c2x, c2y, ex, ey)
+        elif seg.type == "close":
+            path.closeSubpath()
+    return path
+```
+
+2. **Add** the overlay renderer:
+
+```python
+def _add_overlay(scene, ov, project_style, base_z):
+    from PySide6.QtCore import Qt, QRectF
+    from PySide6.QtGui import QFont, QColor, QPen, QBrush, QFontMetricsF
+    from PySide6.QtWidgets import QGraphicsPathItem, QGraphicsTextItem
+    from core.layout.balloons import overlay_to_segments
+    from core.layout.styles import effective_text_style
+
+    # resolve text style (kind default role when ov.role is empty)
+    role = ov.role or {"speech": "dialogue", "thought": "dialogue",
+                       "caption": "caption", "sfx": "sfx"}.get(ov.kind, "dialogue")
+    ts = effective_text_style(_overlay_as_styleable(ov, role), project_style)
+
+    font = QFont(ts.family[0] if ts and ts.family else "DejaVu Sans",
+                 ts.size_px if ts else 16)
+    if ts and ts.italic:
+        font.setItalic(True)
+    fm = QFontMetricsF(font)
+    max_w = max(20.0, ov.style.max_width_px)
+    rect = fm.boundingRect(QRectF(0, 0, max_w, 100000),
+                           int(Qt.TextWordWrap), ov.text)
+    text_w, text_h = rect.width(), rect.height()
+    pad = ov.style.padding_px
+    inner_w, inner_h = text_w + 2 * pad, text_h + 2 * pad
+
+    ax, ay = ov.anchor
+    if ov.anchor_mode == "center":
+        ix, iy = ax - inner_w / 2.0, ay - inner_h / 2.0
+    else:
+        ix, iy = ax, ay
+    inner = (ix, iy, inner_w, inner_h)
+
+    z = base_z + ov.z
+    segs = overlay_to_segments(ov.kind, inner, ov.tail_target, ov.style)
+    body_item = None
+    if segs:
+        path = segments_to_painter_path(segs)
+        body_item = QGraphicsPathItem(path)
+        body_item.setBrush(QBrush(QColor(ov.style.fill)))
+        if ov.style.stroke_px > 0:
+            body_item.setPen(QPen(QColor(ov.style.stroke_color), ov.style.stroke_px))
+        else:
+            body_item.setPen(QPen(Qt.NoPen))
+        body_item.setZValue(z)
+        body_item.setFlag(QGraphicsPathItem.GraphicsItemFlag.ItemClipsChildrenToShape, True)
+        scene.addItem(body_item)
+
+    text_item = QGraphicsTextItem(ov.text, parent=body_item)
+    text_item.setFont(font)
+    if ts:
+        text_item.setDefaultTextColor(QColor(ts.color))
+    text_item.setTextWidth(text_w)
+    text_item.setPos(ix + pad, iy + pad)
+    text_item.setZValue(z + 0.1)
+    if body_item is None:           # sfx (no body): add text directly
+        scene.addItem(text_item)
+```
+
+3. Add the small adapter `_overlay_as_styleable(ov, role)` so `effective_text_style` (which expects a region-like object with `.text_style` and `.role`) can resolve overlay styling. The simplest correct adapter returns a lightweight object exposing `text_style=ov.text_style` and `role=role`:
+
+```python
+class _OverlayStyleable:
+    __slots__ = ("text_style", "role")
+    def __init__(self, text_style, role):
+        self.text_style = text_style
+        self.role = role
+
+
+def _overlay_as_styleable(ov, role):
+    return _OverlayStyleable(ov.text_style, role)
+```
+
+> Verify `effective_text_style`'s exact attribute access (it reads `region.text_style` then `region.role`); the adapter must expose those two names. If it reads additional attributes, add them to `__slots__` with sensible values.
+
+4. In `render_page_to_image`/`build_scene`, after the region loop, add:
+
+```python
+    base_z = (max((r.z for r in page.regions), default=0) + 1000)
+    for ov in sorted(page.overlays, key=lambda o: o.z):
+        _add_overlay(scene, ov, project_style, base_z)
+```
+
+(`project_style` is whatever the surrounding function already resolves for region text; reuse it. If the function signature doesn't have it, pass `None` — `effective_text_style` already handles `None`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_render.py -q`
+Expected: PASS (2 passed). Full suite green (expect 246). If `region_to_painter_path` now delegates to `segments_to_painter_path`, re-run the existing renderer tests to confirm no regression: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/qt_renderer.py tests/layout/test_overlay_render.py
+git commit -m "feat(layout): renderer overlay pass (measure, balloon body+tail, wrapped text)"
+```
+
+---
+
+### Task 7: Integration — all four overlay kinds render with correct layering
+
+**Files:**
+- Test: `tests/layout/test_overlay_render.py` (extend)
+
+**Interfaces:**
+- Consumes: `render_page_to_image` (`core.layout.qt_renderer`); `PageSpec`/`Overlay`/`OverlayStyle` (`core.layout.models`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/layout/test_overlay_render.py`:
+
+```python
+def _is_white(img, x, y):
+    c = img.pixelColor(x, y)
+    return c.red() > 240 and c.green() > 240 and c.blue() > 240
+
+
+def test_speech_body_fill_and_background(qapp):
+    # blue page so the white balloon fill is unambiguous
+    page = PageSpec(page_size_px=(220, 180), background="#1144CC")
+    page.overlays.append(Overlay(
+        id="b", kind="speech", text="Hello there friend, how are you",
+        anchor=(110.0, 70.0), tail_target=(110.0, 165.0),
+        style=OverlayStyle(fill="#FFFFFF", stroke_px=3.0)))
+    img = qt_renderer.render_page_to_image(page)
+    assert _is_white(img, 110, 70)              # inside the balloon body -> white fill
+    assert not _is_white(img, 5, 5)             # page corner -> blue background
+    # tail extends downward toward the target (a non-background pixel below the body)
+    assert any(not (img.pixelColor(110, y).blue() > 200 and img.pixelColor(110, y).red() < 80)
+               for y in range(110, 160))
+
+
+def test_overlay_z_order_higher_on_top(qapp):
+    page = PageSpec(page_size_px=(200, 200), background="#FFFFFF")
+    page.overlays.append(Overlay(id="low", kind="caption", text="LOW",
+                                 anchor=(60.0, 60.0), anchor_mode="topleft", z=0,
+                                 style=OverlayStyle(fill="#FF0000")))
+    page.overlays.append(Overlay(id="high", kind="caption", text="HIGH",
+                                 anchor=(70.0, 70.0), anchor_mode="topleft", z=5,
+                                 style=OverlayStyle(fill="#00AA00")))
+    img = qt_renderer.render_page_to_image(page)
+    # in the overlap region the higher-z (green) overlay wins
+    c = img.pixelColor(95, 95)
+    assert c.green() > c.red()
+
+
+def test_caption_and_sfx_render(qapp):
+    page = PageSpec(page_size_px=(200, 120), background="#FFFFFF")
+    page.overlays.append(Overlay(id="cap", kind="caption", text="Meanwhile...",
+                                 anchor=(8.0, 8.0), anchor_mode="topleft",
+                                 style=OverlayStyle(fill="#FFFFAA")))
+    page.overlays.append(Overlay(id="sfx", kind="sfx", text="KRAK", anchor=(150.0, 60.0)))
+    img = qt_renderer.render_page_to_image(page)
+    # caption box has its yellow fill
+    c = img.pixelColor(20, 20)
+    assert c.red() > 200 and c.green() > 200 and c.blue() < 200
+```
+
+- [ ] **Step 2: Run test to verify it fails / passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_render.py -q`
+Per TDD this is an integration gate over already-built APIs; it should PASS if Tasks 1–6 are correct. If any assertion fails, it localizes a real defect (most likely the `inner` sizing/anchor math in `_add_overlay`, the fill brush, or the z-base). Fix the offending earlier code — do NOT weaken the assertions.
+
+- [ ] **Step 3: (No new implementation expected)**
+
+This task is the integration gate. If `test_speech_body_fill_and_background` fails on the tail check, verify the speech tail is spliced toward a *downward* target (Task 3) and that the body fill brush covers the interior. If `test_overlay_z_order_higher_on_top` fails, verify `base_z + ov.z` ordering and that overlays are iterated `sorted(by z)` after regions.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_render.py -q`
+Expected: PASS. Then the FULL suite: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` → all green (expect 249).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/layout/test_overlay_render.py
+git commit -m "test(layout): overlay kinds render with fill, tail, and z-order"
+```
+
+---
+
+## Notes / deliberately deferred (not gaps)
+- **GUI export still uses the PIL engine** (carried from #1/#2): overlays render through `qt_renderer` (live editor + Qt export) but not through `gui/layout/export_dialog.py` (PIL). Migrating export onto the Qt renderer remains the biggest cross-cutting follow-up.
+- **AI designer (#4)** will emit `Overlay`s (likely from a script/LLM step); **manual editor (#5)** authors/drag-edits them and adds: tail-to-region/character snapping, SFX rotation/path-warp, and contour-aware text wrapping (text currently wraps within the inner rectangle, not the oval/cloud contour).
+- **Shape-aware wrapping** is out of scope: a rounded/oval balloon wraps text within its inscribed rectangle, which is correct for the vast majority of comic balloons.
+- **`balloons.py` scope:** speech (rounded-rect + spliced triangular tail), thought (circumscribing-ellipse scalloped cloud + shrinking-circle trail), caption (rectangle), sfx (text-only). Not a general vector-shape library.
+
+## Self-Review (completed by plan author)
+- **Spec coverage:** model + `PageSpec.overlays` (T1); pure balloon geometry — caption/speech body (T2), speech tail splice (T3), thought cloud + trail (T4); serialization round-trip + back-compat (T5); renderer overlay pass with auto-fit measurement, fill/stroke/tail, wrapped text, z-order, SFX-text-only (T6); integration pixels for all four kinds + layering (T7). Every design §2–§9 item and acceptance criteria 1–7 map to a task.
+- **Placeholder scan:** the only intentional "find the existing idiom" instructions are in T5 (schema/page-loader names: `text_style_to_dict`/`text_style_from_dict`/`_filtered`/`page_from_dict`) and T6 (`project_style`/`effective_text_style` attribute access) — each gives the exact requirement and a concrete fallback, not a TODO. No stub/placeholder code remains in any task.
+- **Type/name consistency:** `Overlay(id,kind,text,anchor,anchor_mode,tail_target,z,role,text_style,style)`, `OverlayStyle(fill,stroke_px,stroke_color,padding_px,radius_px,max_width_px)`, `overlay_to_segments(kind,inner,tail_target,style)`, `caption_body(inner)`, `speech_body(inner,*,radius)`, `thought_body(inner,*,scallop)`, `thought_trail(body_center,target,*,count)`, `segments_to_painter_path(segments)`, `overlay_to_dict`/`overlay_from_dict` are used identically across tasks; `inner` is consistently (x,y,w,h) text-box+padding; `PathSegment(type=…, pts=…)` matches #1's model.
+- **Test interpreter/baseline:** all tasks use `.venv_linux/bin/python` under `QT_QPA_PLATFORM=offscreen`; suite counts step 222 → 249 across tasks (5+5+4+4+4+2+3 new tests = 27).
+```

--- a/Plans/2026-06-27-comic-layout-tiling-engine-design.md
+++ b/Plans/2026-06-27-comic-layout-tiling-engine-design.md
@@ -1,0 +1,177 @@
+# Comic Layout — Sub-project #2: Page-Partition / Tiling Engine (Design) ⏳
+**Last Updated:** 2026-06-27 13:59
+**Author:** Leland Green + Claude (Opus 4.8)
+**Status:** Design — awaiting user review before implementation plan
+**Branch:** `feat/comic-layout-geometry-core` (shared by all 5 comic-layout sub-projects; one PR after #5)
+**Design source:** Brainstorming session 2026-06-27 (this doc)
+**Builds on:** `Plans/2026-06-27-comic-layout-geometry-core-design.md` (#1 — geometry & render core)
+
+---
+
+## 0. Why this exists
+
+#1 gave a region a path-based shape and made the renderer clip an image to that
+shape, honor a stroke, and bleed. But panels are still authored as independent
+boxes; nothing divides the page into a coherent, gap-free set of panels. The
+user's core complaint — **"lots of whitespace between" panels** — comes from
+placing rectangles with fixed gaps on a grid.
+
+#2 fixes that with **partition-then-inset**: divide the whole page into a gap-free
+tiling whose panels share edges, then create every gutter by **insetting** each
+panel. The output is a list of `Region`s with `shape="path"` that #1 renders
+unchanged. This is the piece that eliminates the whitespace and unlocks angled
+gutters and concave panels.
+
+## 1. Scope (decisions from brainstorming)
+
+**In scope**
+- **Recursive slice-tree model** with any-angle straight cuts (horizontal,
+  vertical, or skewed/angled).
+- **Cell-merge → concave panels** (L-shapes, wrap-around) — the original
+  "frames with concave sides" ask.
+- **Partition → merge → per-edge inset** pipeline producing the gutters.
+- **Hand-rolled, dependency-free** straight-edge polygon math (clip, union,
+  inset) in a pure module — no new third-party dependency.
+- **Per-edge inset** unifying outer **margin**, inter-panel **gutter**, and
+  **bleed** (a `bleed` panel skips inset on its page-border edges).
+- **Floating + bleed layering** — floating panels layer on top of the tiled base
+  via z-order.
+- **Preset templates** + **`apply_tiling`** that seeds `page.regions` (the usable,
+  testable surface). No GUI, no LLM.
+
+**Out of scope (later sub-projects)**
+- GUI authoring / knife tool / vertex dragging (#5).
+- AI designer emitting tilings (#4).
+- Curved-edge **tiling** (curves remain available for free-floating/bleed panels
+  and balloons via #1; tiling cuts are straight-edge only — a research-grade
+  problem, explicitly excluded).
+- Migrating GUI PNG/PDF export off the PIL engine onto the Qt renderer (a known
+  follow-up recorded in #1's plan; not required for #2).
+
+## 2. Data model (`core/layout/tiling.py`, pure, no Qt)
+
+```python
+@dataclass
+class Split:
+    axis: Literal["x", "y"]        # "x" = vertical cut → left/right; "y" = horizontal → top/bottom
+    at: float                      # cut position, fraction (0,1) of the cell bbox along the axis
+    a: "Node"                      # first child  (left / top)
+    b: "Node"                      # second child (right / bottom)
+    skew: float = 0.0              # [-1,1]; ≠0 shifts the cut's two endpoints in opposite
+                                   # directions on the spanning edges → an angled gutter
+
+@dataclass
+class Leaf:
+    id: str
+    kind: Literal["image", "text"] = "image"
+    bleed: bool = False
+    merge: Optional[str] = None    # leaves sharing a merge key fuse into one (concave) panel
+
+Node = Union[Split, Leaf]
+```
+
+Cut parameters are **relative to the current cell's bounding box**, so they remain
+well-defined on the non-rectangular cells produced by earlier angled cuts.
+
+## 3. Pipeline — `tile(tree, page_rect, *, gutter, margin) -> List[Region]`
+
+1. **Partition.** Recursively clip the cell polygon by each `Split`'s cut line
+   (Sutherland–Hodgman half-plane clip). Each `Leaf` gets an exact convex polygon;
+   the leaves tile `page_rect` with no gaps or overlaps. A `Split.at` is clamped to
+   a small `[ε, 1-ε]`; `skew` offsets the two cut endpoints on the spanning bbox
+   edges.
+2. **Merge.** Group leaf polygons by `merge` key; union each group by
+   **boundary-edge cancellation**: split colinear opposing edges at their overlap,
+   then cancel exactly-opposing shared edges; the survivors trace the panel ring
+   (concave allowed). A disconnected merge group is logged and left unmerged.
+3. **Per-edge inset.** For each final panel, classify each edge as **boundary**
+   (lies on `page_rect`, within ε) or **interior**, and offset it inward by:
+   - interior edge → `gutter / 2` (adjacent panels sum to a full `gutter`),
+   - boundary edge → `margin`,
+   - boundary edge of a `bleed` panel → `0` (panel runs to the trim/bleed edge).
+   Offset = intersect consecutive offset lines; miter with a miter-limit
+   (bevel fallback); reflex-aware. If a panel is too thin for its gutter and the
+   inset inverts/self-intersects, log a warning and **drop** that panel.
+4. **Emit.** Each inset panel polygon → `Region(shape="path",
+   segments=polygon_to_segments(poly), kind=leaf.kind, bleed=leaf.bleed,
+   id=leaf.id, z=<base>)`.
+
+Margin, inter-panel gutter, angled gutters, and bleed all derive from the single
+per-edge inset over an exact partition.
+
+## 4. Module layout
+
+- **`core/layout/polygon.py`** *(NEW, pure, no Qt)* — reusable straight-edge
+  polygon math: `clip_halfplane(poly, line)`; `union_polygons(polys)`
+  (boundary-edge cancellation + colinear-overlap splitting); `inset_polygon(poly,
+  dist_per_edge)`; `polygon_to_segments(poly) -> List[PathSegment]`. Reusable by
+  #5's editor.
+- **`core/layout/tiling.py`** *(NEW, pure, no Qt)* — `Split`/`Leaf` model, `tile`,
+  preset builders, `apply_tiling`.
+
+## 5. Presets + apply-to-page
+
+- Preset library (in `tiling.py`): `grid(rows, cols)` plus named trees exercising
+  the range — `three_tiers()`, `splash_with_strip()` (one big panel + a row of
+  small), `diagonal_action()` (angled cuts), `feature_L()` (a `merge` group → a
+  concave hero panel).
+- `apply_tiling(page, tree, *, gutter, margin, floating=()) -> PageSpec` — sets
+  `page.regions = tiled_base + list(floating)`, assigning ids and z so **floating
+  panels layer on top** of the tiled base. This is the usable feature surface.
+
+## 6. Integration with #1 (no renderer changes)
+
+Output `Region`s use `shape="path"`/`segments`, which #1's `region_to_painter_path`
++ clip + stroke render as-is. A `bleed` leaf skips inset on its page-border edges,
+so #1's bleed canvas-growth and this no-inset combine into true full-bleed panels.
+**#2 produces regions; #1 renders them — no renderer edits.**
+
+## 7. Error handling (repo rule: all errors logged, platform-independent)
+
+- Malformed tree (bad `at`, missing child, unknown `axis`) → `ValueError` with
+  context.
+- Disconnected `merge` group → log error, leave those cells unmerged (no crash).
+- Panel too thin for its gutter (inset inverts) → log warning + drop the panel.
+- Degenerate cut (`at` at/near 0 or 1) → clamp to `[ε, 1-ε]` + log debug.
+- All via the layout file logger.
+
+## 8. Testing
+
+- **`tests/layout/test_polygon.py`** *(pure)* — half-plane clip of a square;
+  per-edge inset of a square (boundary=`margin` vs interior=`gutter/2`); concave
+  **L-shape inset** (reflex vertex) produces the expected ring; `union_polygons`
+  of two adjacent cells → expected ring (incl. a partial-shared-edge case);
+  thin-panel collapse → dropped + logged; `polygon_to_segments` round-trips.
+- **`tests/layout/test_tiling.py`** *(pure)* — `grid(2,2)` → 4 panels; measured
+  inter-panel gap == `gutter` and outer == `margin` (assert on coordinates);
+  angled (`skew`) cut → a non-axis-aligned gutter edge; `merge` group → one
+  concave panel (expected vertex count); `bleed` leaf → its boundary edges reach
+  `page_rect`; `apply_tiling` seeds `shape="path"` regions with floating on top
+  (higher z); every emitted region passes #1's `validate_segments` and a schema
+  round-trip.
+- **`tests/layout/test_tiling_render.py`** *(one offscreen Qt smoke test)* —
+  render a tiled page via #1's `render_page_to_image` and assert the gutter
+  between two panels is the page background (the whitespace is now intentional,
+  uniform, and the two sub-projects compose).
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q`.
+
+## 9. Cross-cutting compliance
+- All errors logged (file + console), platform-independent.
+- No size/ratio tokens in prompts (N/A — geometry only).
+- Images scaled-not-cropped at generation; tiling only defines panel shapes.
+- No new third-party dependency (hand-rolled polygon math).
+
+## 10. Acceptance criteria (definition of done for #2)
+1. `grid(rows, cols)` produces gap-free panels whose inter-panel gutters measure
+   `gutter` and whose outer margin measures `margin`.
+2. An angled (`skew`) cut yields a non-axis-aligned gutter between panels.
+3. A `merge` group yields a single concave panel (correct reflex ring).
+4. A `bleed` leaf's page-border edges reach `page_rect` (no inset there); interior
+   edges still inset by `gutter/2`.
+5. `apply_tiling` seeds `page.regions` with `shape="path"` regions and layers
+   `floating` panels on top (higher z).
+6. Every emitted region passes #1's `validate_segments` and serializes/round-trips
+   via `schema.py`; a tiled page renders through #1 with background-colored gutters.
+7. Malformed trees raise with context; thin/collapsed panels and disconnected
+   merges are logged, never crash. Full `tests/layout/` suite stays green.

--- a/Plans/2026-06-27-comic-layout-tiling-engine-plan.md
+++ b/Plans/2026-06-27-comic-layout-tiling-engine-plan.md
@@ -1,0 +1,1069 @@
+# Comic Layout — Tiling Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A pure, dependency-free page-partition engine that divides a page into a gap-free tiling of panels (any-angle slice tree, concave cell-merge) and creates every gutter by per-edge inset, emitting `shape="path"` `Region`s that sub-project #1's renderer draws unchanged.
+
+**Architecture:** Two new pure modules. `core/layout/polygon.py` holds straight-edge polygon math (half-plane clip, per-edge inset, edge-cancellation union, polygon→segments). `core/layout/tiling.py` holds a `Split`/`Leaf` slice-tree model and `tile()` which runs partition→merge→inset, plus preset trees and `apply_tiling()`. No Qt in either module; no renderer changes.
+
+**Tech Stack:** Python 3.12, pytest. Reuses `PathSegment`/`Region` (`core/layout/models.py`), `validate_segments`/`segments_bbox` (`core/layout/geometry.py`), and #1's `qt_renderer`/`schema` for the integration tests only. Renderer/serialization tests run headless under `QT_QPA_PLATFORM=offscreen`.
+
+## Global Constraints
+
+- Test interpreter: `.venv_linux/bin/python`. Run tests with `QT_QPA_PLATFORM=offscreen` (required for the Qt integration test; harmless for pure tests).
+- Full layout suite must stay green: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` (currently **195 passed** on branch `feat/comic-layout-geometry-core`).
+- **No new third-party dependency** — all polygon math is hand-rolled in `core/layout/polygon.py`.
+- `core/layout/polygon.py` and `core/layout/tiling.py` must be **Qt-free** (importable headless).
+- **All errors logged** (platform-independent `logging.getLogger(__name__)`): disconnected merge groups, collapsed/too-thin panels, and clamped degenerate cuts are logged, never crash.
+- Output regions use `shape="path"` + `segments`; every emitted region must pass `validate_segments` and round-trip through `core/layout/schema.py`. No renderer edits.
+- Coordinates are page pixels (floats). Use a shared `EPS = 1e-9` for geometric predicates and quantize to 3 decimals (`_q`) before edge cancellation.
+- Conventional Commits (`feat(layout): …`). Commit after each task.
+- **Branch:** continue on `feat/comic-layout-geometry-core` (all 5 comic-layout sub-projects share one branch). **Do NOT open a pull request** — the single PR comes only after sub-project #5.
+
+---
+
+### Task 1: `polygon.py` foundation — orientation, half-plane clip, segments
+
+**Files:**
+- Create: `core/layout/polygon.py`
+- Test: `tests/layout/test_polygon.py` (create)
+
+**Interfaces:**
+- Consumes: `PathSegment` from `core.layout.models`.
+- Produces:
+  - `Point = Tuple[float, float]`, `Poly = List[Point]` (open ring — no repeated closing vertex).
+  - `signed_area(poly: Poly) -> float`
+  - `ensure_orientation(poly: Poly) -> Poly` (returns a copy with positive signed area)
+  - `clip_halfplane(poly: Poly, a: Point, b: Point) -> Poly` (keeps the sub-polygon on the left of directed line a→b; may return `[]`)
+  - `polygon_to_segments(poly: Poly) -> List[PathSegment]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_polygon.py`:
+
+```python
+from core.layout.polygon import (
+    signed_area, ensure_orientation, clip_halfplane, polygon_to_segments,
+)
+
+
+SQUARE = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]  # positive area in screen coords
+
+
+def test_signed_area_positive_for_canonical_square():
+    assert signed_area(SQUARE) == 100.0
+
+
+def test_ensure_orientation_flips_negative():
+    rev = list(reversed(SQUARE))
+    assert signed_area(rev) == -100.0
+    fixed = ensure_orientation(rev)
+    assert signed_area(fixed) == 100.0
+
+
+def test_ensure_orientation_keeps_positive():
+    assert ensure_orientation(SQUARE) == SQUARE
+
+
+def test_clip_halfplane_keeps_left_half():
+    # vertical line downward through x=5: a=(5,0)->b=(5,10); left of downward is x<5
+    clipped = clip_halfplane(SQUARE, (5.0, 0.0), (5.0, 10.0))
+    xs = sorted({round(x, 3) for x, _ in clipped})
+    assert xs == [0.0, 5.0]  # west half only
+    assert abs(signed_area(clipped)) == 50.0
+
+
+def test_clip_halfplane_other_side_by_reversing():
+    clipped = clip_halfplane(SQUARE, (5.0, 10.0), (5.0, 0.0))  # reversed -> east half
+    xs = sorted({round(x, 3) for x, _ in clipped})
+    assert xs == [5.0, 10.0]
+
+
+def test_polygon_to_segments_round_trip_shape():
+    segs = polygon_to_segments([(1.0, 2.0), (3.0, 2.0), (2.0, 5.0)])
+    assert [s.type for s in segs] == ["move", "line", "line", "close"]
+    assert segs[0].pts == [(1.0, 2.0)]
+    assert segs[1].pts == [(3.0, 2.0)]
+    assert segs[2].pts == [(2.0, 5.0)]
+    assert segs[3].pts == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_polygon.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'core.layout.polygon'`.
+
+- [ ] **Step 3: Implement `polygon.py` foundation**
+
+Create `core/layout/polygon.py`:
+
+```python
+"""Pure straight-edge polygon math for the tiling engine (no Qt).
+
+Polygons are open rings: a list of (x, y) points with no repeated closing
+vertex. "Positive signed area" is the canonical orientation; in screen
+coordinates (y down) the interior then lies to the LEFT of each directed edge,
+so the inward normal of edge direction (dx, dy) is (-dy, dx).
+"""
+from __future__ import annotations
+
+import logging
+import math
+from typing import List, Optional, Tuple
+
+from core.layout.models import PathSegment
+
+logger = logging.getLogger(__name__)
+
+Point = Tuple[float, float]
+Poly = List[Point]
+
+EPS = 1e-9
+
+
+def signed_area(poly: Poly) -> float:
+    n = len(poly)
+    s = 0.0
+    for i in range(n):
+        x1, y1 = poly[i]
+        x2, y2 = poly[(i + 1) % n]
+        s += x1 * y2 - x2 * y1
+    return s / 2.0
+
+
+def ensure_orientation(poly: Poly) -> Poly:
+    """Return a copy oriented to positive signed area (canonical)."""
+    return list(reversed(poly)) if signed_area(poly) < 0 else list(poly)
+
+
+def _cross(o: Point, a: Point, b: Point) -> float:
+    """Cross product (a-o) x (b-o); >0 means b is left of ray o->a's... use as side test."""
+    return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+
+
+def _side(p: Point, a: Point, b: Point) -> float:
+    """>0 if p is left of directed line a->b, <0 right, ~0 on the line."""
+    return (b[0] - a[0]) * (p[1] - a[1]) - (b[1] - a[1]) * (p[0] - a[0])
+
+
+def clip_halfplane(poly: Poly, a: Point, b: Point) -> Poly:
+    """Sutherland-Hodgman clip: keep the part of poly on the LEFT of line a->b."""
+    if not poly:
+        return []
+    out: Poly = []
+    n = len(poly)
+    for i in range(n):
+        cur = poly[i]
+        nxt = poly[(i + 1) % n]
+        s_cur = _side(cur, a, b)
+        s_nxt = _side(nxt, a, b)
+        cur_in = s_cur >= -EPS
+        nxt_in = s_nxt >= -EPS
+        if cur_in:
+            out.append(cur)
+        if cur_in != nxt_in:
+            denom = (s_cur - s_nxt)
+            if abs(denom) > EPS:
+                t = s_cur / denom
+                out.append((cur[0] + t * (nxt[0] - cur[0]),
+                            cur[1] + t * (nxt[1] - cur[1])))
+    # drop consecutive duplicates introduced by clipping
+    cleaned: Poly = []
+    for p in out:
+        if not cleaned or abs(p[0] - cleaned[-1][0]) > EPS or abs(p[1] - cleaned[-1][1]) > EPS:
+            cleaned.append(p)
+    if len(cleaned) >= 2 and abs(cleaned[0][0] - cleaned[-1][0]) <= EPS and abs(cleaned[0][1] - cleaned[-1][1]) <= EPS:
+        cleaned.pop()
+    return cleaned
+
+
+def polygon_to_segments(poly: Poly) -> List[PathSegment]:
+    """Convert an open-ring polygon to move/line.../close PathSegments."""
+    if not poly:
+        return []
+    segs = [PathSegment(type="move", pts=[(float(poly[0][0]), float(poly[0][1]))])]
+    for p in poly[1:]:
+        segs.append(PathSegment(type="line", pts=[(float(p[0]), float(p[1]))]))
+    segs.append(PathSegment(type="close", pts=[]))
+    return segs
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_polygon.py -q`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/polygon.py tests/layout/test_polygon.py
+git commit -m "feat(layout): polygon.py foundation — orientation, half-plane clip, segments"
+```
+
+---
+
+### Task 2: `polygon.py` — per-edge inset
+
+**Files:**
+- Modify: `core/layout/polygon.py`
+- Test: `tests/layout/test_polygon.py` (extend)
+
+**Interfaces:**
+- Consumes: `Poly`, `EPS`, `ensure_orientation`, `signed_area` (Task 1).
+- Produces: `inset_polygon(poly: Poly, dists: List[float], *, miter_limit: float = 4.0) -> Optional[Poly]` — offsets edge `i` (from `poly[i]` to `poly[i+1]`) inward by `dists[i]`; returns the inset polygon, or `None` if it collapses (non-positive area / fewer than 3 vertices).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/layout/test_polygon.py`:
+
+```python
+from core.layout.polygon import inset_polygon
+
+
+def test_inset_square_uniform():
+    sq = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]
+    out = inset_polygon(sq, [1.0, 1.0, 1.0, 1.0])
+    xs = sorted({round(x, 3) for x, _ in out})
+    ys = sorted({round(y, 3) for _, y in out})
+    assert xs == [1.0, 9.0]
+    assert ys == [1.0, 9.0]
+
+
+def test_inset_square_per_edge_distances():
+    # edges: 0:(0,0)->(10,0) top, 1:(10,0)->(10,10) right, 2:(10,10)->(0,10) bottom, 3:(0,10)->(0,0) left
+    sq = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]
+    out = inset_polygon(sq, [2.0, 1.0, 2.0, 1.0])  # top/bottom in 2, left/right in 1
+    xs = sorted({round(x, 3) for x, _ in out})
+    ys = sorted({round(y, 3) for _, y in out})
+    assert xs == [1.0, 9.0]   # left/right edges moved 1
+    assert ys == [2.0, 8.0]   # top/bottom edges moved 2
+
+
+def test_inset_concave_L_keeps_reflex():
+    # L-shape (concave): 6 vertices, positive area
+    L = [(0.0, 0.0), (10.0, 0.0), (10.0, 4.0), (4.0, 4.0), (4.0, 10.0), (0.0, 10.0)]
+    out = inset_polygon(L, [1.0] * 6)
+    assert out is not None
+    assert len(out) == 6                      # still an L (one reflex vertex)
+    assert signed_area(out) > 0
+    assert signed_area(out) < signed_area(L)  # shrunk
+
+
+def test_inset_collapse_returns_none():
+    sq = [(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]
+    assert inset_polygon(sq, [3.0, 3.0, 3.0, 3.0]) is None  # 3+3 > 4 each axis -> collapse
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_polygon.py -k inset -q`
+Expected: FAIL — `ImportError: cannot import name 'inset_polygon'`.
+
+- [ ] **Step 3: Implement `inset_polygon`**
+
+Append to `core/layout/polygon.py`:
+
+```python
+def _unit(dx: float, dy: float) -> Tuple[float, float]:
+    h = math.hypot(dx, dy)
+    if h <= EPS:
+        return (0.0, 0.0)
+    return (dx / h, dy / h)
+
+
+def _line_intersect(p1: Point, d1: Point, p2: Point, d2: Point) -> Optional[Point]:
+    """Intersect line p1+t*d1 with p2+u*d2. None if (near-)parallel."""
+    denom = d1[0] * d2[1] - d1[1] * d2[0]
+    if abs(denom) <= EPS:
+        return None
+    t = ((p2[0] - p1[0]) * d2[1] - (p2[1] - p1[1]) * d2[0]) / denom
+    return (p1[0] + t * d1[0], p1[1] + t * d1[1])
+
+
+def inset_polygon(poly: Poly, dists: List[float], *, miter_limit: float = 4.0) -> Optional[Poly]:
+    """Offset each edge inward by dists[i]; return inset polygon or None on collapse.
+
+    Edge i runs poly[i] -> poly[i+1]. Inward normal (positive orientation,
+    screen coords) is (-dy, dx). New vertex i is the intersection of the offset
+    lines of edge i-1 and edge i (miter join); a near-parallel pair falls back to
+    the offset point (bevel-equivalent). Returns None if the result is degenerate.
+    """
+    poly = ensure_orientation(poly)
+    n = len(poly)
+    if n < 3 or len(dists) != n:
+        return None
+    # offset line per edge: a point on it + its direction
+    off_pt: List[Point] = []
+    off_dir: List[Point] = []
+    for i in range(n):
+        p, q = poly[i], poly[(i + 1) % n]
+        dx, dy = q[0] - p[0], q[1] - p[1]
+        ux, uy = _unit(dx, dy)
+        nx, ny = -uy, ux  # inward normal for positive-area poly in screen coords
+        d = dists[i]
+        off_pt.append((p[0] + nx * d, p[1] + ny * d))
+        off_dir.append((dx, dy))
+    out: Poly = []
+    for i in range(n):
+        prev = (i - 1) % n
+        pt = _line_intersect(off_pt[prev], off_dir[prev], off_pt[i], off_dir[i])
+        if pt is None:
+            pt = off_pt[i]  # parallel consecutive edges -> use offset point
+        else:
+            # crude miter clamp: if the join shot far from the original vertex, bevel to offset point
+            ox, oy = poly[i]
+            if math.hypot(pt[0] - ox, pt[1] - oy) > miter_limit * (max(dists) + EPS):
+                pt = off_pt[i]
+        out.append(pt)
+    # collapse guards
+    if len(out) < 3 or signed_area(out) <= EPS:
+        return None
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_polygon.py -k inset -q`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/polygon.py tests/layout/test_polygon.py
+git commit -m "feat(layout): per-edge polygon inset (miter join, collapse guard)"
+```
+
+---
+
+### Task 3: `polygon.py` — edge-cancellation union
+
+**Files:**
+- Modify: `core/layout/polygon.py`
+- Test: `tests/layout/test_polygon.py` (extend)
+
+**Interfaces:**
+- Consumes: `Poly`, `EPS`, `ensure_orientation` (Task 1).
+- Produces: `union_polygons(polys: List[Poly]) -> List[Poly]` — unions edge-sharing polygons by directed-edge cancellation (with colinear-overlap subdivision); returns one ring per connected component (positive orientation). Quantizes vertices to 3 decimals so shared vertices match.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/layout/test_polygon.py`:
+
+```python
+from core.layout.polygon import union_polygons
+
+
+def test_union_two_adjacent_squares_is_rectangle():
+    left = [(0.0, 0.0), (5.0, 0.0), (5.0, 10.0), (0.0, 10.0)]
+    right = [(5.0, 0.0), (10.0, 0.0), (10.0, 10.0), (5.0, 10.0)]
+    rings = union_polygons([left, right])
+    assert len(rings) == 1
+    ring = rings[0]
+    xs = sorted({round(x, 3) for x, _ in ring})
+    ys = sorted({round(y, 3) for _, y in ring})
+    assert xs == [0.0, 10.0] and ys == [0.0, 10.0]
+    assert len(ring) == 4  # the shared interior edge is gone
+
+
+def test_union_makes_concave_L():
+    # bottom wide strip + top-left square -> L shape
+    bottom = [(0.0, 6.0), (10.0, 6.0), (10.0, 10.0), (0.0, 10.0)]
+    topleft = [(0.0, 0.0), (4.0, 0.0), (4.0, 6.0), (0.0, 6.0)]
+    rings = union_polygons([bottom, topleft])
+    assert len(rings) == 1
+    assert len(rings[0]) == 6  # L-shape has 6 vertices (one reflex)
+
+
+def test_union_partial_shared_edge():
+    # right cell is shorter than left's full edge -> partial colinear overlap
+    left = [(0.0, 0.0), (5.0, 0.0), (5.0, 10.0), (0.0, 10.0)]
+    right = [(5.0, 0.0), (10.0, 0.0), (10.0, 5.0), (5.0, 5.0)]
+    rings = union_polygons([left, right])
+    assert len(rings) == 1
+    assert abs(_area(rings[0]) - 75.0) < 1e-6  # 50 + 25
+
+
+def test_union_disconnected_returns_two_rings():
+    a = [(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)]
+    b = [(8.0, 8.0), (10.0, 8.0), (10.0, 10.0), (8.0, 10.0)]
+    rings = union_polygons([a, b])
+    assert len(rings) == 2
+
+
+def _area(poly):
+    from core.layout.polygon import signed_area
+    return abs(signed_area(poly))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_polygon.py -k union -q`
+Expected: FAIL — `ImportError: cannot import name 'union_polygons'`.
+
+- [ ] **Step 3: Implement `union_polygons`**
+
+Append to `core/layout/polygon.py`:
+
+```python
+def _q(p: Point) -> Point:
+    return (round(p[0], 3), round(p[1], 3))
+
+
+def _colinear_between(a: Point, b: Point, p: Point) -> bool:
+    """True if p is colinear with a-b and strictly between a and b."""
+    cross = (b[0] - a[0]) * (p[1] - a[1]) - (b[1] - a[1]) * (p[0] - a[0])
+    if abs(cross) > 1e-6:
+        return False
+    dot = (p[0] - a[0]) * (b[0] - a[0]) + (p[1] - a[1]) * (b[1] - a[1])
+    if dot <= EPS:
+        return False
+    l2 = (b[0] - a[0]) ** 2 + (b[1] - a[1]) ** 2
+    return dot < l2 - EPS
+
+
+def _subdivide(edges: List[Tuple[Point, Point]]) -> List[Tuple[Point, Point]]:
+    """Split each edge at any other edge's endpoint that lies on it (colinear)."""
+    pts = set()
+    for a, b in edges:
+        pts.add(a)
+        pts.add(b)
+    out: List[Tuple[Point, Point]] = []
+    for a, b in edges:
+        cuts = [p for p in pts if _colinear_between(a, b, p)]
+        cuts.sort(key=lambda p: (p[0] - a[0]) ** 2 + (p[1] - a[1]) ** 2)
+        chain = [a] + cuts + [b]
+        for i in range(len(chain) - 1):
+            out.append((chain[i], chain[i + 1]))
+    return out
+
+
+def union_polygons(polys: List[Poly]) -> List[Poly]:
+    """Union edge-sharing polygons via directed-edge cancellation.
+
+    Returns one positively-oriented ring per connected component. Vertices are
+    quantized to 3 decimals so shared edges match exactly.
+    """
+    edges: List[Tuple[Point, Point]] = []
+    for poly in polys:
+        ring = [_q(p) for p in ensure_orientation(poly)]
+        n = len(ring)
+        for i in range(n):
+            edges.append((ring[i], ring[(i + 1) % n]))
+    edges = _subdivide(edges)
+    # cancel exact opposite duplicates
+    from collections import Counter
+    counts: Counter = Counter(edges)
+    survivors: List[Tuple[Point, Point]] = []
+    for e in counts:
+        a, b = e
+        opp = (b, a)
+        net = counts[e] - counts.get(opp, 0)
+        for _ in range(max(0, net)):
+            survivors.append(e)
+    # chain survivors into rings
+    from collections import defaultdict
+    starts = defaultdict(list)
+    for e in survivors:
+        starts[e[0]].append(e)
+    rings: List[Poly] = []
+    used = set()
+    for e0 in survivors:
+        if id(e0) in used:
+            continue
+        ring: Poly = []
+        cur = e0
+        guard = 0
+        while True:
+            guard += 1
+            if guard > len(survivors) + 5:
+                break
+            used.add(id(cur))
+            ring.append(cur[0])
+            nexts = [e for e in starts[cur[1]] if id(e) not in used]
+            if not nexts:
+                break
+            cur = nexts[0]
+            if cur is e0 or cur[1] == e0[0] and id(cur) == id(e0):
+                break
+            if cur[0] == e0[0]:
+                ring.append(cur[0])
+                used.add(id(cur))
+                break
+        if len(ring) >= 3:
+            rings.append(ensure_orientation(ring))
+    return rings
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_polygon.py -k union -q`
+Expected: PASS (4 passed). If the chaining `guard`/termination misbehaves on a case, fix the loop so each connected component yields exactly one closed ring (the tests pin the expected ring counts and areas).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/polygon.py tests/layout/test_polygon.py
+git commit -m "feat(layout): edge-cancellation polygon union (colinear subdivision)"
+```
+
+---
+
+### Task 4: `tiling.py` — slice-tree model + `tile()` partition + per-edge inset
+
+**Files:**
+- Create: `core/layout/tiling.py`
+- Test: `tests/layout/test_tiling.py` (create)
+
+**Interfaces:**
+- Consumes: `clip_halfplane`, `inset_polygon`, `polygon_to_segments`, `Poly` (`core/layout/polygon.py`); `Region` (`core/layout/models.py`); `segments_bbox` (`core/layout/geometry.py`).
+- Produces:
+  - `@dataclass Split(axis: Literal["x","y"], at: float, a: Node, b: Node, skew: float = 0.0)`
+  - `@dataclass Leaf(id: str, kind: Literal["image","text"]="image", bleed: bool=False, merge: Optional[str]=None)`
+  - `Node = Union[Split, Leaf]`
+  - `tile(tree: Node, page_rect: Tuple[float,float,float,float], *, gutter: float, margin: float) -> List[Region]` (this task: no merge yet — every leaf is its own panel)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_tiling.py`:
+
+```python
+from core.layout.tiling import Split, Leaf, tile
+
+
+def _bbox(region):
+    return tuple(round(v) for v in __import__("core.layout.geometry", fromlist=["segments_bbox"]).segments_bbox(region.segments))
+
+
+def test_single_leaf_full_page_has_margin():
+    tree = Leaf(id="only")
+    regions = tile(tree, (0, 0, 100, 100), gutter=10, margin=8)
+    assert len(regions) == 1
+    x, y, w, h = _bbox(regions[0])
+    # all four edges are page boundary -> inset by margin (8) on each side
+    assert (x, y, w, h) == (8, 8, 84, 84)
+
+
+def test_grid_2x2_gutters_and_margin():
+    # vertical split into left/right, each split into top/bottom
+    col = lambda pfx: Split(axis="y", at=0.5, a=Leaf(id=pfx + "t"), b=Leaf(id=pfx + "b"))
+    tree = Split(axis="x", at=0.5, a=col("L"), b=col("R"))
+    regions = {r.id: _bbox(r) for r in tile(tree, (0, 0, 100, 100), gutter=10, margin=10)}
+    assert len(regions) == 4
+    # left-top panel: left/top edges are page border (margin 10), right/bottom are interior (gutter/2 = 5)
+    # page split at x=50, y=50 -> Lt cell is (0,0,50,50); inset L/T by 10, R/B by 5
+    assert regions["Lt"] == (10, 10, 35, 35)   # x:10..45, y:10..45
+    assert regions["Rb"] == (55, 55, 35, 35)   # mirror
+    # gutter between Lt and Rt = (55 - 45) = 10 == gutter
+    assert regions["Rt"][0] - (regions["Lt"][0] + regions["Lt"][2]) == 10
+
+
+def test_angled_cut_produces_non_axis_aligned_edge():
+    tree = Split(axis="x", at=0.5, a=Leaf(id="L"), b=Leaf(id="R"), skew=0.5)
+    regions = {r.id: r for r in tile(tree, (0, 0, 100, 100), gutter=8, margin=8)}
+    left = regions["L"]
+    # the shared (interior) edge is slanted: its two endpoints differ in x
+    xs = sorted({round(p.pts[0][0], 2) for p in left.segments if p.pts})
+    assert max(xs) - min(xs) > 1.0  # not a single vertical line -> angled
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_tiling.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'core.layout.tiling'`.
+
+- [ ] **Step 3: Implement the model + partition + inset (no merge)**
+
+Create `core/layout/tiling.py`:
+
+```python
+"""Page-partition (tiling) engine: slice tree -> gap-free panels -> inset gutters.
+
+Pure (no Qt). Emits shape="path" Regions rendered by the geometry/render core.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import List, Literal, Optional, Tuple, Union
+
+from core.layout.geometry import segments_bbox
+from core.layout.models import Region
+from core.layout.polygon import (
+    Poly, clip_halfplane, inset_polygon, polygon_to_segments, EPS,
+)
+
+logger = logging.getLogger(__name__)
+
+Rect = Tuple[float, float, float, float]  # (x, y, w, h)
+_CUT_EPS = 1e-3
+
+
+@dataclass
+class Split:
+    axis: Literal["x", "y"]   # "x" = vertical cut (left/right); "y" = horizontal (top/bottom)
+    at: float                 # fraction (0,1) of the cell bbox along the axis
+    a: "Node"                 # left / top child
+    b: "Node"                 # right / bottom child
+    skew: float = 0.0         # [-1,1]; angled gutter
+
+
+@dataclass
+class Leaf:
+    id: str
+    kind: Literal["image", "text"] = "image"
+    bleed: bool = False
+    merge: Optional[str] = None
+
+
+Node = Union[Split, Leaf]
+
+
+def _cut_line(cell: Poly, split: Split) -> Tuple[Tuple[float, float], Tuple[float, float]]:
+    xs = [p[0] for p in cell]
+    ys = [p[1] for p in cell]
+    minx, maxx, miny, maxy = min(xs), max(xs), min(ys), max(ys)
+    at = min(max(split.at, _CUT_EPS), 1 - _CUT_EPS)
+    skew = max(-1.0, min(1.0, split.skew))
+    if split.axis == "x":
+        x = minx + at * (maxx - minx)
+        dx = skew * (maxx - minx) * 0.5
+        return ((x + dx, miny), (x - dx, maxy))  # downward-directed: left of it is the 'a' (west) half
+    else:
+        y = miny + at * (maxy - miny)
+        dy = skew * (maxy - miny) * 0.5
+        return ((minx, y + dy), (maxx, y - dy))  # rightward-directed: left of it is the 'a' (north) half
+
+
+def _collect_leaves(node: Node, cell: Poly, out: List[Tuple[Leaf, Poly]]) -> None:
+    if isinstance(node, Leaf):
+        if len(cell) >= 3:
+            out.append((node, cell))
+        else:
+            logger.warning("Tiling: leaf %s produced a degenerate cell; dropped", node.id)
+        return
+    if not isinstance(node, Split):
+        raise ValueError(f"Tiling: unknown node type {type(node)!r}")
+    if node.a is None or node.b is None:
+        raise ValueError("Tiling: Split must have both children")
+    a, b = _cut_line(cell, node)
+    _collect_leaves(node.a, clip_halfplane(cell, a, b), out)
+    _collect_leaves(node.b, clip_halfplane(cell, b, a), out)
+
+
+def _edge_is_boundary(p: Tuple[float, float], q: Tuple[float, float], rect: Rect) -> bool:
+    rx, ry, rw, rh = rect
+    sides = ((0, rx), (0, rx + rw), (1, ry), (1, ry + rh))
+    for coord, val in sides:
+        if abs(p[coord] - val) <= _CUT_EPS and abs(q[coord] - val) <= _CUT_EPS:
+            return True
+    return False
+
+
+def _inset_dists(panel: Poly, rect: Rect, *, gutter: float, margin: float, bleed: bool) -> List[float]:
+    n = len(panel)
+    dists: List[float] = []
+    for i in range(n):
+        p, q = panel[i], panel[(i + 1) % n]
+        if _edge_is_boundary(p, q, rect):
+            dists.append(0.0 if bleed else margin)
+        else:
+            dists.append(gutter / 2.0)
+    return dists
+
+
+def _panel_to_region(panel: Poly, leaf: Leaf, rect: Rect, *, gutter: float, margin: float, z: int) -> Optional[Region]:
+    dists = _inset_dists(panel, rect, gutter=gutter, margin=margin, bleed=leaf.bleed)
+    inset = inset_polygon(panel, dists)
+    if inset is None:
+        logger.warning("Tiling: panel %s too thin for gutter; dropped", leaf.id)
+        return None
+    segs = polygon_to_segments(inset)
+    bx, by, bw, bh = (round(v) for v in segments_bbox(segs))
+    return Region(id=leaf.id, kind=leaf.kind, shape="path", segments=segs,
+                  bleed=leaf.bleed, bbox=(bx, by, bw, bh), z=z)
+
+
+def tile(tree: Node, page_rect: Rect, *, gutter: float, margin: float) -> List[Region]:
+    """Partition page_rect by the slice tree and inset each leaf into a Region."""
+    rx, ry, rw, rh = page_rect
+    page_poly: Poly = [(rx, ry), (rx + rw, ry), (rx + rw, ry + rh), (rx, ry + rh)]
+    leaves: List[Tuple[Leaf, Poly]] = []
+    _collect_leaves(tree, page_poly, leaves)
+    regions: List[Region] = []
+    z = 0
+    for leaf, cell in leaves:
+        r = _panel_to_region(cell, leaf, page_rect, gutter=gutter, margin=margin, z=z)
+        if r is not None:
+            regions.append(r)
+            z += 1
+    return regions
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_tiling.py -q`
+Expected: PASS (3 passed). If `test_grid_2x2` bbox numbers are off by rounding, confirm the cut is exactly at x=50/y=50 and the inset distances are margin=10 (boundary) / gutter/2=5 (interior) — the expected boxes follow directly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/tiling.py tests/layout/test_tiling.py
+git commit -m "feat(layout): tiling slice-tree model + tile() partition + per-edge inset"
+```
+
+---
+
+### Task 5: `tiling.py` — concave cell-merge + bleed
+
+**Files:**
+- Modify: `core/layout/tiling.py` (route merged leaves through `union_polygons`)
+- Test: `tests/layout/test_tiling.py` (extend)
+
+**Interfaces:**
+- Consumes: `union_polygons` (`core/layout/polygon.py`); everything from Task 4.
+- Produces: `tile(...)` now merges leaves sharing a `merge` key into one concave panel (inheriting the first such leaf's `id`/`kind`/`bleed`); a disconnected merge group is logged and left unmerged. Signature unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/layout/test_tiling.py`:
+
+```python
+from core.layout.geometry import segments_bbox
+
+
+def test_merge_group_forms_one_concave_panel():
+    # 3 cells; merge top-left + bottom (full width) into an L; top-right stays.
+    # layout: top tier split L/R; bottom tier full width.
+    top = Split(axis="x", at=0.5, a=Leaf(id="tl", merge="hero"), b=Leaf(id="tr"))
+    tree = Split(axis="y", at=0.5, a=top, b=Leaf(id="bottom", merge="hero"))
+    regions = {r.id: r for r in tile(tree, (0, 0, 100, 100), gutter=6, margin=6)}
+    # merged panel takes the first-encountered merged leaf's id ("tl"); "bottom" is absorbed
+    assert "tl" in regions and "bottom" not in regions and "tr" in regions
+    assert len(regions) == 2
+    hero = regions["tl"]
+    # concave L panel has more than 4 vertices (move + N lines + close)
+    line_pts = [s for s in hero.segments if s.type == "line"]
+    assert len(line_pts) >= 5  # L-shape -> >=6 vertices total
+
+
+def test_bleed_leaf_boundary_edges_reach_page_rect():
+    tree = Split(axis="x", at=0.5, a=Leaf(id="L", bleed=True), b=Leaf(id="R"))
+    regions = {r.id: r for r in tile(tree, (0, 0, 100, 100), gutter=10, margin=10)}
+    lx, ly, lw, lh = (round(v) for v in segments_bbox(regions["L"].segments))
+    # bleed: left/top/bottom boundary edges NOT inset (reach 0,0 and y=0..100); only the
+    # interior right edge insets by gutter/2 (5).
+    assert lx == 0 and ly == 0
+    assert lh == 100
+    assert lx + lw == 45  # 50 (cut) - 5 (interior gutter/2)
+
+
+def test_disconnected_merge_is_logged_and_unmerged(caplog):
+    import logging
+    # two non-adjacent cells share a merge key -> cannot union -> stay separate
+    top = Split(axis="x", at=0.5, a=Leaf(id="tl", merge="x"), b=Leaf(id="tr"))
+    tree = Split(axis="y", at=0.5, a=top, b=Split(axis="x", at=0.5, a=Leaf(id="bl"), b=Leaf(id="br", merge="x")))
+    with caplog.at_level(logging.ERROR):
+        regions = {r.id: r for r in tile(tree, (0, 0, 100, 100), gutter=6, margin=6)}
+    # tl and br are diagonal (not edge-adjacent) -> union yields 2 rings -> unmerged
+    assert "tl" in regions and "br" in regions
+    assert any("merge" in rec.message.lower() for rec in caplog.records)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_tiling.py -k "merge or bleed" -q`
+Expected: FAIL — current `tile()` ignores `merge` (emits `tl` and `bottom` separately; `test_merge_group_forms_one_concave_panel` fails).
+
+- [ ] **Step 3: Implement merge in `tile()`**
+
+In `core/layout/tiling.py`, add the import and replace the `tile` function body. Update the import line:
+
+```python
+from core.layout.polygon import (
+    Poly, clip_halfplane, inset_polygon, polygon_to_segments, union_polygons, EPS,
+)
+```
+
+Replace `tile` with:
+
+```python
+def tile(tree: Node, page_rect: Rect, *, gutter: float, margin: float) -> List[Region]:
+    """Partition page_rect, merge cells sharing a merge key, then inset each panel."""
+    rx, ry, rw, rh = page_rect
+    page_poly: Poly = [(rx, ry), (rx + rw, ry), (rx + rw, ry + rh), (rx, ry + rh)]
+    leaves: List[Tuple[Leaf, Poly]] = []
+    _collect_leaves(tree, page_poly, leaves)
+
+    # Build the panel list: each entry is (representative_leaf, panel_polygon).
+    panels: List[Tuple[Leaf, Poly]] = []
+    consumed_groups: set = set()
+    # group polygons by merge key, preserving first-encounter order
+    groups: dict = {}
+    order: List[Optional[str]] = []
+    for leaf, cell in leaves:
+        key = leaf.merge
+        if key is None:
+            order.append(id(leaf))
+            groups[id(leaf)] = (leaf, [cell])
+        else:
+            if key not in groups:
+                groups[key] = (leaf, [])
+                order.append(key)
+            groups[key][1].append(cell)
+
+    for key in order:
+        rep_leaf, cells = groups[key]
+        if len(cells) == 1:
+            panels.append((rep_leaf, cells[0]))
+            continue
+        rings = union_polygons(cells)
+        if len(rings) == 1:
+            panels.append((rep_leaf, rings[0]))
+        else:
+            logger.error("Tiling: merge group %r is disconnected (%d pieces); leaving unmerged",
+                         key, len(rings))
+            for ring in rings:
+                panels.append((rep_leaf, ring))
+
+    regions: List[Region] = []
+    z = 0
+    for leaf, panel in panels:
+        r = _panel_to_region(panel, leaf, page_rect, gutter=gutter, margin=margin, z=z)
+        if r is not None:
+            regions.append(r)
+            z += 1
+    return regions
+```
+
+Note: when a disconnected merge falls back to multiple rings they reuse `rep_leaf.id`; that is acceptable for the logged error path (the caller's tree was malformed). For the connected case each merge group yields exactly one region.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_tiling.py -q`
+Expected: PASS (all tiling tests). Then the full suite:
+`QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` → green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/tiling.py tests/layout/test_tiling.py
+git commit -m "feat(layout): concave cell-merge + bleed in the tiling engine"
+```
+
+---
+
+### Task 6: `tiling.py` — presets + `apply_tiling`
+
+**Files:**
+- Modify: `core/layout/tiling.py`
+- Test: `tests/layout/test_tiling_apply.py` (create)
+
+**Interfaces:**
+- Consumes: `tile`, `Split`, `Leaf` (Tasks 4–5); `PageSpec`, `Region` (`core/layout/models.py`); `validate_segments` (`core/layout/geometry.py`); `region_to_dict`/`region_from_dict` (`core/layout/schema.py`).
+- Produces:
+  - `grid(rows: int, cols: int, *, kind="image", prefix="p") -> Node`
+  - `three_tiers() -> Node`, `splash_with_strip() -> Node`, `diagonal_action() -> Node`, `feature_L() -> Node`
+  - `apply_tiling(page: PageSpec, tree: Node, *, gutter: float, margin: float, floating: Tuple[Region, ...]=()) -> PageSpec` — sets `page.regions = tiled + list(floating)` with floating at higher z; returns `page`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_tiling_apply.py`:
+
+```python
+from core.layout.models import PageSpec, Region
+from core.layout.tiling import grid, three_tiers, diagonal_action, feature_L, apply_tiling, tile
+from core.layout.geometry import validate_segments
+from core.layout.schema import region_to_dict, region_from_dict
+
+
+def test_grid_preset_counts():
+    assert len(tile(grid(2, 3), (0, 0, 120, 90), gutter=6, margin=6)) == 6
+
+
+def test_named_presets_build_and_tile():
+    for tree in (three_tiers(), diagonal_action(), feature_L()):
+        regions = tile(tree, (0, 0, 200, 300), gutter=8, margin=10)
+        assert regions  # non-empty
+        for r in regions:
+            assert r.shape == "path"
+            assert validate_segments(r.segments) == []  # every emitted region is a valid path
+
+
+def test_emitted_regions_round_trip_through_schema():
+    regions = tile(grid(2, 2), (0, 0, 100, 100), gutter=6, margin=6)
+    for r in regions:
+        r2 = region_from_dict(region_to_dict(r))
+        assert r2.shape == "path"
+        assert [s.type for s in r2.segments] == [s.type for s in r.segments]
+
+
+def test_apply_tiling_seeds_regions_and_layers_floating():
+    page = PageSpec(page_size_px=(100, 100))
+    floating = (Region(id="float1", kind="image", bbox=(20, 20, 30, 30)),)
+    out = apply_tiling(page, grid(2, 2), gutter=6, margin=6, floating=floating)
+    ids = [r.id for r in out.regions]
+    assert "float1" in ids
+    base = [r for r in out.regions if r.id != "float1"]
+    fl = [r for r in out.regions if r.id == "float1"][0]
+    # floating is layered on top: its z exceeds every base panel's z
+    assert fl.z > max(r.z for r in base)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_tiling_apply.py -q`
+Expected: FAIL — `ImportError: cannot import name 'grid'` (presets/apply not defined yet).
+
+- [ ] **Step 3: Implement presets + `apply_tiling`**
+
+Append to `core/layout/tiling.py` (add `PageSpec` to the models import: `from core.layout.models import Region, PageSpec`):
+
+```python
+def grid(rows: int, cols: int, *, kind: Literal["image", "text"] = "image", prefix: str = "p") -> Node:
+    """A regular rows x cols grid (nested y-then-x splits)."""
+    if rows < 1 or cols < 1:
+        raise ValueError("grid requires rows >= 1 and cols >= 1")
+
+    def row(r: int) -> Node:
+        def col(c: int) -> Node:
+            leaf = Leaf(id=f"{prefix}{r}_{c}", kind=kind)
+            if c == cols - 1:
+                return leaf
+            return Split(axis="x", at=1.0 / (cols - c), a=leaf, b=col(c + 1))
+        return col(0)
+
+    def build(r: int) -> Node:
+        if r == rows - 1:
+            return row(r)
+        return Split(axis="y", at=1.0 / (rows - r), a=row(r), b=build(r + 1))
+
+    return build(0)
+
+
+def three_tiers() -> Node:
+    """Three full-width horizontal tiers."""
+    return Split(axis="y", at=1 / 3, a=Leaf(id="t0"),
+                 b=Split(axis="y", at=0.5, a=Leaf(id="t1"), b=Leaf(id="t2")))
+
+
+def splash_with_strip() -> Node:
+    """A large top splash panel and a bottom strip of two."""
+    return Split(axis="y", at=0.66, a=Leaf(id="splash"),
+                 b=Split(axis="x", at=0.5, a=Leaf(id="s0"), b=Leaf(id="s1")))
+
+
+def diagonal_action() -> Node:
+    """Two panels divided by a strongly angled gutter."""
+    return Split(axis="x", at=0.5, a=Leaf(id="d0"), b=Leaf(id="d1"), skew=0.6)
+
+
+def feature_L() -> Node:
+    """A concave L hero (top-left + bottom strip merged) beside a tall right panel."""
+    top = Split(axis="x", at=0.6, a=Leaf(id="hero", merge="L"), b=Leaf(id="side"))
+    return Split(axis="y", at=0.6, a=top, b=Leaf(id="hero_b", merge="L"))
+
+
+def apply_tiling(page: PageSpec, tree: Node, *, gutter: float, margin: float,
+                 floating: Tuple[Region, ...] = ()) -> PageSpec:
+    """Tile the page and layer floating panels on top (higher z). Mutates + returns page."""
+    pw, ph = page.page_size_px
+    base = tile(tree, (0, 0, pw, ph), gutter=gutter, margin=margin)
+    next_z = (max((r.z for r in base), default=-1)) + 1
+    layered: List[Region] = list(base)
+    for r in floating:
+        r.z = next_z
+        next_z += 1
+        layered.append(r)
+    page.regions = layered
+    return page
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_tiling_apply.py -q`
+Expected: PASS (4 passed). Then full suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/tiling.py tests/layout/test_tiling_apply.py
+git commit -m "feat(layout): tiling presets + apply_tiling (floating layered on top)"
+```
+
+---
+
+### Task 7: Integration — a tiled page renders through #1 with background gutters
+
+**Files:**
+- Test: `tests/layout/test_tiling_render.py` (create)
+
+**Interfaces:**
+- Consumes: `grid`, `apply_tiling` (`core/layout/tiling.py`); `PageSpec` (`core/layout/models.py`); `render_page_to_image` (`core/layout/qt_renderer.py`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_tiling_render.py`:
+
+```python
+from core.layout.models import PageSpec
+from core.layout.tiling import grid, apply_tiling
+from core.layout import qt_renderer
+
+
+def test_tiled_page_renders_with_background_gutters(qapp):
+    # 1x2 grid on a white page: the vertical gutter between the two panels must be background.
+    page = PageSpec(page_size_px=(200, 100), background="#FFFFFF")
+    apply_tiling(page, grid(1, 2), gutter=20, margin=10)
+    img = qt_renderer.render_page_to_image(page)
+    assert img.width() == 200 and img.height() == 100
+    # center column (x=100) lies in the 20px gutter between the two panels -> background (white)
+    gutter_px = img.pixelColor(100, 50)
+    assert gutter_px.red() > 240 and gutter_px.green() > 240 and gutter_px.blue() > 240
+    # a point inside the left panel (well left of the gutter) is within an (empty) image
+    # placeholder frame, i.e. NOT the page background — the placeholder fill is grey.
+    left_px = img.pixelColor(40, 50)
+    assert not (left_px.red() > 240 and left_px.green() > 240 and left_px.blue() > 240)
+
+
+def test_two_panels_present(qapp):
+    page = PageSpec(page_size_px=(200, 100), background="#FFFFFF")
+    apply_tiling(page, grid(1, 2), gutter=20, margin=10)
+    assert len(page.regions) == 2
+    for r in page.regions:
+        assert r.shape == "path"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_tiling_render.py -q`
+Expected: This test should actually **pass on first run if Tasks 1–6 are correct** (it uses only already-built APIs). Per TDD, first run it BEFORE writing it is impossible; instead, write it and confirm it passes, and if it fails, the failure localizes a real integration defect (e.g., emitted segments the renderer rejects, or panels overlapping the gutter). Treat any failure here as a bug in Tasks 1–6 to fix, not a reason to weaken the assertion.
+
+- [ ] **Step 3: (No new implementation expected)**
+
+This task is the integration gate: it wires `tiling` → `qt_renderer` with no new production code. If it fails, debug the offending earlier module (most likely `inset_polygon` distances or `polygon_to_segments` orientation) until the gutter is genuinely background and two valid path regions render.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_tiling_render.py -q`
+Expected: PASS (2 passed). Then the FULL suite:
+`QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` → all green (195 + the new tiling/polygon tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/layout/test_tiling_render.py
+git commit -m "test(layout): tiled page renders through the geometry core with background gutters"
+```
+
+---
+
+## Notes / deliberately deferred (not gaps)
+- **GUI export still uses the PIL engine** (carried over from #1): a tiled page rendered via `qt_renderer` shows the new gutters, but `gui/layout/export_dialog.py` (PIL) does not. Migrating export onto the Qt renderer remains the biggest cross-cutting follow-up.
+- **AI designer (#4)** will emit `Split`/`Leaf` trees (or an `svg⇄segments`-style serialization of them); **manual editor (#5)** will author/drag them and must handle segment writeback (`_writeback_move` in `qt_renderer.py` only persists bbox/points today).
+- **Curved-edge tiling** is out of scope (research-grade); curves remain available for floating/bleed panels and balloons via #1.
+- **`union_polygons` robustness:** targets the exact-partition inputs the tiler produces (edge-sharing cells), with 3-decimal quantization + colinear subdivision. It is not a general boolean-union library; arbitrary overlapping polygons are out of scope.
+
+## Self-Review (completed by plan author)
+- **Spec coverage:** slice-tree model + any-angle cuts (T4); cell-merge concave (T5); partition→merge→inset pipeline (T4+T5); hand-rolled pure polygon math — clip (T1), inset (T2), union (T3); per-edge inset unifying margin/gutter/bleed (T4 `_inset_dists`, bleed in T5); floating+bleed layering (T6 `apply_tiling`); presets + apply (T6); no-renderer-change integration + validate/round-trip (T6, T7). All §2–§8 spec items map to a task; acceptance criteria 1–7 each have a covering test.
+- **Placeholder scan:** none — every code/test step is complete. (T7 intentionally has no new production code; its body explains the integration-gate semantics.)
+- **Type/name consistency:** `Split(axis,at,a,b,skew)`, `Leaf(id,kind,bleed,merge)`, `tile(tree, page_rect, *, gutter, margin)`, `clip_halfplane`, `inset_polygon(poly, dists)`, `union_polygons`, `polygon_to_segments`, `apply_tiling(page, tree, *, gutter, margin, floating)` are used identically across tasks; `Region(shape="path", segments=…)` matches #1's model.

--- a/Plans/2026-06-28-comic-layout-overlay-editing-design.md
+++ b/Plans/2026-06-28-comic-layout-overlay-editing-design.md
@@ -1,0 +1,122 @@
+# Comic Layout — Manual Editor: Overlay Editing + Export (sub-project #5c of 5, FINAL)
+
+**Status:** Design 2026-06-28. Scope user-approved (full overlay authoring + fold-in export unification).
+**Branch:** `feat/comic-layout-geometry-core` (all comic-layout sub-projects share one branch).
+**PR gate:** #5c is the LAST sub-project — open the single comic-layout PR after #5c is complete (when asked).
+
+## 1. Goal
+
+Complete the manual editor with **comic text-overlay authoring** and make **exports
+render the comic layout**:
+
+- **Place / move / delete** overlays (speech, thought, caption, SFX).
+- **Tail → region snap** — drag a balloon's tail; it snaps to the nearest panel.
+- **SFX rotation** — a new `Overlay.rotation` field, rendered, editable.
+- **Stranded-overlay reposition** — when a regions-only redesign leaves pixel-anchored
+  overlays floating over new panels, move them back onto a panel (#4 review #3 carry-forward).
+- **Export fold-in** — the Layout tab gets a Qt-path PNG export, and the stale PIL
+  export path is redirected to the Qt renderer, so PNG/PDF reflect geometry + overlays.
+
+## 2. Scope decisions (user-approved)
+
+| Decision | Choice |
+|----------|--------|
+| #5c overlay depth | **Full authoring** — place, move, tail-snap, delete, SFX rotation, stranded reposition |
+| Export | **Fold in** — exports must render comic geometry + overlays |
+| Rotation UX | **Inspector spin** (0–359°), not a drag handle — simpler, fully testable |
+| Overlay selection | **Overlay inspector list** (not canvas hit-testing) — avoids a second canvas selection path, keeps it testable; consistent with the inspector/controller split |
+| Stranded test | **bbox-based** — an overlay is "stranded" if its `anchor` lies outside every region's bbox; reposition = move `anchor` to the nearest region's bbox center |
+
+## 3. Current architecture (verified, with anchors)
+
+- **Overlay model** (`core/layout/models.py:141`): `id, kind ∈ {speech,thought,caption,sfx}, text, anchor:(float,float), anchor_mode ∈ {center,topleft}, tail_target:Optional[(float,float)], z, role, text_style, style:OverlayStyle`. No `rotation` yet.
+- **Serialization** (`core/layout/schema.py`): `overlay_to_dict:118` / `overlay_from_dict:132` (uses `_filtered(OverlayStyle, d)`); page round-trip at `to_dict:189` / `from_dict:213`. Back-compat: missing keys default.
+- **Rendering** (`core/layout/qt_renderer.py`): `_add_overlay:286` measures wrapped text → sizes `inner` rect → `balloons.overlay_to_segments(kind, inner, tail_target, style)` → `_OverlayPathItem` body (fill/stroke, clips text child) + `QGraphicsTextItem`; SFX has no body (text added directly). `build_scene:362` overlay pass sorts by `z`. Overlays are **not selectable** (no `setData`, no flags) — editing is via the controller, not canvas selection.
+- **Editor foundation (#5a/#5b):** `GeometryEditor` (handle regen after full-scene rebuild), `LayoutTab._refresh` rebuilds the scene + `rebuild_handles`, `snapshot_and_refresh`, `set_refresh_suspended`, `_current_page`. `CanvasWidget` has tool modes (#5b). `History.append` for undo.
+- **Export:** `qt_renderer.save_page_png:418` (`render_page_to_image:385` → includes overlays), `export_document_pdf:421`. Layout-tab "Export PDF…" → `export_pdf_to:442` → `qt_renderer.export_document_pdf` (already Qt). The PIL `gui/layout/export_dialog.py` (`LayoutExportWorker` → `core.layout.LayoutEngine`) is **unwired** (no callers) and bypasses overlays/geometry.
+- **Designer apply:** `LayoutTab.apply_designer_result:584` — overlays path at :598-599 (`if result.overlays: pages[0].overlays = list(result.overlays)`); the regions-only branch leaves prior overlays untouched (the stranding case).
+
+## 4. Architecture
+
+### 4.1 `Overlay.rotation` (model + serialization + render)
+
+- Add `rotation: float = 0.0` to `Overlay` (degrees clockwise about the body center / anchor). Back-compat: default 0.
+- `overlay_to_dict` writes `"rotation": ov.rotation`; `overlay_from_dict` reads `float(d.get("rotation", 0.0) or 0.0)` (degrade-safe).
+- `_add_overlay`: after building `body_item`/`text_item`, if `rotation` ≠ 0 apply a rotation transform about the anchor. For a body overlay, set the body's transform origin to the anchor and `setRotation(rotation)` (text is a child → rotates with it). For SFX (no body) rotate the text item about the anchor. Use `QGraphicsItem.setTransformOriginPoint` + `setRotation`.
+
+### 4.2 Pure stranded-overlay reposition (`core/layout/overlay_ops.py`, Qt-free)
+
+- `overlay_anchor_stranded(ov, regions) -> bool`: True if `ov.anchor` is outside every region's bbox.
+- `nearest_region_center(point, regions) -> Optional[(float,float)]`: bbox center of the region whose bbox center is nearest `point` (None if no regions).
+- `reposition_stranded_overlays(page) -> int`: for each stranded overlay, set `anchor` to `nearest_region_center`; return the count moved. No-op (0) if no regions. Pure, deterministic.
+
+### 4.3 `OverlayInspector` widget (`gui/layout/overlay_inspector.py`, emit-signals-only)
+
+A panel listing the page's overlays with authoring controls. Emits intent signals;
+`LayoutTab` owns all mutation (same split as Geometry/Content inspectors).
+- **Overlay list** (`QListWidget`) — selecting a row emits `overlaySelected(str)` (overlay id).
+- **Add row**: four buttons (Speech / Thought / Caption / SFX) → `addRequested(str kind)`.
+- **Delete** button → `deleteRequested(str id)`.
+- **Rotation** spin (`QSpinBox` 0–359, suffix °) → `rotationChanged(str id, int deg)`; enabled when an overlay is selected.
+- **"Edit on canvas"** toggle → `editToggled(str id, bool)` (drives `OverlayEditor`).
+- `set_page(page)` refreshes the list; `set_selected(overlay_id)` reflects selection + rotation without re-emitting (blockSignals).
+
+### 4.4 `OverlayEditor` controller (`gui/layout/overlay_editor.py`)
+
+Mirrors `GeometryEditor`: owns drag handles for ONE selected overlay; handles are
+**regenerated from the model after every scene rebuild** (`rebuild_handles`, called from
+`LayoutTab._refresh`). Handles (move-only, like #5a):
+- **Body handle** at `anchor` → drag writes `ov.anchor`; live-updates by reposition (a mid-drag `setPos` on the body group, or a lightweight refresh-suspend + re-add). Simplest consistent approach: suspend refresh on drag-start, mutate `ov.anchor` on move, commit = snapshot + refresh (re-lays handle). (No in-place body redraw needed — overlays are cheap to rebuild on commit; mid-drag we move only the handle + optionally the body item via `setPos`.)
+- **Tail handle** at `tail_target` (only if `tail_target` is not None) → drag writes `ov.tail_target`; **commit snaps** to `nearest_region_center` if within a snap radius (else keeps the dragged point).
+- Commit: `snapshot_and_refresh("edit overlay: <id>")`. Invalid/missing overlay → no-op + log.
+- `set_edit_overlay(id|None)`, `rebuild_handles()`, `begin_edit()`, `move_handle(kind, x, y)`, `commit()`. `_find_overlay(id)` via `page.overlays`.
+
+### 4.5 LayoutTab wiring
+
+`LayoutTab` owns all mutation:
+- `_add_overlay(kind)`: append a default `Overlay` (id `ov{N}`, default text per kind, `anchor` = page center, `tail_target` = None except speech/thought get a default below-center point) to `page.overlays`; `snapshot_and_refresh`; select it.
+- `_delete_overlay(id)`, `_set_overlay_rotation(id, deg)`, `_on_overlay_selected(id)` (drive inspector + editor), `_on_overlay_edit_toggled(id, on)`.
+- In `apply_designer_result` **regions-only** path (no `result.overlays`), call `overlay_ops.reposition_stranded_overlays(page)` so a redesign tidies orphaned overlays (logged: "repositioned N stranded overlays").
+- The overlay inspector + editor are created in `_build`; `_refresh` also calls `overlay_editor.rebuild_handles()` and `overlay_inspector.set_page(page)`.
+
+### 4.6 Export fold-in
+
+- **Layout tab PNG export:** add an "Export PNG…" toolbar action → `export_png_to(path)` → `qt_renderer.save_page_png(page, path, style=doc.style)` (Qt → overlays + geometry included).
+- **Retire the PIL bypass:** switch `gui/layout/export_dialog.py` `LayoutExportWorker._export_png`/`_export_pdf` to render via the Qt renderer (`qt_renderer.render_page_to_image(page).save(...)` and `qt_renderer.export_document_pdf(doc, ...)`) instead of `core.layout.LayoutEngine`, so any future use of that dialog renders the comic layout. `dpi` becomes advisory (Qt renders at `page_size_px`); document this in the dialog.
+
+## 5. Error handling / edge cases
+
+- **No regions** when repositioning / tail-snapping: `reposition_stranded_overlays` returns 0; tail-snap keeps the dragged point. Never crash.
+- **Malformed rotation** on load: `overlay_from_dict` coerces via `float(... or 0.0)`; non-numeric → 0.
+- **Edit overlay deleted** after a rebuild: `OverlayEditor.rebuild_handles` finds no overlay → clears edit mode + handles (mirror #5a).
+- **SFX rotation with no body:** rotate the text item directly about the anchor.
+- **All errors logged** via `logging.getLogger(__name__)`; a failed/again-degenerate op is a no-op + log, never a crash or corrupt model.
+
+## 6. Testing (headless, `QT_QPA_PLATFORM=offscreen`)
+
+Pure:
+- `Overlay.rotation` round-trips through `overlay_to_dict`/`overlay_from_dict` (incl. missing-key → 0.0, non-numeric → 0.0).
+- `overlay_ops`: stranded detection (anchor inside vs outside all bboxes); `nearest_region_center`; `reposition_stranded_overlays` moves only stranded ones + returns count; 0 with no regions.
+
+GUI:
+- `_add_overlay(kind)` appends one overlay + snapshot + selects it; `_delete_overlay` removes + snapshot; `_set_overlay_rotation` writes `ov.rotation` + snapshot.
+- `OverlayEditor` handle generation: body handle at anchor; tail handle present iff `tail_target`; move + commit writes `ov.anchor`/`ov.tail_target` + one snapshot; tail commit snaps to nearest region center within radius.
+- `OverlayInspector` signals (`addRequested`/`deleteRequested`/`rotationChanged`/`overlaySelected`/`editToggled`).
+- Renderer: an overlay with `rotation=30` yields a body (or sfx text) item whose `rotation()==30`.
+- `apply_designer_result` regions-only path repositions stranded overlays.
+- Export: `export_png_to` writes a non-empty PNG via the Qt path; the PIL worker now calls the Qt renderer (no `LayoutEngine` import for rendering).
+- Full layout suite stays green (baseline **316**; +N).
+
+## 7. Out of scope (deferred, not gaps)
+
+- **Contour-aware text wrapping** (text following a non-rect balloon's interior) — future polish.
+- **Rotation drag handle** (rotation is via the inspector spin in #5c).
+- **Overlay z-order UI** beyond existing `z` (no reorder widget) and **multi-overlay select**.
+- The #5b cleanup Minors (split id-uniqueness, mid-file test imports) — fold opportunistically if touched.
+
+## 8. Self-review (author)
+
+- **Placeholder scan:** none; every unit names a concrete file/interface and the existing helper it reuses (`overlay_to_segments`, `save_page_png`, `region` bbox).
+- **Consistency:** mutation only in `LayoutTab`; `overlay_ops.py` Qt-free + deterministic; `OverlayEditor` mirrors `GeometryEditor`'s regenerate-after-rebuild contract; rotation via spin keeps it testable.
+- **Scope:** full overlay authoring + export fold-in; sized for one plan (~7 tasks). Contour-wrapping + rotation-handle explicitly deferred.
+- **Ambiguity:** "stranded" = anchor outside all region bboxes; reposition target = nearest bbox center; rotation = degrees CW about anchor; tail-snap = nearest region center within a radius, else keep dragged point.

--- a/Plans/2026-06-28-comic-layout-overlay-editing-plan.md
+++ b/Plans/2026-06-28-comic-layout-overlay-editing-plan.md
@@ -1,0 +1,1189 @@
+# Comic Layout — Overlay Editing + Export (#5c) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the comic-layout manual editor with full overlay authoring (place/move/tail-snap/delete + SFX rotation + stranded-overlay reposition) and make exports render the comic layout (PIL→Qt fold-in). This is the FINAL sub-project of the comic-layout feature.
+
+**Architecture:** A new `rotation` field on `Overlay` (rendered via Qt `setRotation` about the anchor). A pure `core/layout/overlay_ops.py` for stranded detection/reposition. An `OverlayInspector` (emit-signals-only list + authoring controls) and an `OverlayEditor` controller (drag handles regenerated after each scene rebuild, mirroring #5a's `GeometryEditor`). `LayoutTab` owns all mutation. Exports route through the existing Qt renderer.
+
+**Tech Stack:** Python 3.12, PySide6 (GUI), pytest. Reuses `core/layout/qt_renderer.py` (`_add_overlay`, `save_page_png`, `render_page_to_image`, `export_document_pdf`, `build_scene`), `core/layout/balloons.py` (`overlay_to_segments`), `core/layout/schema.py` (`overlay_to_dict`/`overlay_from_dict`), `core/layout/models.py` (`Overlay`, `OverlayStyle`, `Region`), `core/layout/history.py`, and #5a/#5b `LayoutTab` plumbing (`snapshot_and_refresh`, `set_refresh_suspended`, `_current_page`, `_refresh`).
+
+## Global Constraints
+
+- Test interpreter: `.venv_linux/bin/python`, ALWAYS prefixed with `QT_QPA_PLATFORM=offscreen`.
+- Full layout suite must stay green: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` (currently **316 passed** on branch `feat/comic-layout-geometry-core`).
+- **No new third-party dependency.**
+- `core/layout/overlay_ops.py` stays **Qt-free** (importable headless). Qt code lives only in `gui/layout/` and `core/layout/qt_renderer.py`.
+- **All errors logged** (`logging.getLogger(__name__)`): a failed/degenerate op is a **no-op + log**, never a crash, never a corrupt model.
+- **Backward compatibility:** existing pages (no `rotation` key) load with `rotation == 0.0`; serialization round-trips byte-stable for existing fields.
+- **Inspector/controller split:** UI widgets emit intent signals; `LayoutTab` owns all model mutation (same pattern as #5a/#5b).
+- **Coordinates:** scene == page pixels. Rotation is **degrees clockwise about the overlay anchor**.
+- **Scope:** place/move/tail-snap/delete, SFX rotation (via inspector spin), stranded reposition, export fold-in. **No** contour-aware text wrapping, **no** rotation drag handle, **no** multi-overlay select.
+- Conventional Commits (`feat(layout): …`). Commit after each task.
+- **Branch:** continue on `feat/comic-layout-geometry-core`. **Do NOT open a pull request** as part of these tasks — the single comic-layout PR is a separate step after #5c is complete.
+
+### Names used across tasks (keep identical)
+- `Overlay.rotation: float = 0.0` (Task 1).
+- `overlay_ops.overlay_anchor_stranded(ov, regions) -> bool`, `nearest_region_center(point, regions) -> Optional[Tuple[float,float]]`, `reposition_stranded_overlays(page) -> int` (Task 3).
+- `OverlayInspector` signals `addRequested(str)`, `deleteRequested(str)`, `rotationChanged(str,int)`, `overlaySelected(str)`, `editToggled(str,bool)`; methods `set_page(page)`, `set_selected(overlay_id)`; widgets `overlay_list`/`rotation_spin`/`edit_chk` (Task 4).
+- `OverlayEditor(canvas, layout_tab)` with `set_edit_overlay(id|None)`, `rebuild_handles()`, `begin_edit()`, `move_handle(kind, x, y)`, `commit()`, `_find_overlay(id)` (Task 5).
+- `LayoutTab._add_overlay(kind)`, `_delete_overlay(id)`, `_set_overlay_rotation(id, deg)`, `_on_overlay_selected(id)`, `_on_overlay_edit_toggled(id, on)`, `export_png_to(path)` (Tasks 6-7).
+
+---
+
+### Task 1: `Overlay.rotation` field + serialization round-trip (pure)
+
+**Files:**
+- Modify: `core/layout/models.py` (`Overlay` ~159)
+- Modify: `core/layout/schema.py` (`overlay_to_dict` ~118, `overlay_from_dict` ~132)
+- Test: `tests/layout/test_overlay_rotation.py` (create)
+
+**Interfaces:**
+- Consumes: `Overlay` (`core.layout.models`).
+- Produces: `Overlay.rotation: float = 0.0`; `overlay_to_dict` emits `"rotation"`; `overlay_from_dict` reads it degrade-safe.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_overlay_rotation.py`:
+
+```python
+from core.layout.models import Overlay
+from core.layout.schema import overlay_to_dict, overlay_from_dict
+
+
+def _ov(**kw):
+    base = dict(id="o1", kind="sfx", text="BOOM", anchor=(100.0, 100.0))
+    base.update(kw)
+    return Overlay(**base)
+
+
+def test_rotation_defaults_to_zero():
+    assert _ov().rotation == 0.0
+
+
+def test_rotation_round_trips():
+    d = overlay_to_dict(_ov(rotation=37.5))
+    assert d["rotation"] == 37.5
+    assert overlay_from_dict(d).rotation == 37.5
+
+
+def test_rotation_missing_key_loads_zero():
+    d = overlay_to_dict(_ov())
+    del d["rotation"]
+    assert overlay_from_dict(d).rotation == 0.0
+
+
+def test_rotation_non_numeric_degrades_to_zero():
+    d = overlay_to_dict(_ov())
+    d["rotation"] = None
+    assert overlay_from_dict(d).rotation == 0.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_rotation.py -q`
+Expected: FAIL — `TypeError: Overlay.__init__() got an unexpected keyword argument 'rotation'`.
+
+- [ ] **Step 3: Add the field + serialization**
+
+In `core/layout/models.py`, in the `Overlay` dataclass, add after the `style` field (~159):
+
+```python
+    rotation: float = 0.0  # degrees clockwise about the anchor (SFX & balloons)
+```
+
+In `core/layout/schema.py` `overlay_to_dict`, add `"rotation": ov.rotation,` to the dict (e.g. after the `"z": ov.z, "role": ov.role,` line):
+
+```python
+        "z": ov.z, "role": ov.role, "rotation": ov.rotation,
+```
+
+In `overlay_from_dict`, add the `rotation` kwarg to the `Overlay(...)` call (degrade-safe):
+
+```python
+        rotation=float(d.get("rotation", 0.0) or 0.0),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_rotation.py -q`
+Expected: PASS (4 passed). Then full suite green: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` (expect ~320). Confirm existing overlay serialization tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/models.py core/layout/schema.py tests/layout/test_overlay_rotation.py
+git commit -m "feat(layout): Overlay.rotation field with serialization round-trip"
+```
+
+---
+
+### Task 2: render overlay rotation (`_add_overlay`)
+
+**Files:**
+- Modify: `core/layout/qt_renderer.py` (`_add_overlay` ~286, near the end after `text_item` is built)
+- Test: `tests/layout/test_overlay_render_rotation.py` (create)
+
+**Interfaces:**
+- Consumes: `Overlay.rotation` (Task 1); `build_scene` (`core.layout.qt_renderer`).
+- Produces: `_add_overlay` rotates the body (or, for SFX, the text item) about the anchor.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_overlay_render_rotation.py`:
+
+```python
+from core.layout.models import PageSpec, Overlay
+from core.layout import qt_renderer
+
+
+def _page(overlays):
+    return PageSpec(page_size_px=(400, 400), regions=[], overlays=overlays)
+
+
+def test_sfx_overlay_rotation_applied(qapp):
+    ov = Overlay(id="s", kind="sfx", text="POW", anchor=(200.0, 200.0), rotation=30.0)
+    scene = qt_renderer.build_scene(_page([ov]))
+    rots = [it.rotation() for it in scene.items() if hasattr(it, "rotation")]
+    assert any(abs(r - 30.0) < 1e-6 for r in rots)
+
+
+def test_speech_overlay_rotation_applied(qapp):
+    ov = Overlay(id="b", kind="speech", text="hi", anchor=(200.0, 200.0), rotation=45.0)
+    scene = qt_renderer.build_scene(_page([ov]))
+    rots = [it.rotation() for it in scene.items() if hasattr(it, "rotation")]
+    assert any(abs(r - 45.0) < 1e-6 for r in rots)
+
+
+def test_zero_rotation_no_transform(qapp):
+    ov = Overlay(id="b", kind="speech", text="hi", anchor=(200.0, 200.0))
+    scene = qt_renderer.build_scene(_page([ov]))
+    rots = [it.rotation() for it in scene.items() if hasattr(it, "rotation")]
+    assert all(abs(r) < 1e-6 for r in rots)
+```
+
+(If `PageSpec`'s constructor kwargs differ, read `core/layout/models.py` `PageSpec` and adjust the `_page` helper — the test only needs a page with `page_size_px`, empty `regions`, and the given `overlays`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_render_rotation.py -q`
+Expected: FAIL — `test_sfx_overlay_rotation_applied`/`test_speech_overlay_rotation_applied` fail (no item has rotation 30/45).
+
+- [ ] **Step 3: Apply rotation in `_add_overlay`**
+
+In `core/layout/qt_renderer.py`, at the END of `_add_overlay` (after the `if body_item is None: scene.addItem(text_item)` block), add:
+
+```python
+    # Rotation: spin the body (text rides along as its child) or, for SFX with no
+    # body, the text item — both about the overlay anchor (scene coords).
+    rot = getattr(ov, "rotation", 0.0) or 0.0
+    if rot:
+        from PySide6.QtCore import QPointF
+        if body_item is not None:
+            body_item.setTransformOriginPoint(QPointF(ax, ay))  # body sits at scene origin
+            body_item.setRotation(rot)
+        else:
+            text_item.setTransformOriginPoint(
+                QPointF(ax - text_item.x(), ay - text_item.y()))
+            text_item.setRotation(rot)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_render_rotation.py -q`
+Expected: PASS (3 passed). Then full suite green (expect ~323).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/qt_renderer.py tests/layout/test_overlay_render_rotation.py
+git commit -m "feat(layout): render overlay rotation about the anchor"
+```
+
+---
+
+### Task 3: `overlay_ops` — stranded detection + reposition (pure)
+
+**Files:**
+- Create: `core/layout/overlay_ops.py`
+- Test: `tests/layout/test_overlay_ops.py` (create)
+
+**Interfaces:**
+- Consumes: `Overlay`, `Region`, `PageSpec` (`core.layout.models`).
+- Produces: `overlay_anchor_stranded(ov, regions) -> bool`; `nearest_region_center(point, regions) -> Optional[Tuple[float,float]]`; `reposition_stranded_overlays(page) -> int`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_overlay_ops.py`:
+
+```python
+from core.layout.models import PageSpec, Region, Overlay
+from core.layout.overlay_ops import (
+    overlay_anchor_stranded, nearest_region_center, reposition_stranded_overlays,
+)
+
+
+def _regions():
+    return [
+        Region(id="a", kind="image", shape="rect", bbox=(0, 0, 100, 100)),
+        Region(id="b", kind="image", shape="rect", bbox=(200, 0, 100, 100)),
+    ]
+
+
+def test_stranded_true_when_outside_all_bboxes():
+    ov = Overlay(id="o", kind="sfx", text="x", anchor=(150.0, 50.0))  # in the gap
+    assert overlay_anchor_stranded(ov, _regions()) is True
+
+
+def test_stranded_false_when_inside_a_bbox():
+    ov = Overlay(id="o", kind="sfx", text="x", anchor=(50.0, 50.0))  # inside region a
+    assert overlay_anchor_stranded(ov, _regions()) is False
+
+
+def test_nearest_region_center_picks_closest():
+    assert nearest_region_center((150.0, 50.0), _regions()) == (250.0, 50.0)
+    assert nearest_region_center((140.0, 50.0), _regions()) == (50.0, 50.0)
+
+
+def test_nearest_region_center_none_when_no_regions():
+    assert nearest_region_center((10.0, 10.0), []) is None
+
+
+def test_reposition_moves_only_stranded():
+    page = PageSpec(page_size_px=(400, 400), regions=_regions(), overlays=[
+        Overlay(id="in", kind="sfx", text="x", anchor=(50.0, 50.0)),    # inside a
+        Overlay(id="out", kind="sfx", text="y", anchor=(150.0, 50.0)),  # stranded -> nearest b
+    ])
+    moved = reposition_stranded_overlays(page)
+    assert moved == 1
+    by_id = {o.id: o.anchor for o in page.overlays}
+    assert by_id["in"] == (50.0, 50.0)        # untouched
+    assert by_id["out"] == (250.0, 50.0)      # moved to region b center
+
+
+def test_reposition_noop_without_regions():
+    page = PageSpec(page_size_px=(400, 400), regions=[], overlays=[
+        Overlay(id="o", kind="sfx", text="x", anchor=(10.0, 10.0))])
+    assert reposition_stranded_overlays(page) == 0
+```
+
+(If `PageSpec`/`Region` kwargs differ, read `core/layout/models.py` and adjust the fixtures — the logic only needs region `bbox` and overlay `anchor`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_ops.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'core.layout.overlay_ops'`.
+
+- [ ] **Step 3: Implement `overlay_ops`**
+
+Create `core/layout/overlay_ops.py`:
+
+```python
+"""Pure (Qt-free) overlay operations: stranded-anchor detection + reposition.
+
+When a regions-only redesign replaces the panels, pixel-anchored overlays can be
+left floating over empty space. These helpers detect that (anchor outside every
+region's bbox) and move the anchor onto the nearest region's bbox center.
+Deterministic; never mutates input regions.
+"""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Tuple
+
+from core.layout.models import Overlay, Region, PageSpec
+
+logger = logging.getLogger(__name__)
+
+Point = Tuple[float, float]
+
+
+def _bbox_contains(bbox, x: float, y: float) -> bool:
+    bx, by, bw, bh = bbox
+    return bx <= x <= bx + bw and by <= y <= by + bh
+
+
+def _bbox_center(bbox) -> Point:
+    bx, by, bw, bh = bbox
+    return (bx + bw / 2.0, by + bh / 2.0)
+
+
+def overlay_anchor_stranded(ov: Overlay, regions: List[Region]) -> bool:
+    """True if the overlay's anchor lies outside every region's bbox."""
+    ax, ay = ov.anchor
+    return not any(_bbox_contains(r.bbox, ax, ay) for r in regions)
+
+
+def nearest_region_center(point: Point, regions: List[Region]) -> Optional[Point]:
+    """bbox center of the region whose center is nearest ``point`` (None if empty)."""
+    if not regions:
+        return None
+    px, py = point
+    best = None
+    best_d2 = None
+    for r in regions:
+        cx, cy = _bbox_center(r.bbox)
+        d2 = (cx - px) ** 2 + (cy - py) ** 2
+        if best_d2 is None or d2 < best_d2:
+            best_d2 = d2
+            best = (cx, cy)
+    return best
+
+
+def reposition_stranded_overlays(page: PageSpec) -> int:
+    """Move every stranded overlay's anchor to the nearest region center.
+
+    Returns the number of overlays moved. No-op (0) when the page has no regions
+    or no overlays. Logs a summary when it moves any.
+    """
+    regions = list(page.regions)
+    if not regions or not page.overlays:
+        return 0
+    moved = 0
+    for ov in page.overlays:
+        if overlay_anchor_stranded(ov, regions):
+            target = nearest_region_center(ov.anchor, regions)
+            if target is not None:
+                ov.anchor = target
+                moved += 1
+    if moved:
+        logger.info("repositioned %d stranded overlay(s) onto nearest panels", moved)
+    return moved
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_ops.py -q`
+Expected: PASS (6 passed). Then full suite green (expect ~329).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/overlay_ops.py tests/layout/test_overlay_ops.py
+git commit -m "feat(layout): overlay_ops stranded-anchor detection + reposition (pure)"
+```
+
+---
+
+### Task 4: `OverlayInspector` widget (emit-signals-only)
+
+**Files:**
+- Create: `gui/layout/overlay_inspector.py`
+- Test: `tests/layout/test_overlay_inspector.py` (create)
+
+**Interfaces:**
+- Consumes: `PageSpec`, `Overlay` (`core.layout.models`).
+- Produces: `OverlayInspector` with signals `addRequested(str)`, `deleteRequested(str)`, `rotationChanged(str,int)`, `overlaySelected(str)`, `editToggled(str,bool)`; methods `set_page(page)`, `set_selected(overlay_id)`; widgets `overlay_list`, `rotation_spin`, `edit_chk`, `add_speech_btn`/`add_thought_btn`/`add_caption_btn`/`add_sfx_btn`, `delete_btn`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_overlay_inspector.py`:
+
+```python
+from PySide6.QtCore import Qt
+from gui.layout.overlay_inspector import OverlayInspector
+from core.layout.models import PageSpec, Overlay
+
+
+def _page(overlays):
+    return PageSpec(page_size_px=(400, 400), regions=[], overlays=overlays)
+
+
+def test_set_page_lists_overlays(qapp):
+    insp = OverlayInspector()
+    insp.set_page(_page([
+        Overlay(id="o1", kind="speech", text="hi", anchor=(10.0, 10.0)),
+        Overlay(id="o2", kind="sfx", text="POW", anchor=(20.0, 20.0)),
+    ]))
+    assert insp.overlay_list.count() == 2
+
+
+def test_add_buttons_emit_kind(qapp):
+    insp = OverlayInspector()
+    seen = []
+    insp.addRequested.connect(lambda k: seen.append(k))
+    insp.add_speech_btn.click()
+    insp.add_sfx_btn.click()
+    assert seen == ["speech", "sfx"]
+
+
+def test_rotation_and_delete_emit_for_selected(qapp):
+    insp = OverlayInspector()
+    insp.set_page(_page([Overlay(id="o1", kind="sfx", text="x", anchor=(0.0, 0.0), rotation=10.0)]))
+    insp.set_selected("o1")
+    assert insp.rotation_spin.value() == 10
+    rot, dele = [], []
+    insp.rotationChanged.connect(lambda i, d: rot.append((i, d)))
+    insp.deleteRequested.connect(lambda i: dele.append(i))
+    insp.rotation_spin.setValue(90)
+    insp.delete_btn.click()
+    assert rot == [("o1", 90)]
+    assert dele == ["o1"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_inspector.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'gui.layout.overlay_inspector'`.
+
+- [ ] **Step 3: Create `OverlayInspector`**
+
+Create `gui/layout/overlay_inspector.py`:
+
+```python
+"""Overlay inspector: list + author comic text overlays.
+
+Emits intent signals only; ``LayoutTab`` owns all model mutation (same split as
+Geometry/Content inspectors).
+"""
+from typing import Optional
+
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QListWidget, QListWidgetItem,
+    QPushButton, QSpinBox, QCheckBox,
+)
+from PySide6.QtCore import Signal, Qt
+
+from core.layout.models import PageSpec, Overlay
+
+
+class OverlayInspector(QWidget):
+    addRequested = Signal(str)        # (kind)
+    deleteRequested = Signal(str)     # (overlay_id)
+    rotationChanged = Signal(str, int)  # (overlay_id, degrees)
+    overlaySelected = Signal(str)     # (overlay_id)
+    editToggled = Signal(str, bool)   # (overlay_id, on)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._selected_id: Optional[str] = None
+        self._build()
+        self.set_selected(None)
+
+    def _build(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.addWidget(QLabel("Overlays"))
+
+        self.overlay_list = QListWidget()
+        self.overlay_list.itemSelectionChanged.connect(self._on_row_changed)
+        root.addWidget(self.overlay_list)
+
+        add_row = QHBoxLayout()
+        self.add_speech_btn = QPushButton("+Speech")
+        self.add_thought_btn = QPushButton("+Thought")
+        self.add_caption_btn = QPushButton("+Caption")
+        self.add_sfx_btn = QPushButton("+SFX")
+        for btn, kind in ((self.add_speech_btn, "speech"),
+                          (self.add_thought_btn, "thought"),
+                          (self.add_caption_btn, "caption"),
+                          (self.add_sfx_btn, "sfx")):
+            btn.clicked.connect(lambda _checked=False, k=kind: self.addRequested.emit(k))
+            add_row.addWidget(btn)
+        root.addLayout(add_row)
+
+        edit_row = QHBoxLayout()
+        self.delete_btn = QPushButton("Delete overlay")
+        self.delete_btn.clicked.connect(self._on_delete)
+        edit_row.addWidget(self.delete_btn)
+        self.edit_chk = QCheckBox("Edit on canvas")
+        self.edit_chk.toggled.connect(self._on_edit)
+        edit_row.addWidget(self.edit_chk)
+        edit_row.addStretch(1)
+        root.addLayout(edit_row)
+
+        rot_row = QHBoxLayout()
+        rot_row.addWidget(QLabel("Rotation:"))
+        self.rotation_spin = QSpinBox()
+        self.rotation_spin.setRange(0, 359)
+        self.rotation_spin.setSuffix("°")
+        self.rotation_spin.valueChanged.connect(self._on_rotation)
+        rot_row.addWidget(self.rotation_spin)
+        rot_row.addStretch(1)
+        root.addLayout(rot_row)
+
+    def set_page(self, page: Optional[PageSpec]):
+        self.overlay_list.blockSignals(True)
+        self.overlay_list.clear()
+        if page is not None:
+            for ov in page.overlays:
+                item = QListWidgetItem(f"{ov.kind}: {ov.text[:20]}")
+                item.setData(Qt.UserRole, ov.id)
+                self.overlay_list.addItem(item)
+        self.overlay_list.blockSignals(False)
+        self.set_selected(self._selected_id)
+
+    def set_selected(self, overlay_id: Optional[str]):
+        self._selected_id = overlay_id
+        enabled = overlay_id is not None
+        for w in (self.delete_btn, self.rotation_spin, self.edit_chk):
+            w.setEnabled(enabled)
+        # reflect rotation + edit toggle from the listed item, if present
+        rot = 0
+        for i in range(self.overlay_list.count()):
+            it = self.overlay_list.item(i)
+            if it.data(Qt.UserRole) == overlay_id:
+                self.overlay_list.blockSignals(True)
+                self.overlay_list.setCurrentRow(i)
+                self.overlay_list.blockSignals(False)
+                rot = getattr(it, "_rotation", 0)
+                break
+        self.edit_chk.blockSignals(True)
+        self.edit_chk.setChecked(False)
+        self.edit_chk.blockSignals(False)
+        self.rotation_spin.blockSignals(True)
+        self.rotation_spin.setValue(int(rot))
+        self.rotation_spin.blockSignals(False)
+
+    def _selected_overlay_id(self) -> Optional[str]:
+        it = self.overlay_list.currentItem()
+        return it.data(Qt.UserRole) if it is not None else None
+
+    def _on_row_changed(self):
+        oid = self._selected_overlay_id()
+        if oid is not None:
+            self._selected_id = oid
+            self.overlaySelected.emit(oid)
+
+    def _on_delete(self):
+        if self._selected_id is not None:
+            self.deleteRequested.emit(self._selected_id)
+
+    def _on_rotation(self, value: int):
+        if self._selected_id is not None:
+            self.rotationChanged.emit(self._selected_id, int(value))
+
+    def _on_edit(self, checked: bool):
+        if self._selected_id is not None:
+            self.editToggled.emit(self._selected_id, bool(checked))
+```
+
+For the rotation reflection in `set_selected`, store the rotation on the list item when building. Update `set_page` to stash it: after `item.setData(Qt.UserRole, ov.id)`, add `item._rotation = int(getattr(ov, "rotation", 0) or 0)`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_inspector.py -q`
+Expected: PASS (3 passed). Then full suite green (expect ~332).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/layout/overlay_inspector.py tests/layout/test_overlay_inspector.py
+git commit -m "feat(layout): overlay inspector (list/add/delete/rotation/edit signals)"
+```
+
+---
+
+### Task 5: `OverlayEditor` controller — body + tail handles
+
+**Files:**
+- Create: `gui/layout/overlay_editor.py`
+- Test: `tests/layout/test_overlay_editor.py` (create)
+
+**Interfaces:**
+- Consumes: `overlay_ops.nearest_region_center` (Task 3); `LayoutTab.set_refresh_suspended`/`snapshot_and_refresh`/`_current_page`/`canvas` (#5a); `History`.
+- Produces: `OverlayEditor(canvas, layout_tab)` with `set_edit_overlay(id|None)`, `rebuild_handles()`, `begin_edit()`, `move_handle(kind, x, y)`, `commit()`, `_find_overlay(id)`; `_OvHandle` (draggable handle, `kind ∈ {"body","tail"}`).
+
+This mirrors #5a `GeometryEditor`: handles are regenerated from the model after every
+scene rebuild (`LayoutTab._refresh` calls `rebuild_handles`). The test drives the
+controller methods directly (no synthetic Qt mouse events).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_overlay_editor.py`:
+
+```python
+from gui.layout.layout_tab import LayoutTab
+from core.layout.models import Region, Overlay
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tab(overlays, regions=None):
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = regions or []
+    tab.document.pages[0].overlays = overlays
+    tab._refresh()
+    return tab
+
+
+def test_body_handle_only_when_no_tail(qapp):
+    tab = _tab([Overlay(id="o", kind="caption", text="x", anchor=(50.0, 50.0))])
+    tab.overlay_editor.set_edit_overlay("o")
+    kinds = sorted(h._kind for h in tab.overlay_editor._handles)
+    assert kinds == ["body"]
+
+
+def test_body_and_tail_handles_when_tail(qapp):
+    tab = _tab([Overlay(id="o", kind="speech", text="x", anchor=(50.0, 50.0),
+                        tail_target=(80.0, 90.0))])
+    tab.overlay_editor.set_edit_overlay("o")
+    kinds = sorted(h._kind for h in tab.overlay_editor._handles)
+    assert kinds == ["body", "tail"]
+
+
+def test_move_body_commits_anchor(qapp):
+    tab = _tab([Overlay(id="o", kind="caption", text="x", anchor=(50.0, 50.0))])
+    tab.overlay_editor.set_edit_overlay("o")
+    before = len(tab.history.snapshots())
+    tab.overlay_editor.begin_edit()
+    tab.overlay_editor.move_handle("body", 120.0, 130.0)
+    tab.overlay_editor.commit()
+    assert tab.document.pages[0].overlays[0].anchor == (120.0, 130.0)
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_tail_commit_snaps_to_region_center(qapp):
+    tab = _tab(
+        [Overlay(id="o", kind="speech", text="x", anchor=(50.0, 50.0), tail_target=(60.0, 60.0))],
+        regions=[Region(id="r", kind="image", shape="rect", bbox=(200, 200, 100, 100))],
+    )
+    tab.overlay_editor.set_edit_overlay("o")
+    tab.overlay_editor.begin_edit()
+    tab.overlay_editor.move_handle("tail", 248.0, 248.0)  # near region center (250,250)
+    tab.overlay_editor.commit()
+    assert tab.document.pages[0].overlays[0].tail_target == (250.0, 250.0)
+
+
+def test_edit_off_clears_handles(qapp):
+    tab = _tab([Overlay(id="o", kind="caption", text="x", anchor=(50.0, 50.0))])
+    tab.overlay_editor.set_edit_overlay("o")
+    tab.overlay_editor.set_edit_overlay(None)
+    assert tab.overlay_editor._handles == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_editor.py -q`
+Expected: FAIL — `AttributeError: 'LayoutTab' object has no attribute 'overlay_editor'` (the editor is wired in Task 6; this task creates the class and a temporary direct instantiation in the test will fail until Task 6 — so this task ALSO adds a minimal `self.overlay_editor = OverlayEditor(self.canvas, self)` in `LayoutTab._build` and a `rebuild_handles()` call in `_refresh`. See Step 3(b).)
+
+- [ ] **Step 3: Create `OverlayEditor` and wire the minimal hooks**
+
+(a) Create `gui/layout/overlay_editor.py`:
+
+```python
+"""Manual overlay editor: body/tail drag handles layered on the canvas.
+
+Mirrors GeometryEditor: handles are regenerated from the model after each scene
+rebuild (LayoutTab._refresh), not preserved. Move-only. Tail drags snap to the
+nearest region center on commit.
+"""
+from typing import List, Optional
+
+from PySide6.QtWidgets import QGraphicsEllipseItem, QGraphicsItem
+from PySide6.QtGui import QBrush, QPen, QColor
+from PySide6.QtCore import QRectF
+
+_HANDLE_R = 6.0
+_SNAP_RADIUS = 40.0  # px: tail snaps to a region center within this distance
+
+
+class _OvHandle(QGraphicsEllipseItem):
+    """A draggable overlay handle. ``kind`` is "body" or "tail"."""
+
+    def __init__(self, editor: "OverlayEditor", kind: str):
+        super().__init__()
+        self._editor = editor
+        self._kind = kind
+        self.setFlag(QGraphicsItem.ItemIsMovable, True)
+        self.setFlag(QGraphicsItem.ItemSendsGeometryChanges, True)
+
+    def mousePressEvent(self, event):
+        self._editor.begin_edit()
+        super().mousePressEvent(event)
+
+    def itemChange(self, change, value):
+        if change == QGraphicsItem.ItemPositionHasChanged:
+            self._editor.move_handle(self._kind, self.x(), self.y())
+        return super().itemChange(change, value)
+
+    def mouseReleaseEvent(self, event):
+        super().mouseReleaseEvent(event)
+        self._editor.commit()
+
+
+class OverlayEditor:
+    """Owns body/tail drag handles for one selected overlay on a canvas."""
+
+    def __init__(self, canvas, layout_tab):
+        self._canvas = canvas
+        self._tab = layout_tab
+        self._edit_id: Optional[str] = None
+        self._handles: List[_OvHandle] = []
+        self._pre = None
+
+    def active_overlay_id(self) -> Optional[str]:
+        return self._edit_id
+
+    def set_edit_overlay(self, overlay_id: Optional[str]) -> None:
+        self._edit_id = overlay_id or None
+        self.rebuild_handles()
+
+    def _find_overlay(self, overlay_id):
+        page = self._tab._current_page()
+        if page is None or not overlay_id:
+            return None
+        for ov in page.overlays:
+            if ov.id == overlay_id:
+                return ov
+        return None
+
+    def _clear(self):
+        for h in self._handles:
+            s = h.scene()
+            if s is not None:
+                s.removeItem(h)
+        self._handles = []
+
+    def rebuild_handles(self) -> None:
+        self._clear()
+        ov = self._find_overlay(self._edit_id)
+        if ov is None:
+            self._edit_id = None
+            return
+        scene = self._canvas.scene()
+        if scene is None:
+            return
+        self._add_handle("body", ov.anchor)
+        if ov.tail_target is not None:
+            self._add_handle("tail", ov.tail_target)
+
+    def _add_handle(self, kind: str, pos):
+        scene = self._canvas.scene()
+        h = _OvHandle(self, kind)
+        h.setRect(QRectF(-_HANDLE_R, -_HANDLE_R, 2 * _HANDLE_R, 2 * _HANDLE_R))
+        h.setPos(pos[0], pos[1])
+        h.setZValue(1_000_000)
+        h.setBrush(QBrush(QColor("#E84A5F") if kind == "tail" else QColor("#2D7DD2")))
+        h.setPen(QPen(QColor("#FFFFFF"), 1.5))
+        scene.addItem(h)
+        self._handles.append(h)
+
+    def begin_edit(self) -> None:
+        ov = self._find_overlay(self._edit_id)
+        if ov is None:
+            self._pre = None
+            return
+        self._pre = (ov.anchor, ov.tail_target)
+        self._tab.set_refresh_suspended(True)
+
+    def move_handle(self, kind: str, x: float, y: float) -> None:
+        ov = self._find_overlay(self._edit_id)
+        if ov is None:
+            return
+        if kind == "body":
+            ov.anchor = (x, y)
+        elif kind == "tail":
+            ov.tail_target = (x, y)
+
+    def commit(self) -> None:
+        self._tab.set_refresh_suspended(False)
+        ov = self._find_overlay(self._edit_id)
+        if ov is None:
+            self._pre = None
+            return
+        # Tail snaps to the nearest region center within the snap radius.
+        if ov.tail_target is not None:
+            from core.layout.overlay_ops import nearest_region_center
+            page = self._tab._current_page()
+            regions = list(page.regions) if page is not None else []
+            center = nearest_region_center(ov.tail_target, regions)
+            if center is not None:
+                dx = center[0] - ov.tail_target[0]
+                dy = center[1] - ov.tail_target[1]
+                if (dx * dx + dy * dy) ** 0.5 <= _SNAP_RADIUS:
+                    ov.tail_target = center
+        self._pre = None
+        self._tab.snapshot_and_refresh(f"edit overlay: {ov.id}")
+```
+
+(b) In `gui/layout/layout_tab.py`:
+- In `_build`, immediately after the `GeometryEditor` is created (`self.geometry_editor = GeometryEditor(self.canvas, self)`), add:
+
+```python
+        from gui.layout.overlay_editor import OverlayEditor
+        self.overlay_editor = OverlayEditor(self.canvas, self)
+```
+
+- In `_refresh`, in the same guarded block that calls `ge.rebuild_handles()`, also rebuild overlay handles:
+
+```python
+            oe = getattr(self, "overlay_editor", None)
+            if oe is not None:
+                oe.rebuild_handles()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_editor.py -q`
+Expected: PASS (5 passed). Then full suite green (expect ~337).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/layout/overlay_editor.py gui/layout/layout_tab.py tests/layout/test_overlay_editor.py
+git commit -m "feat(layout): overlay editor body/tail handles with tail-snap commit"
+```
+
+---
+
+### Task 6: LayoutTab overlay wiring (add/delete/rotation/select + stranded reposition)
+
+**Files:**
+- Modify: `gui/layout/layout_tab.py` (`_build`: create + wire `OverlayInspector`; handlers; `_refresh`: `overlay_inspector.set_page`; `apply_designer_result`: reposition on regions-only)
+- Test: `tests/layout/test_overlay_wiring.py` (create)
+
+**Interfaces:**
+- Consumes: `OverlayInspector` (Task 4); `OverlayEditor` (Task 5); `overlay_ops.reposition_stranded_overlays` (Task 3); `Overlay`, `OverlayStyle` (`core.layout.models`).
+- Produces: `LayoutTab._add_overlay(kind)`, `_delete_overlay(id)`, `_set_overlay_rotation(id, deg)`, `_on_overlay_selected(id)`, `_on_overlay_edit_toggled(id, on)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_overlay_wiring.py`:
+
+```python
+from gui.layout.layout_tab import LayoutTab
+from core.layout.models import Region, Overlay
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tab():
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = []
+    tab.document.pages[0].overlays = []
+    tab._refresh()
+    return tab
+
+
+def test_add_overlay_appends_and_snapshots(qapp):
+    tab = _tab()
+    before = len(tab.history.snapshots())
+    tab._add_overlay("speech")
+    ovs = tab.document.pages[0].overlays
+    assert len(ovs) == 1 and ovs[0].kind == "speech"
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_delete_overlay_removes_and_snapshots(qapp):
+    tab = _tab()
+    tab._add_overlay("sfx")
+    oid = tab.document.pages[0].overlays[0].id
+    before = len(tab.history.snapshots())
+    tab._delete_overlay(oid)
+    assert tab.document.pages[0].overlays == []
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_set_overlay_rotation_writes_model(qapp):
+    tab = _tab()
+    tab._add_overlay("sfx")
+    oid = tab.document.pages[0].overlays[0].id
+    tab._set_overlay_rotation(oid, 75)
+    assert tab.document.pages[0].overlays[0].rotation == 75
+
+
+def test_apply_designer_regions_only_repositions_overlays(qapp):
+    tab = _tab()
+    tab.document.pages[0].overlays = [
+        Overlay(id="o", kind="sfx", text="x", anchor=(5.0, 5.0))]  # will be stranded
+
+    class R:  # minimal designer result: regions only, no overlays
+        regions = [Region(id="r", kind="image", shape="rect", bbox=(200, 200, 100, 100))]
+        overlays = []
+    tab.apply_designer_result(R())
+    assert tab.document.pages[0].overlays[0].anchor == (250.0, 250.0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_wiring.py -q`
+Expected: FAIL — `AttributeError: 'LayoutTab' object has no attribute '_add_overlay'`.
+
+- [ ] **Step 3: Add handlers + wire the inspector**
+
+In `gui/layout/layout_tab.py`:
+
+(a) In `_build`, after the `OverlayEditor` creation (Task 5), create + wire the inspector (place it near the geometry inspector's `root.addWidget`):
+
+```python
+        from gui.layout.overlay_inspector import OverlayInspector
+        self.overlay_inspector = OverlayInspector()
+        self.overlay_inspector.addRequested.connect(self._add_overlay)
+        self.overlay_inspector.deleteRequested.connect(self._delete_overlay)
+        self.overlay_inspector.rotationChanged.connect(self._set_overlay_rotation)
+        self.overlay_inspector.overlaySelected.connect(self._on_overlay_selected)
+        self.overlay_inspector.editToggled.connect(self._on_overlay_edit_toggled)
+        root.addWidget(self.overlay_inspector)
+```
+
+(b) In `_refresh`, in the guarded editor block, refresh the overlay list:
+
+```python
+            oi = getattr(self, "overlay_inspector", None)
+            if oi is not None and self.document and self.document.pages:
+                oi.set_page(self.document.pages[0])
+```
+
+(c) Add the handlers (after the region-op handlers):
+
+```python
+    _OVERLAY_DEFAULT_TEXT = {
+        "speech": "Dialogue", "thought": "Thinking…",
+        "caption": "Caption", "sfx": "POW!",
+    }
+
+    def _new_overlay_id(self, page) -> str:
+        n = 1
+        existing = {o.id for o in page.overlays}
+        while f"ov{n}" in existing:
+            n += 1
+        return f"ov{n}"
+
+    def _add_overlay(self, kind: str) -> bool:
+        from core.layout.models import Overlay
+        page = self._current_page()
+        if page is None or kind not in ("speech", "thought", "caption", "sfx"):
+            return False
+        pw, ph = page.page_size_px
+        cx, cy = pw / 2.0, ph / 2.0
+        tail = (cx, cy + 80.0) if kind in ("speech", "thought") else None
+        ov = Overlay(id=self._new_overlay_id(page), kind=kind,
+                     text=self._OVERLAY_DEFAULT_TEXT.get(kind, ""),
+                     anchor=(cx, cy), tail_target=tail)
+        page.overlays.append(ov)
+        self.snapshot_and_refresh(f"add {kind} overlay")
+        self.overlay_inspector.set_selected(ov.id)
+        return True
+
+    def _find_overlay(self, overlay_id):
+        page = self._current_page()
+        if page is None:
+            return None
+        for ov in page.overlays:
+            if ov.id == overlay_id:
+                return ov
+        return None
+
+    def _delete_overlay(self, overlay_id: str) -> bool:
+        page = self._current_page()
+        if page is None:
+            return False
+        for i, ov in enumerate(page.overlays):
+            if ov.id == overlay_id:
+                if self.overlay_editor.active_overlay_id() == overlay_id:
+                    self.overlay_editor.set_edit_overlay(None)
+                del page.overlays[i]
+                self.snapshot_and_refresh(f"delete overlay: {overlay_id}")
+                return True
+        return False
+
+    def _set_overlay_rotation(self, overlay_id: str, deg: int) -> bool:
+        ov = self._find_overlay(overlay_id)
+        if ov is None:
+            return False
+        ov.rotation = float(deg)
+        self.snapshot_and_refresh(f"rotate overlay: {overlay_id}")
+        return True
+
+    def _on_overlay_selected(self, overlay_id: str):
+        self.overlay_inspector.set_selected(overlay_id)
+        self.overlay_editor.set_edit_overlay(None)
+
+    def _on_overlay_edit_toggled(self, overlay_id: str, on: bool):
+        self.overlay_editor.set_edit_overlay(overlay_id if on else None)
+```
+
+(d) In `apply_designer_result` (~584), the existing structure is:
+
+```python
+        applied = False
+        if result.regions:
+            self.document.pages[0].regions = list(result.regions)
+            applied = True
+        if getattr(result, "overlays", None):
+            self.document.pages[0].overlays = list(result.overlays)
+            applied = True
+        if applied:
+            self.history.append(user_text or "design")
+            self._refresh()
+```
+
+Add a `regions-only` reposition: convert the second `if` into an `if/elif` so that when regions were redesigned but overlays were NOT replaced, stranded overlays are tidied. Replace the `if getattr(result, "overlays", None):` block with:
+
+```python
+        if getattr(result, "overlays", None):
+            self.document.pages[0].overlays = list(result.overlays)
+            applied = True
+        elif result.regions:
+            # Regions-only redesign: tidy overlays stranded over the new panels.
+            from core.layout.overlay_ops import reposition_stranded_overlays
+            reposition_stranded_overlays(self.document.pages[0])
+```
+
+Leave the `if applied: history.append + _refresh` block unchanged (the regions branch already set `applied = True`, so the refresh still runs).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_overlay_wiring.py -q`
+Expected: PASS (4 passed). Then full suite green (expect ~341). Confirm `test_layout_tab_designer_overlays.py` still passes (the overlays-replaced path is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/layout/layout_tab.py tests/layout/test_overlay_wiring.py
+git commit -m "feat(layout): wire overlay inspector + add/delete/rotate + stranded reposition"
+```
+
+---
+
+### Task 7: Export fold-in — Qt-path PNG export + retire the PIL bypass
+
+**Files:**
+- Modify: `gui/layout/layout_tab.py` (toolbar "Export PNG…" + `export_png_to`)
+- Modify: `gui/layout/export_dialog.py` (`LayoutExportWorker._export_png`/`_export_pdf` → Qt renderer)
+- Test: `tests/layout/test_export_qt.py` (create)
+
+**Interfaces:**
+- Consumes: `qt_renderer.save_page_png`, `qt_renderer.render_page_to_image`, `qt_renderer.export_document_pdf` (`core.layout.qt_renderer`); `dataclasses.replace`.
+- Produces: `LayoutTab.export_png_to(path)`; `LayoutExportWorker` renders via the Qt renderer (no `LayoutEngine` for image rendering).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_export_qt.py`:
+
+```python
+import os
+from gui.layout.layout_tab import LayoutTab
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def test_export_png_to_writes_file(qapp, tmp_path):
+    tab = LayoutTab(config=FakeConfig())
+    out = tmp_path / "page.png"
+    tab.export_png_to(str(out))
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_export_worker_uses_qt_renderer(qapp):
+    # The PIL LayoutEngine must no longer be used for image rendering in the worker.
+    import inspect
+    from gui.layout import export_dialog
+    src = inspect.getsource(export_dialog.LayoutExportWorker)
+    assert "qt_renderer" in src
+    assert "engine.render_page" not in src  # PIL render path removed
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_export_qt.py -q`
+Expected: FAIL — `AttributeError: 'LayoutTab' object has no attribute 'export_png_to'` and the worker still references `engine.render_page`.
+
+- [ ] **Step 3: Add the Layout-tab PNG export**
+
+In `gui/layout/layout_tab.py`:
+
+(a) Add `export_png_to` (next to `export_pdf_to` ~442):
+
+```python
+    def export_png_to(self, path: str):
+        if self.document is None or not self.document.pages:
+            return
+        from core.layout import qt_renderer
+        style = self.document.style if self.document else None
+        qt_renderer.save_page_png(self.document.pages[0], path, style=style)
+        self.status.setText(f"Exported {path}")
+```
+
+(b) Add a toolbar button + dialog. In `_build`'s toolbar list, add `("Export PNG…", self._export_png_dialog)` next to the existing `("Export PDF…", self._export_dialog)` entry. Add the dialog method (next to `_export_dialog`):
+
+```python
+    def _export_png_dialog(self):
+        from PySide6.QtWidgets import QFileDialog
+        path, _ = QFileDialog.getSaveFileName(self, "Export PNG", "", "PNG Images (*.png)")
+        if path:
+            try:
+                self.export_png_to(path)
+            except Exception as e:  # noqa: BLE001
+                self._report_error("export png", e)
+```
+
+- [ ] **Step 4: Redirect the PIL worker to the Qt renderer**
+
+In `gui/layout/export_dialog.py`, replace the body of `_export_png` and `_export_pdf` so they render via the Qt renderer instead of `LayoutEngine`.
+
+Replace `_export_png` with:
+
+```python
+    def _export_png(self, output_path: Path, pages_to_export: List[int], num_pages: int):
+        """Export to PNG sequence via the Qt renderer (comic geometry + overlays)."""
+        from core.layout import qt_renderer
+        for idx, page_num in enumerate(pages_to_export):
+            page = self.document.pages[page_num]
+            progress_pct = int((idx / num_pages) * 100)
+            self.progress.emit(progress_pct, f"Rendering page {page_num + 1}...")
+            image = qt_renderer.render_page_to_image(page, style=self.document.style)
+            if num_pages > 1:
+                page_output = output_path.parent / f"{output_path.stem}_page{page_num + 1:03d}.png"
+            else:
+                page_output = output_path
+            image.save(str(page_output), "PNG")
+            logger.info(f"Exported page {page_num + 1} to {page_output}")
+        self.progress.emit(100, "Complete!")
+```
+
+Replace `_export_pdf` with (renders the selected pages via the Qt PDF path):
+
+```python
+    def _export_pdf(self, output_path: Path, pages_to_export: List[int], num_pages: int):
+        """Export to PDF via the Qt renderer (comic geometry + overlays)."""
+        from dataclasses import replace
+        from core.layout import qt_renderer
+        self.progress.emit(0, "Rendering PDF...")
+        sub = replace(self.document,
+                      pages=[self.document.pages[i] for i in pages_to_export])
+        qt_renderer.export_document_pdf(sub, str(output_path), dpi=self.dpi)
+        self.progress.emit(100, "Complete!")
+```
+
+If `LayoutEngine` is now unused in the file, remove the `from core.layout import LayoutEngine` import (line ~18) to keep the module clean. Leave `_export_json` unchanged.
+
+- [ ] **Step 5: Run tests + commit**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_export_qt.py -q` → PASS (2 passed). Then the FULL suite: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` → all green (expect ~343).
+
+```bash
+git add gui/layout/layout_tab.py gui/layout/export_dialog.py tests/layout/test_export_qt.py
+git commit -m "feat(layout): Qt-path PNG export + route export dialog through Qt renderer"
+```
+
+---
+
+## Notes / deliberately deferred (not gaps)
+- **Contour-aware text wrapping** (text follows a non-rect balloon interior) — future polish.
+- **Rotation drag handle** — rotation is via the inspector spin in #5c.
+- **Multi-overlay select / z-reorder UI** — not in #5c.
+- **#5b cleanup Minors** (split id-uniqueness, mid-file test imports, missing annotations) — fold opportunistically if a task touches that code.
+- After #5c, the whole comic-layout feature is complete → the single PR is the next step (separate from these tasks).
+
+## Self-Review (completed by plan author)
+- **Spec coverage:** rotation field+serialization (Task 1) + render (Task 2); stranded reposition pure (Task 3) + wired into designer-apply (Task 6); overlay inspector place/delete/rotation/select/edit (Task 4) + controller mutation (Task 6); overlay move/tail-snap handles (Task 5); export fold-in PNG + PIL→Qt redirect (Task 7). Every design §4 item maps to a task. Error paths (no regions, missing overlay, malformed rotation) covered in Tasks 3/5/1.
+- **Placeholder scan:** no TBD/TODO; every code step shows complete code. Two steps say "read the file first to confirm anchors" (PageSpec kwargs in tests; the apply_designer_result else-branch) — these are verification notes, not placeholders; the code to add is given.
+- **Type/name consistency:** `Overlay.rotation` (T1) read by renderer (T2), inspector (T4), wiring (T6); `overlay_ops.*` (T3) consumed by `OverlayEditor.commit` (T5) + `apply_designer_result` (T6); `OverlayInspector` signals (T4) connected in `_build` (T6); `OverlayEditor(canvas, layout_tab)` + `rebuild_handles` (T5) called from `_refresh` (T5 wires the hook); `save_page_png`/`render_page_to_image`/`export_document_pdf` (T7) match real signatures (verified). `_current_page`/`snapshot_and_refresh`/`set_refresh_suspended` reused from #5a.
+- **Test interpreter/baseline:** all tasks use `.venv_linux/bin/python` under `QT_QPA_PLATFORM=offscreen`; suite 316 → ~343 (4+3+6+3+5+4+2 = 27 new tests; counts approximate — binding check is "all new tests pass and the full suite stays green").

--- a/Plans/2026-06-28-comic-layout-region-ops-design.md
+++ b/Plans/2026-06-28-comic-layout-region-ops-design.md
@@ -1,0 +1,174 @@
+# Comic Layout — Manual Editor: Region Operations (sub-project #5b of 5)
+
+**Status:** Design 2026-06-28. Scope user-approved (core ops; two-click free-line knife).
+**Branch:** `feat/comic-layout-geometry-core` (all comic-layout sub-projects share one branch).
+**PR gate:** Do NOT open a PR — the single PR comes only after the whole comic-layout feature (#5c) is done.
+
+## 1. Goal
+
+Add **panel-level operations** to the Layout-tab manual editor, on top of the
+#5a `GeometryEditor` foundation and the pure polygon primitives from #2:
+
+- **Split / knife** — a **two-click free line** across a panel cuts it into two
+  panels (any angle), via `polygon.clip_halfplane`.
+- **Merge** — combine two adjacent panels into one, via `polygon.union_polygons`.
+- **Delete** — remove a panel.
+
+**Out of scope (user-approved "core ops only"):** vertex insert/delete,
+line↔curve conversion, rect-corner resize (possible later); all overlay editing
+and export unification are **#5c**.
+
+## 2. Scope decisions (user-approved)
+
+| Decision | Choice |
+|----------|--------|
+| #5b depth | **Core ops only** — split, merge, delete |
+| Knife UX | **Two-click free line** — click two points; both sides become panels |
+| Result shape | **`polygon`** regions (renderer + #5a vertex editor both support them) |
+| Operable shapes | rect, polygon, and **straight-edged** `path` (move/line/close only); curved paths are rejected with a logged status message (never crash) |
+
+## 3. Current architecture (verified, with anchors)
+
+- **Pure polygon toolkit (Qt-free):** `core/layout/polygon.py` — `signed_area`,
+  `ensure_orientation`, `clip_halfplane(poly, a, b)` (Sutherland–Hodgman half-plane
+  clip; keeps the side left of a→b), `union_polygons(polys) -> List[Poly]`
+  (index-based ring chaining + `_remove_colinear`; scoped to edge-sharing cells),
+  `polygon_to_segments(poly)`. `Poly = List[Point]`, `Point = Tuple[float,float]`.
+- **Region model:** `core/layout/models.py:117` — `Region.shape ∈ {rect,polygon,path}`,
+  `bbox`, `points` (polygon vertices, int page px), `segments` (path), `kind`,
+  `z`, `bleed`, `image_style`, `role`, `name`. Rect geometry lives in `bbox`.
+- **Editor foundation (#5a):** `gui/layout/geometry_editor.py` (`GeometryEditor`,
+  handle regeneration after rebuild), `gui/layout/geometry_inspector.py`
+  (emit-signals-only widget; `LayoutTab` owns mutation), `gui/layout/layout_tab.py`
+  (`_find_region:214`, `_refresh:129` rebuilds whole scene + `rebuild_handles`,
+  `snapshot_and_refresh`, `set_refresh_suspended`, `history`).
+- **Canvas:** `gui/layout/canvas_widget.py` — `QGraphicsView`; emits
+  `regionSelected(str)` from scene selection; `selected_region_id()`; scene ==
+  page px; `mapToScene` for mouse→scene. No tool-mode concept yet.
+- **Undo:** `History.append(prompt)` snapshots the document; the editor snapshots
+  at commit time only.
+
+## 4. Architecture
+
+### 4.1 Pure module `core/layout/region_ops.py` (Qt-free, fully unit-tested)
+
+The geometry/model transforms live here so they test headless and stay out of Qt.
+
+- `region_to_polygon(region) -> Optional[Poly]`
+  - `rect` → the 4 bbox corners (CW from top-left).
+  - `polygon` → `[(float,float)] from region.points`.
+  - `path` with only `move`/`line`/`close` segments → the ordered anchor points.
+  - `path` containing `quad`/`cubic` → **None** (curved; unsupported this phase).
+- `split_region(region, a, b) -> Optional[Tuple[Region, Region]]`
+  - `poly = region_to_polygon(region)`; if `None` → `None`.
+  - `left = clip_halfplane(poly, a, b)`, `right = clip_halfplane(poly, b, a)`
+    (reversing the cut direction selects the opposite half).
+  - If either side has `< 3` vertices (cut missed / grazed) → `None`.
+  - Build two `polygon` regions copying `kind/z/bleed/image_style/role/name` from
+    the original, ids `f"{region.id}_a"` / `f"{region.id}_b"`, `points` = rounded
+    int tuples, `bbox` recomputed from points. Return `(r_a, r_b)`.
+- `merge_regions(base, other) -> Optional[Region]`
+  - `p1, p2 = region_to_polygon(base), region_to_polygon(other)`; either `None` → `None`.
+  - `rings = union_polygons([p1, p2])`; if `len(rings) != 1` → `None`
+    (panels are disjoint / share no edge — not mergeable into one ring).
+  - Build one `polygon` region from `base`'s `id/kind/z/bleed/image_style/role/name`,
+    `points` from the single ring, `bbox` recomputed. Return it.
+- Helpers: `_poly_bbox(poly) -> Rect`, `_region_from_polygon(template, poly, *, id)`.
+- **Determinism:** no `Math.random`/time; results depend only on inputs.
+
+### 4.2 Canvas tool modes (`canvas_widget.py`)
+
+Add a minimal **tool-mode** state so the canvas can collect knife clicks / a merge
+target without disturbing normal selection:
+
+- `set_tool_mode(mode: str)` where `mode ∈ {"none","knife","merge"}` (default `"none"`).
+- New signals: `knifeLine(float,float,float,float)` (p1x,p1y,p2x,p2y in scene px)
+  and `mergeTarget(str)` (the clicked region id).
+- `mousePressEvent` override:
+  - `"none"` → `super()` (unchanged selection/rubber-band behavior).
+  - `"knife"` → record `mapToScene(pos)`; on the **second** click emit
+    `knifeLine(...)`, then auto-reset to `"none"`. (First click stashed on the widget.)
+  - `"merge"` → resolve the region id under the cursor (`itemAt`→`data(0)`); if found
+    emit `mergeTarget(id)` then reset to `"none"`; if empty space, ignore.
+- Switching tool mode clears any half-entered knife state.
+
+### 4.3 Inspector controls (`geometry_inspector.py`)
+
+Add a button row (emit-signals-only, consistent with #5a):
+
+- **"Delete panel"** → `deleteRequested(str)`.
+- **"Knife (split)"** (checkable) → `knifeToggled(str, bool)`.
+- **"Merge…"** (checkable) → `mergeToggled(str, bool)`.
+
+`set_region` enables Delete for any region; Knife/Merge for rect/polygon/path
+(the op itself fail-safes on curved paths). The two checkable tools are mutually
+exclusive and reset (unchecked) on every `set_region` (selection change), exactly
+like the existing `edit_shape_chk`.
+
+### 4.4 Controller wiring (`layout_tab.py`)
+
+`LayoutTab` owns all model mutation (same split as #5a). Handlers:
+
+- `_on_region_delete(region_id)`: drop the region from `page.regions`; if it was the
+  `geometry_editor` edit region, exit edit mode; `snapshot_and_refresh("delete panel: …")`.
+- `_on_region_knife_toggled(region_id, on)`: on → remember `region_id`, set canvas
+  tool mode `"knife"`; off → tool mode `"none"`. On `canvas.knifeLine(p1,p2)`:
+  `split_region(region, p1, p2)`; if `None` → status message + log, reset; else
+  replace the region **in place** (same list index) with the two results,
+  `snapshot_and_refresh`, reset tool mode + uncheck the inspector toggle.
+- `_on_region_merge_toggled(region_id, on)`: on → remember base `region_id`, set
+  tool mode `"merge"`. On `canvas.mergeTarget(other_id)`: if `other_id == base` →
+  ignore; else `merge_regions(base, other)`; if `None` → status + log; else replace
+  base in place with the merged region, remove `other`, `snapshot_and_refresh`, reset.
+- All mutations go through `snapshot_and_refresh` (one undo snapshot each; `_refresh`
+  rebuilds the scene and `rebuild_handles`).
+
+## 5. Error handling / edge cases
+
+- **Cut misses the panel** (`split_region` → None): no model change; status
+  "Cannot split — the cut line missed the panel"; `logger.warning`; tool resets.
+- **Panels not adjacent** (`merge_regions` → None): no change; status "Cannot merge —
+  panels are not adjacent"; `logger.warning`.
+- **Curved path** (`region_to_polygon` → None): same fail-safe path (status + log).
+- **Delete last region / edit-region deleted:** allowed; if the deleted region was in
+  edit mode, `geometry_editor.set_edit_region(None)` first so no stale handles.
+- **Tool mode left active** when selection changes: `set_region` unchecks the tool
+  toggles and `LayoutTab` resets the canvas to `"none"` (no dangling half-knife).
+- **Never crash, never corrupt:** every op validates before mutating; an invalid op is
+  a no-op + log.
+
+## 6. Testing (headless, `QT_QPA_PLATFORM=offscreen`)
+
+Pure (`tests/layout/test_region_ops.py`):
+- `region_to_polygon`: rect→4 corners; polygon→points; straight path→anchors; curved path→None.
+- `split_region`: a unit square cut by its vertical midline → two regions, each a
+  valid polygon, x-extents partition the original; a cut entirely outside → None;
+  ids `_a`/`_b`; kind/z/bleed copied.
+- `merge_regions`: two edge-sharing squares → one region, single ring, bbox = union;
+  two disjoint squares → None; curved input → None.
+
+GUI (`tests/layout/test_region_ops_gui.py`):
+- `_on_region_delete` removes the region and appends one snapshot.
+- knife flow: drive `_on_region_knife_toggled(id, True)` then `canvas.knifeLine(...)`
+  emit → `page.regions` goes 1→2 at the same index; one snapshot.
+- merge flow: select base, `mergeTarget(other)` → 2→1; one snapshot.
+- invalid op (cut miss / disjoint) → region count unchanged, no snapshot.
+- Full layout suite stays green (baseline **293**; +N).
+
+## 7. Out of scope (deferred, not gaps)
+
+- Vertex insert/delete, line↔curve conversion, rect-corner resize.
+- Splitting/merging **curved** path regions (would need curve subdivision).
+- All overlay editing + export unification → **#5c**.
+
+## 8. Self-review (author)
+
+- **Placeholder scan:** none; every unit names a concrete file/interface and the
+  existing primitive it reuses (`clip_halfplane`, `union_polygons`).
+- **Consistency:** mutation lives only in `LayoutTab` (matches #5a); the pure module
+  is Qt-free and deterministic; tool-mode additions don't change default canvas
+  behavior (mode `"none"` is `super()`).
+- **Scope:** core ops only; sized for one plan (~6 tasks: pure module split/merge,
+  region_to_polygon, canvas tool mode, inspector buttons, controller wiring, integration).
+- **Ambiguity:** "two-click free line" = clip both half-planes by the same segment
+  reversed; results are `polygon`; curved paths explicitly rejected.

--- a/Plans/2026-06-28-comic-layout-region-ops-plan.md
+++ b/Plans/2026-06-28-comic-layout-region-ops-plan.md
@@ -1,0 +1,890 @@
+# Comic Layout — Region Operations (#5b) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add panel-level split (two-click free-line knife), merge, and delete to the Layout-tab manual editor, on top of the #5a `GeometryEditor` foundation and the #2 pure polygon primitives.
+
+**Architecture:** A new pure, Qt-free `core/layout/region_ops.py` reduces a region to a polygon (`region_to_polygon`), then uses `polygon.clip_halfplane` (split) and `polygon.union_polygons` (merge) to produce new **polygon** regions. `CanvasWidget` gains a small tool-mode state machine that emits `knifeLine`/`mergeTarget`; `GeometryInspector` gains Delete/Knife/Merge controls (emit-signals-only); `LayoutTab` owns all model mutation via directly-callable `_apply_delete/_apply_knife/_apply_merge` methods (tested without Qt events).
+
+**Tech Stack:** Python 3.12, PySide6 (GUI), pytest. Reuses `core/layout/polygon.py` (`clip_halfplane`, `union_polygons`, `ensure_orientation`, `signed_area`), `core/layout/models.py` (`Region`, `PathSegment`), `core/layout/history.py` (`History`), and #5a's `LayoutTab.snapshot_and_refresh`/`_find_region`/`geometry_editor`.
+
+## Global Constraints
+
+- Test interpreter: `.venv_linux/bin/python`, ALWAYS prefixed with `QT_QPA_PLATFORM=offscreen`.
+- Full layout suite must stay green: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` (currently **293 passed** on branch `feat/comic-layout-geometry-core`).
+- **No new third-party dependency.**
+- `core/layout/region_ops.py` and `core/layout/polygon.py` stay **Qt-free** (importable headless). Qt code lives only in `gui/layout/`.
+- **All errors logged** (`logging.getLogger(__name__)`): an unsupported/failed op is a **no-op + log + status message**, never a crash, never a corrupt model.
+- **Scope:** split / merge / delete only. Operates on rect, polygon, and **straight-edged** `path` (move/line/close); curved paths (quad/cubic) are rejected (region_to_polygon → None). **No** vertex insert/delete, **no** line↔curve, **no** rect-corner resize, **no** overlay/export work (those are #5c).
+- **Inspector/controller split:** UI widgets emit intent signals; `LayoutTab` owns all model mutation (same pattern as #5a).
+- **Results are `polygon` regions** copying the source's `kind/z/bleed/image_style/role/name`.
+- **Coordinates:** scene == page pixels.
+- Conventional Commits (`feat(layout): …`). Commit after each task.
+- **Branch:** continue on `feat/comic-layout-geometry-core`. **Do NOT open a pull request** — the single PR comes only after the whole comic-layout feature (#5c) is done.
+
+### Names used across tasks (keep identical)
+- `region_ops.region_to_polygon(region) -> Optional[Poly]` (Task 1); `_poly_bbox(poly) -> Rect`, `_region_from_polygon(template, poly, *, id) -> Region` (Task 1).
+- `region_ops.split_region(region, a, b) -> Optional[Tuple[Region, Region]]` (Task 2).
+- `region_ops.merge_regions(base, other) -> Optional[Region]` (Task 3).
+- `LayoutTab._apply_delete(region_id) -> bool`, `_apply_knife(region_id, a, b) -> bool`, `_apply_merge(base_id, other_id) -> bool`, `_current_page()`, `_region_index(region_id) -> Optional[int]` (Task 4).
+- `CanvasWidget.set_tool_mode(mode)`, `tool_mode() -> str`, `_register_knife_point(x, y) -> Optional[tuple]`, signals `knifeLine(float,float,float,float)` + `mergeTarget(str)` (Task 5).
+- `GeometryInspector` signals `deleteRequested(str)`, `knifeToggled(str,bool)`, `mergeToggled(str,bool)` + widgets `delete_btn`/`knife_btn`/`merge_btn` (Task 6); `LayoutTab._on_region_delete_requested/_on_region_knife_toggled/_on_canvas_knife_line/_on_region_merge_toggled/_on_canvas_merge_target` (Task 6).
+
+---
+
+### Task 1: `region_to_polygon` + region/polygon helpers (pure)
+
+**Files:**
+- Create: `core/layout/region_ops.py`
+- Test: `tests/layout/test_region_ops.py` (create)
+
+**Interfaces:**
+- Consumes: `Region`, `PathSegment` (`core.layout.models`); `Poly`, `Point` (`core.layout.polygon`).
+- Produces: `region_to_polygon(region) -> Optional[Poly]`; `_poly_bbox(poly) -> Rect`; `_region_from_polygon(template, poly, *, id) -> Region`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_region_ops.py`:
+
+```python
+from core.layout.models import Region, PathSegment
+from core.layout.region_ops import region_to_polygon
+
+
+def test_region_to_polygon_rect():
+    r = Region(id="r", kind="image", shape="rect", bbox=(10, 20, 100, 40))
+    assert region_to_polygon(r) == [
+        (10.0, 20.0), (110.0, 20.0), (110.0, 60.0), (10.0, 60.0)]
+
+
+def test_region_to_polygon_polygon():
+    r = Region(id="p", kind="image", shape="polygon",
+               points=[(0, 0), (40, 0), (40, 30)], bbox=(0, 0, 40, 30))
+    assert region_to_polygon(r) == [(0.0, 0.0), (40.0, 0.0), (40.0, 30.0)]
+
+
+def test_region_to_polygon_straight_path():
+    r = Region(id="q", kind="image", shape="path", bbox=(0, 0, 50, 50), segments=[
+        PathSegment(type="move", pts=[(0.0, 0.0)]),
+        PathSegment(type="line", pts=[(50.0, 0.0)]),
+        PathSegment(type="line", pts=[(50.0, 50.0)]),
+        PathSegment(type="close", pts=[]),
+    ])
+    assert region_to_polygon(r) == [(0.0, 0.0), (50.0, 0.0), (50.0, 50.0)]
+
+
+def test_region_to_polygon_curved_path_none():
+    r = Region(id="c", kind="image", shape="path", bbox=(0, 0, 50, 50), segments=[
+        PathSegment(type="move", pts=[(0.0, 0.0)]),
+        PathSegment(type="cubic", pts=[(10.0, 10.0), (20.0, 20.0), (50.0, 50.0)]),
+        PathSegment(type="close", pts=[]),
+    ])
+    assert region_to_polygon(r) is None
+
+
+def test_region_to_polygon_degenerate_polygon_none():
+    r = Region(id="d", kind="image", shape="polygon", points=[(0, 0), (1, 1)], bbox=(0, 0, 1, 1))
+    assert region_to_polygon(r) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_ops.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'core.layout.region_ops'`.
+
+- [ ] **Step 3: Implement the module foundation**
+
+Create `core/layout/region_ops.py`:
+
+```python
+"""Pure (Qt-free) panel operations for the manual editor: split / merge / delete.
+
+A region is reduced to an open-ring polygon, transformed with
+``polygon.clip_halfplane`` / ``polygon.union_polygons``, and rebuilt as a
+``polygon`` Region. Curved path regions (quad/cubic) are unsupported and yield
+None so callers degrade gracefully — never crash, never corrupt the model.
+"""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Tuple
+
+from core.layout.models import Region
+from core.layout.polygon import (
+    Poly, Point, clip_halfplane, union_polygons, ensure_orientation, signed_area,
+)
+
+logger = logging.getLogger(__name__)
+
+Rect = Tuple[int, int, int, int]
+_AREA_EPS = 1.0  # sq-px tolerance for the merge area-conservation check
+
+
+def region_to_polygon(region: Region) -> Optional[Poly]:
+    """Open-ring polygon for a region, or None if unsupported/degenerate.
+
+    rect -> 4 bbox corners; polygon -> its points; path with only move/line/close
+    -> ordered anchor points; path with any quad/cubic -> None (curved).
+    """
+    if region.shape == "rect":
+        x, y, w, h = region.bbox
+        return [(float(x), float(y)), (float(x + w), float(y)),
+                (float(x + w), float(y + h)), (float(x), float(y + h))]
+    if region.shape == "polygon":
+        if len(region.points) < 3:
+            return None
+        return [(float(px), float(py)) for px, py in region.points]
+    if region.shape == "path":
+        poly: Poly = []
+        for seg in region.segments:
+            if seg.type in ("quad", "cubic"):
+                return None
+            if seg.type in ("move", "line"):
+                px, py = seg.pts[0]
+                poly.append((float(px), float(py)))
+            # close -> contributes no point
+        return poly if len(poly) >= 3 else None
+    return None
+
+
+def _poly_bbox(poly: Poly) -> Rect:
+    xs = [p[0] for p in poly]
+    ys = [p[1] for p in poly]
+    x0, y0 = min(xs), min(ys)
+    return (round(x0), round(y0), round(max(xs) - x0), round(max(ys) - y0))
+
+
+def _region_from_polygon(template: Region, poly: Poly, *, id: str) -> Region:
+    """Build a polygon Region from ``poly``, copying identity/style from template."""
+    return Region(
+        id=id,
+        kind=template.kind,
+        shape="polygon",
+        bbox=_poly_bbox(poly),
+        points=[(round(px), round(py)) for px, py in poly],
+        bleed=template.bleed,
+        z=template.z,
+        name=template.name,
+        role=template.role,
+        text_style=template.text_style,
+        image_style=template.image_style,
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_ops.py -q`
+Expected: PASS (5 passed). Then full suite green: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` (expect ~298).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/region_ops.py tests/layout/test_region_ops.py
+git commit -m "feat(layout): region_to_polygon + polygon-region helpers (pure)"
+```
+
+---
+
+### Task 2: `split_region` — two-click free-line knife (pure)
+
+**Files:**
+- Modify: `core/layout/region_ops.py`
+- Test: `tests/layout/test_region_ops.py` (append)
+
+**Interfaces:**
+- Consumes: `region_to_polygon`, `_region_from_polygon` (Task 1); `clip_halfplane`, `ensure_orientation` (`core.layout.polygon`).
+- Produces: `split_region(region, a, b) -> Optional[Tuple[Region, Region]]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/layout/test_region_ops.py`:
+
+```python
+from core.layout.region_ops import split_region
+
+
+def _square(id="s"):
+    return Region(id=id, kind="image", shape="rect", bbox=(0, 0, 100, 100),
+                  bleed=True, z=5)
+
+
+def test_split_square_vertical_midline():
+    out = split_region(_square(), (50.0, 0.0), (50.0, 100.0))
+    assert out is not None
+    a, b = out
+    assert a.shape == "polygon" and b.shape == "polygon"
+    assert a.id == "s_a" and b.id == "s_b"
+    assert a.bleed is True and a.z == 5  # identity/style copied
+    xranges = sorted([
+        (min(p[0] for p in a.points), max(p[0] for p in a.points)),
+        (min(p[0] for p in b.points), max(p[0] for p in b.points)),
+    ])
+    assert xranges == [(0, 50), (50, 100)]
+
+
+def test_split_miss_returns_none():
+    # vertical line entirely to the right of the square -> one side empty
+    assert split_region(_square(), (200.0, 0.0), (200.0, 100.0)) is None
+
+
+def test_split_curved_path_none():
+    r = Region(id="c", kind="image", shape="path", bbox=(0, 0, 50, 50), segments=[
+        PathSegment(type="move", pts=[(0.0, 0.0)]),
+        PathSegment(type="quad", pts=[(25.0, 25.0), (50.0, 0.0)]),
+        PathSegment(type="close", pts=[]),
+    ])
+    assert split_region(r, (10.0, 0.0), (10.0, 50.0)) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_ops.py -k split -q`
+Expected: FAIL — `ImportError: cannot import name 'split_region'`.
+
+- [ ] **Step 3: Implement `split_region`**
+
+Append to `core/layout/region_ops.py`:
+
+```python
+def split_region(region: Region, a: Point, b: Point) -> Optional[Tuple[Region, Region]]:
+    """Cut ``region`` by the line through a->b into two polygon regions.
+
+    Returns ``(left, right)`` — ``left`` is the half on the LEFT of a->b, ``right``
+    the other half (clip with the cut reversed). Returns None if the region is
+    curved/unsupported or the cut misses (either side has < 3 vertices). The input
+    region is never mutated. New ids are ``f"{region.id}_a"`` / ``f"{region.id}_b"``.
+    """
+    poly = region_to_polygon(region)
+    if poly is None:
+        return None
+    poly = ensure_orientation(poly)
+    left = clip_halfplane(poly, a, b)
+    right = clip_halfplane(poly, b, a)
+    if len(left) < 3 or len(right) < 3:
+        return None
+    return (
+        _region_from_polygon(region, left, id=f"{region.id}_a"),
+        _region_from_polygon(region, right, id=f"{region.id}_b"),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_ops.py -q`
+Expected: PASS. Then full suite green (expect ~301).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/region_ops.py tests/layout/test_region_ops.py
+git commit -m "feat(layout): split_region two-click free-line knife (pure)"
+```
+
+---
+
+### Task 3: `merge_regions` — adjacency union (pure)
+
+**Files:**
+- Modify: `core/layout/region_ops.py`
+- Test: `tests/layout/test_region_ops.py` (append)
+
+**Interfaces:**
+- Consumes: `region_to_polygon`, `_region_from_polygon`, `_AREA_EPS` (Task 1); `union_polygons`, `ensure_orientation`, `signed_area` (`core.layout.polygon`).
+- Produces: `merge_regions(base, other) -> Optional[Region]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/layout/test_region_ops.py`:
+
+```python
+from core.layout.region_ops import merge_regions
+
+
+def test_merge_adjacent_squares():
+    left = Region(id="L", kind="image", shape="rect", bbox=(0, 0, 50, 100), z=3)
+    right = Region(id="R", kind="image", shape="rect", bbox=(50, 0, 50, 100))
+    m = merge_regions(left, right)
+    assert m is not None
+    assert m.id == "L" and m.shape == "polygon" and m.z == 3
+    assert m.bbox == (0, 0, 100, 100)
+
+
+def test_merge_disjoint_returns_none():
+    left = Region(id="L", kind="image", shape="rect", bbox=(0, 0, 50, 100))
+    far = Region(id="R", kind="image", shape="rect", bbox=(60, 0, 50, 100))
+    assert merge_regions(left, far) is None
+
+
+def test_merge_curved_returns_none():
+    left = Region(id="L", kind="image", shape="rect", bbox=(0, 0, 50, 100))
+    curved = Region(id="C", kind="image", shape="path", bbox=(0, 0, 3, 3), segments=[
+        PathSegment(type="move", pts=[(0.0, 0.0)]),
+        PathSegment(type="cubic", pts=[(1.0, 1.0), (2.0, 2.0), (3.0, 3.0)]),
+    ])
+    assert merge_regions(left, curved) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_ops.py -k merge -q`
+Expected: FAIL — `ImportError: cannot import name 'merge_regions'`.
+
+- [ ] **Step 3: Implement `merge_regions`**
+
+Append to `core/layout/region_ops.py`:
+
+```python
+def merge_regions(base: Region, other: Region) -> Optional[Region]:
+    """Union two adjacent regions into one polygon region (keeps base's identity).
+
+    Returns None if either region is curved/unsupported, or the two are not a clean
+    edge-merge: the union must yield exactly one ring whose area equals the sum of
+    the inputs' areas (no gap, no overlap). This makes the result independent of
+    ``union_polygons`` behavior on disjoint input. Inputs are never mutated.
+    """
+    p1 = region_to_polygon(base)
+    p2 = region_to_polygon(other)
+    if p1 is None or p2 is None:
+        return None
+    p1 = ensure_orientation(p1)
+    p2 = ensure_orientation(p2)
+    rings = union_polygons([p1, p2])
+    if len(rings) != 1 or len(rings[0]) < 3:
+        return None
+    merged = ensure_orientation(rings[0])
+    if abs(signed_area(merged) - (signed_area(p1) + signed_area(p2))) > _AREA_EPS:
+        return None  # gap or overlap -> not a clean adjacency merge
+    return _region_from_polygon(base, merged, id=base.id)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_ops.py -q`
+Expected: PASS (all region_ops tests). Then full suite green (expect ~304). If `test_merge_adjacent_squares` fails on `bbox`, print `union_polygons([p1,p2])` to confirm the ring; the area guard already rejects bad unions, so a failure here means the two rects don't share their full edge in the fixture (they do: both span y 0..100 at x=50).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/layout/region_ops.py tests/layout/test_region_ops.py
+git commit -m "feat(layout): merge_regions adjacency union with area-conservation guard (pure)"
+```
+
+---
+
+### Task 4: `LayoutTab` mutation methods — delete / knife / merge
+
+**Files:**
+- Modify: `gui/layout/layout_tab.py` (add `_current_page`, `_region_index`, `_apply_delete`, `_apply_knife`, `_apply_merge`; place after `_find_region` ~214)
+- Test: `tests/layout/test_region_ops_gui.py` (create)
+
+**Interfaces:**
+- Consumes: `region_ops.split_region`, `region_ops.merge_regions` (Tasks 2-3); `LayoutTab.snapshot_and_refresh`, `geometry_editor.active_region_id/set_edit_region`, `self.document`, `self.status` (#5a).
+- Produces: `_current_page() -> Optional[PageSpec]`; `_region_index(region_id) -> Optional[int]`; `_apply_delete(region_id) -> bool`; `_apply_knife(region_id, a, b) -> bool`; `_apply_merge(base_id, other_id) -> bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_region_ops_gui.py`:
+
+```python
+from gui.layout.layout_tab import LayoutTab
+from core.layout.models import Region
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tab_with(regions):
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = regions
+    tab._refresh()
+    return tab
+
+
+def test_apply_delete_removes_and_snapshots(qapp):
+    tab = _tab_with([
+        Region(id="a", kind="image", shape="rect", bbox=(0, 0, 50, 50)),
+        Region(id="b", kind="image", shape="rect", bbox=(50, 0, 50, 50)),
+    ])
+    before = len(tab.history.snapshots())
+    assert tab._apply_delete("a") is True
+    assert [r.id for r in tab.document.pages[0].regions] == ["b"]
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_apply_knife_splits_in_place(qapp):
+    tab = _tab_with([Region(id="x", kind="image", shape="rect", bbox=(0, 0, 100, 100))])
+    before = len(tab.history.snapshots())
+    assert tab._apply_knife("x", (50.0, 0.0), (50.0, 100.0)) is True
+    assert [r.id for r in tab.document.pages[0].regions] == ["x_a", "x_b"]
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_apply_knife_miss_no_change(qapp):
+    tab = _tab_with([Region(id="x", kind="image", shape="rect", bbox=(0, 0, 100, 100))])
+    before = len(tab.history.snapshots())
+    assert tab._apply_knife("x", (200.0, 0.0), (200.0, 100.0)) is False
+    assert [r.id for r in tab.document.pages[0].regions] == ["x"]
+    assert len(tab.history.snapshots()) == before
+
+
+def test_apply_merge_combines(qapp):
+    tab = _tab_with([
+        Region(id="L", kind="image", shape="rect", bbox=(0, 0, 50, 100)),
+        Region(id="R", kind="image", shape="rect", bbox=(50, 0, 50, 100)),
+    ])
+    before = len(tab.history.snapshots())
+    assert tab._apply_merge("L", "R") is True
+    assert [r.id for r in tab.document.pages[0].regions] == ["L"]
+    assert tab.document.pages[0].regions[0].bbox == (0, 0, 100, 100)
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_apply_merge_disjoint_no_change(qapp):
+    tab = _tab_with([
+        Region(id="L", kind="image", shape="rect", bbox=(0, 0, 50, 100)),
+        Region(id="R", kind="image", shape="rect", bbox=(60, 0, 50, 100)),
+    ])
+    before = len(tab.history.snapshots())
+    assert tab._apply_merge("L", "R") is False
+    assert len(tab.document.pages[0].regions) == 2
+    assert len(tab.history.snapshots()) == before
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_ops_gui.py -q`
+Expected: FAIL — `AttributeError: 'LayoutTab' object has no attribute '_apply_delete'`.
+
+- [ ] **Step 3: Implement the mutation methods**
+
+In `gui/layout/layout_tab.py`, add after `_find_region` (~214):
+
+```python
+    def _current_page(self):
+        if not self.document or not self.document.pages:
+            return None
+        return self.document.pages[0]
+
+    def _region_index(self, region_id: str):
+        page = self._current_page()
+        if page is None:
+            return None
+        for i, r in enumerate(page.regions):
+            if r.id == region_id:
+                return i
+        return None
+
+    def _apply_delete(self, region_id: str) -> bool:
+        page = self._current_page()
+        idx = self._region_index(region_id)
+        if page is None or idx is None:
+            return False
+        if self.geometry_editor.active_region_id() == region_id:
+            self.geometry_editor.set_edit_region(None)
+        region = page.regions[idx]
+        del page.regions[idx]
+        self.snapshot_and_refresh(f"delete panel: {region.name or region.id}")
+        return True
+
+    def _apply_knife(self, region_id: str, a, b) -> bool:
+        import logging
+        page = self._current_page()
+        idx = self._region_index(region_id)
+        if page is None or idx is None:
+            return False
+        from core.layout.region_ops import split_region
+        out = split_region(page.regions[idx], a, b)
+        if out is None:
+            logging.getLogger(__name__).warning(
+                "knife: cut missed or unsupported shape for region %s", region_id)
+            self.status.setText("Cannot split — the cut line missed the panel")
+            return False
+        page.regions[idx:idx + 1] = list(out)
+        self.snapshot_and_refresh(f"split panel: {region_id}")
+        return True
+
+    def _apply_merge(self, base_id: str, other_id: str) -> bool:
+        import logging
+        page = self._current_page()
+        if page is None or base_id == other_id:
+            return False
+        bi = self._region_index(base_id)
+        oi = self._region_index(other_id)
+        if bi is None or oi is None:
+            return False
+        from core.layout.region_ops import merge_regions
+        merged = merge_regions(page.regions[bi], page.regions[oi])
+        if merged is None:
+            logging.getLogger(__name__).warning(
+                "merge: regions %s + %s are not adjacent", base_id, other_id)
+            self.status.setText("Cannot merge — panels are not adjacent")
+            return False
+        page.regions[bi] = merged
+        del page.regions[oi]  # replacing base did not change length, so oi is valid
+        self.snapshot_and_refresh(f"merge panels: {base_id} + {other_id}")
+        return True
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_ops_gui.py -q`
+Expected: PASS (5 passed). Then full suite green (expect ~309).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/layout/layout_tab.py tests/layout/test_region_ops_gui.py
+git commit -m "feat(layout): LayoutTab delete/knife/merge mutation methods"
+```
+
+---
+
+### Task 5: `CanvasWidget` tool modes — knife / merge click capture
+
+**Files:**
+- Modify: `gui/layout/canvas_widget.py`
+- Test: `tests/layout/test_canvas_tool_mode.py` (create)
+
+**Interfaces:**
+- Consumes: nothing new (uses `QGraphicsView.mapToScene`, `scene().items`).
+- Produces: `CanvasWidget.set_tool_mode(mode)`, `tool_mode() -> str`, `_register_knife_point(x, y) -> Optional[tuple]`, `_region_id_at(scene_pt) -> Optional[str]`; signals `knifeLine(float,float,float,float)`, `mergeTarget(str)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_canvas_tool_mode.py`:
+
+```python
+from gui.layout.canvas_widget import CanvasWidget
+
+
+def test_knife_two_click_state(qapp):
+    c = CanvasWidget()
+    c.set_tool_mode("knife")
+    assert c.tool_mode() == "knife"
+    assert c._register_knife_point(10.0, 20.0) is None       # first click stored
+    assert c._register_knife_point(30.0, 40.0) == (10.0, 20.0, 30.0, 40.0)
+
+
+def test_set_tool_mode_resets_and_validates(qapp):
+    c = CanvasWidget()
+    c.set_tool_mode("knife")
+    c._register_knife_point(1.0, 1.0)        # half-entered knife
+    c.set_tool_mode("bogus")                 # invalid -> "none" + reset
+    assert c.tool_mode() == "none"
+    assert c._knife_first is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_canvas_tool_mode.py -q`
+Expected: FAIL — `AttributeError: 'CanvasWidget' object has no attribute 'set_tool_mode'`.
+
+- [ ] **Step 3: Implement tool modes**
+
+In `gui/layout/canvas_widget.py`:
+
+(a) Add the two signals next to `regionSelected`:
+
+```python
+    regionSelected = Signal(str)
+    knifeLine = Signal(float, float, float, float)  # p1x, p1y, p2x, p2y (scene px)
+    mergeTarget = Signal(str)                        # clicked region id
+```
+
+(b) In `__init__`, after `self.setScene(QGraphicsScene(self))`, add:
+
+```python
+        self._tool_mode = "none"
+        self._knife_first = None
+```
+
+(c) Add the tool-mode methods (after `selected_region_id`):
+
+```python
+    def set_tool_mode(self, mode: str) -> None:
+        """Switch the canvas tool: "none" (normal select), "knife", or "merge"."""
+        if mode not in ("none", "knife", "merge"):
+            mode = "none"
+        self._tool_mode = mode
+        self._knife_first = None
+
+    def tool_mode(self) -> str:
+        return self._tool_mode
+
+    def _register_knife_point(self, x: float, y: float):
+        """Collect a knife click; return (x1,y1,x2,y2) on the second, else None."""
+        if self._knife_first is None:
+            self._knife_first = (x, y)
+            return None
+        x1, y1 = self._knife_first
+        self._knife_first = None
+        return (x1, y1, x, y)
+
+    def _region_id_at(self, scene_pt):
+        for it in self.scene().items(scene_pt):
+            rid = it.data(0)
+            if rid:
+                return rid
+        return None
+
+    def mousePressEvent(self, event):
+        if self._tool_mode == "knife":
+            sp = self.mapToScene(event.position().toPoint())
+            line = self._register_knife_point(sp.x(), sp.y())
+            if line is not None:
+                self._tool_mode = "none"
+                self.knifeLine.emit(*line)
+            event.accept()
+            return
+        if self._tool_mode == "merge":
+            sp = self.mapToScene(event.position().toPoint())
+            rid = self._region_id_at(sp)
+            self._tool_mode = "none"
+            if rid:
+                self.mergeTarget.emit(rid)
+            event.accept()
+            return
+        super().mousePressEvent(event)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_canvas_tool_mode.py -q`
+Expected: PASS (2 passed). Then full suite green (expect ~311). Confirm existing `test_geometry_editor*.py` still pass (normal mode `"none"` falls through to `super().mousePressEvent`, so selection/handle-drag behavior is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/layout/canvas_widget.py tests/layout/test_canvas_tool_mode.py
+git commit -m "feat(layout): canvas knife/merge tool modes with click capture"
+```
+
+---
+
+### Task 6: Inspector buttons + controller wiring (integration)
+
+**Files:**
+- Modify: `gui/layout/geometry_inspector.py` (add Delete/Knife/Merge controls + signals; reset toggles in `set_region`)
+- Modify: `gui/layout/layout_tab.py` (`_build`: connect inspector + canvas signals; add toggle handlers + `_knife_region_id`/`_merge_base_id`)
+- Test: `tests/layout/test_region_ops_wiring.py` (create)
+
+**Interfaces:**
+- Consumes: `_apply_delete/_apply_knife/_apply_merge` (Task 4); `CanvasWidget.set_tool_mode`, `knifeLine`, `mergeTarget` (Task 5).
+- Produces: `GeometryInspector.deleteRequested(str)/knifeToggled(str,bool)/mergeToggled(str,bool)` + `delete_btn`/`knife_btn`/`merge_btn`; `LayoutTab._on_region_delete_requested/_on_region_knife_toggled/_on_canvas_knife_line/_on_region_merge_toggled/_on_canvas_merge_target`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/layout/test_region_ops_wiring.py`:
+
+```python
+from gui.layout.layout_tab import LayoutTab
+from gui.layout.geometry_inspector import GeometryInspector
+from core.layout.models import Region
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tab_with(regions):
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = regions
+    tab._refresh()
+    return tab
+
+
+def test_inspector_emits_delete_and_toggles(qapp):
+    insp = GeometryInspector()
+    r = Region(id="p", kind="image", shape="polygon",
+               points=[(0, 0), (10, 0), (10, 10)], bbox=(0, 0, 10, 10))
+    insp.set_region(r)
+    seen = []
+    insp.deleteRequested.connect(lambda rid: seen.append(("del", rid)))
+    insp.knifeToggled.connect(lambda rid, on: seen.append(("knife", rid, on)))
+    insp.delete_btn.click()
+    insp.knife_btn.setChecked(True)
+    assert ("del", "p") in seen
+    assert ("knife", "p", True) in seen
+
+
+def test_knife_wiring_end_to_end(qapp):
+    tab = _tab_with([Region(id="x", kind="image", shape="rect", bbox=(0, 0, 100, 100))])
+    tab._on_region_knife_toggled("x", True)
+    assert tab.canvas.tool_mode() == "knife"
+    tab.canvas.knifeLine.emit(50.0, 0.0, 50.0, 100.0)
+    assert [r.id for r in tab.document.pages[0].regions] == ["x_a", "x_b"]
+
+
+def test_merge_wiring_end_to_end(qapp):
+    tab = _tab_with([
+        Region(id="L", kind="image", shape="rect", bbox=(0, 0, 50, 100)),
+        Region(id="R", kind="image", shape="rect", bbox=(50, 0, 50, 100)),
+    ])
+    tab._on_region_merge_toggled("L", True)
+    assert tab.canvas.tool_mode() == "merge"
+    tab.canvas.mergeTarget.emit("R")
+    assert [r.id for r in tab.document.pages[0].regions] == ["L"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_ops_wiring.py -q`
+Expected: FAIL — `AttributeError: 'GeometryInspector' object has no attribute 'delete_btn'`.
+
+- [ ] **Step 3: Add the inspector controls**
+
+In `gui/layout/geometry_inspector.py`:
+
+(a) Add `QPushButton` to the imports:
+
+```python
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QCheckBox, QSpinBox, QPushButton,
+)
+```
+
+(b) Add the signals next to the existing ones:
+
+```python
+    deleteRequested = Signal(str)        # (region_id)
+    knifeToggled = Signal(str, bool)     # (region_id, on)
+    mergeToggled = Signal(str, bool)     # (region_id, on)
+```
+
+(c) In `_build`, after the `edit_shape_chk` line (`root.addWidget(self.edit_shape_chk)`), add a button row:
+
+```python
+        ops_row = QHBoxLayout()
+        self.delete_btn = QPushButton("Delete panel")
+        self.delete_btn.clicked.connect(self._on_delete)
+        ops_row.addWidget(self.delete_btn)
+        self.knife_btn = QPushButton("Knife (split)")
+        self.knife_btn.setCheckable(True)
+        self.knife_btn.toggled.connect(self._on_knife)
+        ops_row.addWidget(self.knife_btn)
+        self.merge_btn = QPushButton("Merge…")
+        self.merge_btn.setCheckable(True)
+        self.merge_btn.toggled.connect(self._on_merge)
+        ops_row.addWidget(self.merge_btn)
+        root.addLayout(ops_row)
+```
+
+(d) In `set_region`, reset/enable the new controls. Find the block that resets `edit_shape_chk` (it does `blockSignals(True)`, `setChecked(False)`, `setEnabled(...)`, `blockSignals(False)`) and add, immediately after it:
+
+```python
+        for btn in (self.knife_btn, self.merge_btn):
+            btn.blockSignals(True)
+            btn.setChecked(False)
+            btn.setEnabled(region is not None)
+            btn.blockSignals(False)
+        self.delete_btn.setEnabled(region is not None)
+```
+
+(e) Add the handlers (after `_on_edit_shape`):
+
+```python
+    def _on_delete(self):
+        if self._region is not None:
+            self.deleteRequested.emit(self._region.id)
+
+    def _on_knife(self, checked: bool):
+        if self._region is not None:
+            self.knifeToggled.emit(self._region.id, bool(checked))
+
+    def _on_merge(self, checked: bool):
+        if self._region is not None:
+            self.mergeToggled.emit(self._region.id, bool(checked))
+```
+
+- [ ] **Step 4: Wire `LayoutTab`**
+
+In `gui/layout/layout_tab.py`:
+
+(a) In `__init__`, after `self._locked = self._load_locked()` (before `self._build()`), add:
+
+```python
+        self._knife_region_id = None
+        self._merge_base_id = None
+```
+
+(b) In `_build`, in the geometry-inspector wiring block (where `editShapeToggled` is connected), add:
+
+```python
+        self.geometry_inspector.deleteRequested.connect(self._on_region_delete_requested)
+        self.geometry_inspector.knifeToggled.connect(self._on_region_knife_toggled)
+        self.geometry_inspector.mergeToggled.connect(self._on_region_merge_toggled)
+```
+
+(c) In `_build`, immediately after `self.canvas.regionSelected.connect(self._on_region_selected)` (~line 97), connect the canvas tool signals:
+
+```python
+        self.canvas.knifeLine.connect(self._on_canvas_knife_line)
+        self.canvas.mergeTarget.connect(self._on_canvas_merge_target)
+```
+
+(d) Add the handlers (after the `_apply_*` methods from Task 4):
+
+```python
+    def _on_region_delete_requested(self, region_id: str):
+        self._apply_delete(region_id)
+
+    def _on_region_knife_toggled(self, region_id: str, on: bool):
+        if on:
+            self._knife_region_id = region_id
+            self.canvas.set_tool_mode("knife")
+            self.status.setText("Knife: click two points to cut the panel")
+        else:
+            self._knife_region_id = None
+            self.canvas.set_tool_mode("none")
+
+    def _on_canvas_knife_line(self, x1: float, y1: float, x2: float, y2: float):
+        rid = self._knife_region_id
+        self._knife_region_id = None
+        if rid:
+            self._apply_knife(rid, (x1, y1), (x2, y2))
+
+    def _on_region_merge_toggled(self, region_id: str, on: bool):
+        if on:
+            self._merge_base_id = region_id
+            self.canvas.set_tool_mode("merge")
+            self.status.setText("Merge: click an adjacent panel")
+        else:
+            self._merge_base_id = None
+            self.canvas.set_tool_mode("none")
+
+    def _on_canvas_merge_target(self, other_id: str):
+        base = self._merge_base_id
+        self._merge_base_id = None
+        if base:
+            self._apply_merge(base, other_id)
+```
+
+- [ ] **Step 5: Run tests + commit**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/test_region_ops_wiring.py -q` → PASS (3 passed). Then the FULL suite: `QT_QPA_PLATFORM=offscreen .venv_linux/bin/python -m pytest tests/layout/ -q` → all green (expect ~314), confirming `test_geometry_inspector.py` still constructs `GeometryInspector` cleanly with the new buttons.
+
+```bash
+git add gui/layout/geometry_inspector.py gui/layout/layout_tab.py tests/layout/test_region_ops_wiring.py
+git commit -m "feat(layout): wire delete/knife/merge inspector controls to canvas + controller"
+```
+
+---
+
+## Notes / deliberately deferred (not gaps)
+- **Vertex insert/delete, line↔curve conversion, rect-corner resize** — possible later additions; not #5b.
+- **Splitting/merging curved path regions** — would need curve subdivision; rejected fail-safe for now.
+- **Overlay editing + SFX rotation + stranded-overlay reposition + PIL→Qt export unification** → **#5c**.
+- **Merge UX is single-step** (toggle Merge, click the other panel). Multi-select merge is not in scope.
+
+## Self-Review (completed by plan author)
+- **Spec coverage:** split (Task 2, two-click free line via clip_halfplane both sides) + merge (Task 3, union_polygons + area-conservation guard) + delete (Task 4) + canvas knife/merge capture (Task 5) + inspector controls & wiring (Task 6). region_to_polygon (Task 1) underpins all three ops; curved-path rejection is in Task 1 and exercised by Tasks 2-3. Error paths (cut miss / not adjacent / curved) → no-op + log + status (Task 4), tested in Task 4. Inspector/controller split honored (widgets emit; LayoutTab mutates).
+- **Placeholder scan:** no TBD/TODO; every code step shows complete code; degrade paths are concrete (`split_region`/`merge_regions` return None → status + warning).
+- **Type/name consistency:** `region_to_polygon`/`_region_from_polygon` (T1) consumed by `split_region`/`merge_regions` (T2/T3); those consumed by `_apply_knife`/`_apply_merge` (T4); `set_tool_mode`/`knifeLine`/`mergeTarget` (T5) consumed by the wiring (T6); inspector signal names (`deleteRequested`/`knifeToggled`/`mergeToggled`) match between `GeometryInspector` and the `LayoutTab` connects. `clip_halfplane`/`union_polygons`/`ensure_orientation`/`signed_area`, `Region` fields, `snapshot_and_refresh`, `geometry_editor.active_region_id/set_edit_region` all match real signatures.
+- **Test interpreter/baseline:** all tasks use `.venv_linux/bin/python` under `QT_QPA_PLATFORM=offscreen`; suite 293 → ~314 (5+3+3+5+2+3 = 21 new tests; counts approximate — binding check is "all new tests pass and the full suite stays green").

--- a/core/layout/balloons.py
+++ b/core/layout/balloons.py
@@ -1,0 +1,89 @@
+"""Pure (Qt-free) comic-overlay geometry: balloon/caption bodies + tails.
+
+Compiles an overlay's inner bounding rectangle (text box + padding) into
+PathSegment geometry that core.layout.qt_renderer draws unchanged. No Qt, no
+font metrics here — the renderer measures text and passes us `inner`.
+
+`inner` is (x, y, w, h); the produced body's bounding box contains `inner`.
+"""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Tuple
+
+from core.layout.models import OverlayStyle, PathSegment
+
+logger = logging.getLogger(__name__)
+
+Point = Tuple[float, float]
+Rect = Tuple[float, float, float, float]
+
+KAPPA = 0.5522847498307936  # control-point factor for a circular quarter-arc cubic
+
+
+def _valid_rect(inner: Rect) -> bool:
+    _, _, w, h = inner
+    return w > 0.0 and h > 0.0
+
+
+def caption_body(inner: Rect) -> List[PathSegment]:
+    """A plain rectangle (caption box) around `inner`."""
+    x, y, w, h = inner
+    return [
+        PathSegment(type="move", pts=[(x, y)]),
+        PathSegment(type="line", pts=[(x + w, y)]),
+        PathSegment(type="line", pts=[(x + w, y + h)]),
+        PathSegment(type="line", pts=[(x, y + h)]),
+        PathSegment(type="close", pts=[]),
+    ]
+
+
+def speech_body(inner: Rect, *, radius: float) -> List[PathSegment]:
+    """A rounded rectangle around `inner`; corners are circular cubic arcs.
+
+    Segment order (used by the tail splice in Task 3):
+      0 move, 1 TOP line, 2 TR cubic, 3 RIGHT line, 4 BR cubic,
+      5 BOTTOM line, 6 BL cubic, 7 LEFT line, 8 TL cubic, 9 close
+    """
+    x, y, w, h = inner
+    r = max(0.0, min(radius, w / 2.0, h / 2.0))
+    k = r * KAPPA
+    x2, y2 = x + w, y + h
+    return [
+        PathSegment(type="move", pts=[(x + r, y)]),
+        PathSegment(type="line", pts=[(x2 - r, y)]),
+        PathSegment(type="cubic", pts=[(x2 - r + k, y), (x2, y + r - k), (x2, y + r)]),
+        PathSegment(type="line", pts=[(x2, y2 - r)]),
+        PathSegment(type="cubic", pts=[(x2, y2 - r + k), (x2 - r + k, y2), (x2 - r, y2)]),
+        PathSegment(type="line", pts=[(x + r, y2)]),
+        PathSegment(type="cubic", pts=[(x + r - k, y2), (x, y2 - r + k), (x, y2 - r)]),
+        PathSegment(type="line", pts=[(x, y + r)]),
+        PathSegment(type="cubic", pts=[(x, y + r - k), (x + r - k, y), (x + r, y)]),
+        PathSegment(type="close", pts=[]),
+    ]
+
+
+def overlay_to_segments(kind: str, inner: Rect, tail_target: Optional[Point],
+                        style: OverlayStyle) -> List[PathSegment]:
+    """Compile an overlay body (+ tail) for `kind`.
+
+    caption -> rectangle (tail ignored); speech -> rounded body (tail spliced in
+    Task 3); thought -> cloud + trail (Task 4); sfx -> [] (text only).
+    Degenerate `inner` (non-positive size) logs a warning and returns [].
+    """
+    if kind == "sfx":
+        return []
+    if not _valid_rect(inner):
+        logger.warning("Overlay %r has a degenerate/non-positive inner rect %r; no body",
+                       kind, inner)
+        return []
+    if kind == "caption":
+        return caption_body(inner)
+    if kind == "speech":
+        return speech_body(inner, radius=style.radius_px)
+    if kind == "thought":
+        # Implemented in Task 4; until then fall back to a plain body so callers
+        # never crash. Replaced by thought_body + trail in Task 4.
+        return speech_body(inner, radius=style.radius_px)
+    logger.warning("Overlay has unknown kind %r; no body", kind)
+    return []

--- a/core/layout/balloons.py
+++ b/core/layout/balloons.py
@@ -9,6 +9,7 @@ font metrics here — the renderer measures text and passes us `inner`.
 from __future__ import annotations
 
 import logging
+import math
 from typing import List, Optional, Tuple
 
 from core.layout.models import OverlayStyle, PathSegment
@@ -122,6 +123,55 @@ def _splice_speech_tail(segs: List[PathSegment], inner: Rect, target: Point,
     return out
 
 
+def _circle_segments(cx: float, cy: float, r: float) -> List[PathSegment]:
+    """A closed circle approximated by four cubic quarter-arcs (move..close)."""
+    k = r * KAPPA
+    return [
+        PathSegment(type="move", pts=[(cx + r, cy)]),
+        PathSegment(type="cubic", pts=[(cx + r, cy + k), (cx + k, cy + r), (cx, cy + r)]),
+        PathSegment(type="cubic", pts=[(cx - k, cy + r), (cx - r, cy + k), (cx - r, cy)]),
+        PathSegment(type="cubic", pts=[(cx - r, cy - k), (cx - k, cy - r), (cx, cy - r)]),
+        PathSegment(type="cubic", pts=[(cx + k, cy - r), (cx + r, cy - k), (cx + r, cy)]),
+        PathSegment(type="close", pts=[]),
+    ]
+
+
+def thought_body(inner: Rect, *, scallop: float) -> List[PathSegment]:
+    """A scalloped 'cloud' on an ellipse circumscribing `inner`.
+
+    N outward quad bumps around the ellipse. The circumscribing ellipse
+    (semi-axes 1.42x the rect half-extents) contains `inner`'s corners; the
+    bumps extend further, so bbox(cloud) contains `inner`.
+    """
+    x, y, w, h = inner
+    cx, cy = x + w / 2.0, y + h / 2.0
+    ax, ay = (w / 2.0) * 1.42, (h / 2.0) * 1.42  # circumscribe the corners
+    bumps = max(8, int(((w + h) / 40.0)) * 2)    # even count, scales with size
+    pts = [(cx + ax * math.cos(2 * math.pi * i / bumps),
+            cy + ay * math.sin(2 * math.pi * i / bumps)) for i in range(bumps)]
+    segs = [PathSegment(type="move", pts=[pts[0]])]
+    for i in range(bumps):
+        nxt = pts[(i + 1) % bumps]
+        mid_ang = 2 * math.pi * (i + 0.5) / bumps
+        ctrl = (cx + (ax + scallop) * math.cos(mid_ang),
+                cy + (ay + scallop) * math.sin(mid_ang))
+        segs.append(PathSegment(type="quad", pts=[ctrl, nxt]))
+    segs.append(PathSegment(type="close", pts=[]))
+    return segs
+
+
+def thought_trail(body_center: Point, target: Point, *, count: int = 3) -> List[PathSegment]:
+    """`count` shrinking circles from near `body_center` toward `target`."""
+    out: List[PathSegment] = []
+    for i in range(count):
+        t = (i + 1) / (count + 1)
+        cx = body_center[0] + (target[0] - body_center[0]) * t
+        cy = body_center[1] + (target[1] - body_center[1]) * t
+        r = max(1.0, 6.0 * (1.0 - t))   # shrink toward the target
+        out.extend(_circle_segments(cx, cy, r))
+    return out
+
+
 def overlay_to_segments(kind: str, inner: Rect, tail_target: Optional[Point],
                         style: OverlayStyle) -> List[PathSegment]:
     """Compile an overlay body (+ tail) for `kind`.
@@ -145,8 +195,10 @@ def overlay_to_segments(kind: str, inner: Rect, tail_target: Optional[Point],
         base_width = max(8.0, min(inner[2], inner[3]) * 0.35)
         return _splice_speech_tail(body, inner, tail_target, base_width, style.radius_px)
     if kind == "thought":
-        # Implemented in Task 4; until then fall back to a plain body so callers
-        # never crash. Replaced by thought_body + trail in Task 4.
-        return speech_body(inner, radius=style.radius_px)
+        body = thought_body(inner, scallop=max(4.0, style.radius_px * 0.5))
+        if tail_target is None:
+            return body
+        cx, cy = inner[0] + inner[2] / 2.0, inner[1] + inner[3] / 2.0
+        return body + thought_trail((cx, cy), tail_target, count=3)
     logger.warning("Overlay has unknown kind %r; no body", kind)
     return []

--- a/core/layout/balloons.py
+++ b/core/layout/balloons.py
@@ -63,6 +63,65 @@ def speech_body(inner: Rect, *, radius: float) -> List[PathSegment]:
     ]
 
 
+def _edge_for_target(inner: Rect, target: Point) -> str:
+    x, y, w, h = inner
+    cx, cy = x + w / 2.0, y + h / 2.0
+    dx, dy = target[0] - cx, target[1] - cy
+    # choose the dominant direction; ties prefer vertical (bottom/top) — the
+    # conventional comic tail direction
+    if abs(dy) >= abs(dx):
+        return "bottom" if dy >= 0 else "top"
+    return "right" if dx >= 0 else "left"
+
+
+def _edge_span(inner: Rect, r: float, edge: str) -> Tuple[Point, Point, int]:
+    """Straight-edge start/end (in outline traversal order) + its segment index,
+    for a rounded body of `inner` with corner radius r."""
+    x, y, w, h = inner
+    x2, y2 = x + w, y + h
+    if edge == "top":     # left->right, segment index 1
+        return (x + r, y), (x2 - r, y), 1
+    if edge == "right":   # top->bottom, index 3
+        return (x2, y + r), (x2, y2 - r), 3
+    if edge == "bottom":  # right->left, index 5
+        return (x2 - r, y2), (x + r, y2), 5
+    return (x, y2 - r), (x, y + r), 7  # left: bottom->top, index 7
+
+
+def _splice_speech_tail(segs: List[PathSegment], inner: Rect, target: Point,
+                        base_width: float, radius: float) -> List[PathSegment]:
+    x, y, w, h = inner
+    r = max(0.0, min(radius, w / 2.0, h / 2.0))
+    edge = _edge_for_target(inner, target)
+    (sx, sy), (ex, ey), idx = _edge_span(inner, r, edge)
+    tip = (float(target[0]), float(target[1]))
+    if edge in ("top", "bottom"):
+        lo, hi = sorted((sx, ex))
+        mid = min(max(target[0], lo + 1e-6), hi - 1e-6)
+        half = min(base_width / 2.0, (hi - lo) / 2.0 - 1e-6)
+        p1, p2 = (mid - half, sy), (mid + half, sy)
+    else:  # left / right edges (vertical span)
+        lo, hi = sorted((sy, ey))
+        mid = min(max(target[1], lo + 1e-6), hi - 1e-6)
+        half = min(base_width / 2.0, (hi - lo) / 2.0 - 1e-6)
+        p1, p2 = (sx, mid - half), (sx, mid + half)
+    # order base points along the traversal start (sx,sy) -> end (ex,ey):
+    # `a` is the base point nearer the start vertex.
+    def _d2(p, q):
+        return (p[0] - q[0]) ** 2 + (p[1] - q[1]) ** 2
+    a, b = (p1, p2) if _d2(p1, (sx, sy)) <= _d2(p2, (sx, sy)) else (p2, p1)
+    out: List[PathSegment] = []
+    for i, seg in enumerate(segs):
+        if i == idx and seg.type == "line":
+            out.append(PathSegment(type="line", pts=[a]))
+            out.append(PathSegment(type="line", pts=[tip]))
+            out.append(PathSegment(type="line", pts=[b]))
+            out.append(seg)  # original edge endpoint completes the edge
+        else:
+            out.append(seg)
+    return out
+
+
 def overlay_to_segments(kind: str, inner: Rect, tail_target: Optional[Point],
                         style: OverlayStyle) -> List[PathSegment]:
     """Compile an overlay body (+ tail) for `kind`.
@@ -80,7 +139,11 @@ def overlay_to_segments(kind: str, inner: Rect, tail_target: Optional[Point],
     if kind == "caption":
         return caption_body(inner)
     if kind == "speech":
-        return speech_body(inner, radius=style.radius_px)
+        body = speech_body(inner, radius=style.radius_px)
+        if tail_target is None:
+            return body
+        base_width = max(8.0, min(inner[2], inner[3]) * 0.35)
+        return _splice_speech_tail(body, inner, tail_target, base_width, style.radius_px)
     if kind == "thought":
         # Implemented in Task 4; until then fall back to a plain body so callers
         # never crash. Replaced by thought_body + trail in Task 4.

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -37,16 +37,34 @@ def build_messages(content_kind: str, page_px: Tuple[int, int], user_text: str,
         f"{current}"
         f"<request>\n{user_text}\n</request>\n"
         f"<instructions>\n"
-        f"Return a JSON object with optional keys:\n"
+        f"Return a SINGLE JSON object with optional keys:\n"
         f'  "questions": [strings]   // ask for missing detail if needed\n'
-        f'  "layout": {{ "regions": [ {{\n'
-        f'      "id": string, "kind": "image"|"text", "shape": "rect"|"polygon",\n'
-        f'      "bbox": [x,y,w,h], "points": [[x,y],...] (polygon only),\n'
-        f'      "z": int, "role": string, "text": string (text only) }} ] }}\n'
-        f"All coordinates MUST be within the page ({pw} x {ph}). Prefer 'rect' unless the\n"
+        f'  "layout": {{\n'
+        f'    "tiling": {{ "preset": "grid"|"three_tiers"|"splash_with_strip"|'
+        f'"diagonal_action"|"feature_L",\n'
+        f'                "params": {{ "rows": int, "cols": int, "gutter_px": number,'
+        f' "margin_px": number }} }},\n'
+        f"        // optional; generates gap-free panels. rows/cols apply to \"grid\".\n"
+        f'    "regions": [ {{ "id": string, "kind": "image"|"text",\n'
+        f'        "shape": "rect"|"polygon"|"path",\n'
+        f'        "bbox": [x,y,w,h], "points": [[x,y],...] (polygon only),\n'
+        f'        "svg": "M.. L.. C.. Z" (path only; SVG path data in page pixels),\n'
+        f'        "bleed": bool, "stroke_px": number,\n'
+        f'        "z": int, "role": string, "text": string (text only) }} ],\n'
+        f'    "overlays": [ {{ "id": string,\n'
+        f'        "kind": "speech"|"thought"|"caption"|"sfx", "text": string,\n'
+        f'        "anchor_region": string, "anchor_offset": [fx,fy] (0..1 within region),\n'
+        f'        "tail_to_region": string,            // tail points at that region center\n'
+        f'        "anchor": [x,y], "tail_target": [x,y], // raw-pixel alternative\n'
+        f'        "role": string }} ]\n'
+        f'  }}\n'
+        f"All coordinates MUST be within the page ({pw} x {ph}). Prefer \"rect\" for simple\n"
+        f"panels; use \"tiling\" for clean gap-free grids/strips; use \"shape\":\"path\" with\n"
+        f"\"svg\" for curved or angled panels; use \"polygon\" for straight-edged non-rect panels.\n"
         f"Each text region MUST set \"role\" to one of: {roles}.\n"
-        f"request implies panels that flow into each other (then use 'polygon'). You may\n"
-        f"return questions, a layout, or both.\n"
+        f"Overlays float above panels: prefer \"anchor_region\"+\"anchor_offset\" (and\n"
+        f"\"tail_to_region\") so balloons sit inside a panel; use raw \"anchor\"/\"tail_target\"\n"
+        f"pixels only for free placement. You may return questions, a layout, or both.\n"
         f"</instructions>"
     )
     return [{"role": "system", "content": _SYSTEM}, {"role": "user", "content": user}]

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -151,10 +151,14 @@ def _build_overlay(od: Dict, regions_by_id: Dict, page_px: Tuple[int, int], idx:
     if resolved is None:
         return None
     anchor, anchor_mode, tail = resolved
+    try:
+        z = int(od.get("z", 0))
+    except (TypeError, ValueError):
+        z = 0
     return Overlay(
         id=od.get("id", f"ov{idx + 1}"), kind=kind, text=str(od.get("text", "")),
         anchor=anchor, anchor_mode=anchor_mode, tail_target=tail,
-        z=int(od.get("z", 0)), role=od.get("role", ""),
+        z=z, role=od.get("role", ""),
     )
 
 

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import List, Dict, Optional, Tuple, Callable
 
-from core.layout.models import Region
+from core.layout.models import Region, Overlay
 from core.layout import schema
 
 logger = logging.getLogger("imageai.layout.designer")
@@ -79,6 +79,7 @@ def resolve_provider_ids(provider: str) -> Tuple[str, str]:
 class DesignerResult:
     questions: List[str] = field(default_factory=list)
     regions: Optional[List[Region]] = None
+    overlays: List[Overlay] = field(default_factory=list)
     raw: str = ""
 
 
@@ -92,6 +93,71 @@ def fallback_result(page_px: Tuple[int, int]) -> DesignerResult:
         regions=[region], raw="")
 
 
+def _resolve_overlay_anchor(od: Dict, regions_by_id: Dict, page_px: Tuple[int, int]):
+    """Resolve an overlay dict's placement to (anchor_px, anchor_mode, tail_px|None).
+
+    Raw-pixel "anchor"/"tail_target" win; otherwise "anchor_region"+"anchor_offset"
+    (0..1 within the region bbox) and "tail_to_region" (region center) are resolved
+    against the already-parsed regions. Returns None (drop the overlay) if no anchor
+    can be resolved. All resolution is logged on failure; never raises.
+    """
+    pw, ph = page_px
+    anchor_mode = od.get("anchor_mode", "center")
+    anchor = None
+    raw = od.get("anchor")
+    if isinstance(raw, (list, tuple)) and len(raw) == 2:
+        anchor = (float(raw[0]), float(raw[1]))
+    else:
+        rid = od.get("anchor_region")
+        if rid is not None and rid in regions_by_id:
+            bx, by, bw, bh = regions_by_id[rid].bbox
+            off = od.get("anchor_offset", [0.5, 0.5])
+            if isinstance(off, (list, tuple)) and len(off) == 2:
+                ox, oy = float(off[0]), float(off[1])
+            else:
+                ox, oy = 0.5, 0.5
+            anchor = (bx + ox * bw, by + oy * bh)
+        elif rid is not None:
+            logger.warning("Designer overlay %r: unknown anchor_region %r; skipped",
+                           od.get("id"), rid)
+            return None
+    if anchor is None:
+        logger.warning("Designer overlay %r: no anchor or anchor_region; skipped", od.get("id"))
+        return None
+    anchor = (min(max(anchor[0], 0.0), float(pw)), min(max(anchor[1], 0.0), float(ph)))
+
+    tail = None
+    traw = od.get("tail_target")
+    if isinstance(traw, (list, tuple)) and len(traw) == 2:
+        tail = (float(traw[0]), float(traw[1]))
+    else:
+        trid = od.get("tail_to_region")
+        if trid is not None and trid in regions_by_id:
+            bx, by, bw, bh = regions_by_id[trid].bbox
+            tail = (bx + bw / 2.0, by + bh / 2.0)
+        elif trid is not None:
+            logger.warning("Designer overlay %r: unknown tail_to_region %r; tail dropped",
+                           od.get("id"), trid)
+    return anchor, anchor_mode, tail
+
+
+def _build_overlay(od: Dict, regions_by_id: Dict, page_px: Tuple[int, int], idx: int):
+    """Build one Overlay from an LLM overlay dict, or None to skip it."""
+    kind = od.get("kind")
+    if kind not in ("speech", "thought", "caption", "sfx"):
+        logger.warning("Designer overlay %r: unknown kind %r; skipped", od.get("id"), kind)
+        return None
+    resolved = _resolve_overlay_anchor(od, regions_by_id, page_px)
+    if resolved is None:
+        return None
+    anchor, anchor_mode, tail = resolved
+    return Overlay(
+        id=od.get("id", f"ov{idx + 1}"), kind=kind, text=str(od.get("text", "")),
+        anchor=anchor, anchor_mode=anchor_mode, tail_target=tail,
+        z=int(od.get("z", 0)), role=od.get("role", ""),
+    )
+
+
 def parse_response(content: str, page_px: Tuple[int, int]) -> DesignerResult:
     from gui.llm_utils import LLMResponseParser
     data = LLMResponseParser.parse_json_response(content, expected_type=dict)
@@ -102,22 +168,31 @@ def parse_response(content: str, page_px: Tuple[int, int]) -> DesignerResult:
     questions = ([str(q) for q in raw_questions if str(q).strip()]
                  if isinstance(raw_questions, list) else [])
     regions = None
+    overlays: List[Overlay] = []
     layout = data.get("layout")
-    if isinstance(layout, dict) and isinstance(layout.get("regions"), list):
-        regions = []
-        for i, rd in enumerate(layout["regions"]):
-            if not isinstance(rd, dict):
-                continue
-            rd = dict(rd)  # don't mutate the parsed dict
-            rd.setdefault("id", f"region{i + 1}")
-            rd.setdefault("kind", "image")
-            region = schema.region_from_dict(rd)
-            regions.append(schema.normalize_region(region, page_px))
-        if not regions:
-            regions = None
-    if regions is None and not questions:
+    if isinstance(layout, dict):
+        if isinstance(layout.get("regions"), list):
+            collected = []
+            for i, rd in enumerate(layout["regions"]):
+                if not isinstance(rd, dict):
+                    continue
+                rd = dict(rd)  # don't mutate the parsed dict
+                rd.setdefault("id", f"region{i + 1}")
+                rd.setdefault("kind", "image")
+                region = schema.region_from_dict(rd)
+                collected.append(schema.normalize_region(region, page_px))
+            if collected:
+                regions = collected
+        if isinstance(layout.get("overlays"), list):
+            by_id = {r.id: r for r in (regions or [])}
+            for i, od in enumerate(layout["overlays"]):
+                if isinstance(od, dict):
+                    ov = _build_overlay(od, by_id, page_px, i)
+                    if ov is not None:
+                        overlays.append(ov)
+    if regions is None and not questions and not overlays:
         return fallback_result(page_px)
-    return DesignerResult(questions=questions, regions=regions, raw=content)
+    return DesignerResult(questions=questions, regions=regions, overlays=overlays, raw=content)
 
 
 def run_design(messages: List[Dict], page_px: Tuple[int, int],

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -261,7 +261,12 @@ def parse_response(content: str, page_px: Tuple[int, int]) -> DesignerResult:
             by_id = {r.id: r for r in (regions or [])}
             for i, od in enumerate(layout["overlays"]):
                 if isinstance(od, dict):
-                    ov = _build_overlay(od, by_id, page_px, i)
+                    try:
+                        ov = _build_overlay(od, by_id, page_px, i)
+                    except (TypeError, ValueError) as e:
+                        logger.warning("Designer overlay %r: malformed numeric field (%s); skipped",
+                                       od.get("id"), e)
+                        ov = None
                     if ov is not None:
                         overlays.append(ov)
     if regions is None and not questions and not overlays:

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -162,6 +162,57 @@ def _build_overlay(od: Dict, regions_by_id: Dict, page_px: Tuple[int, int], idx:
     )
 
 
+def _regions_from_tiling(tspec, page_px: Tuple[int, int]) -> List[Region]:
+    """Expand a tiling-preset request into gap-free panel Regions (or [] on failure)."""
+    if not isinstance(tspec, dict):
+        return []
+    from core.layout import tiling
+    preset = tspec.get("preset")
+    params = tspec.get("params") or {}
+    pw, ph = page_px
+    try:
+        if preset == "grid":
+            tree = tiling.grid(int(params.get("rows", 2)), int(params.get("cols", 2)))
+        elif preset == "three_tiers":
+            tree = tiling.three_tiers()
+        elif preset == "splash_with_strip":
+            tree = tiling.splash_with_strip()
+        elif preset == "diagonal_action":
+            tree = tiling.diagonal_action()
+        elif preset == "feature_L":
+            tree = tiling.feature_L()
+        else:
+            logger.warning("Designer: unknown tiling preset %r; ignored", preset)
+            return []
+        gutter = float(params.get("gutter_px", 12))
+        margin = float(params.get("margin_px", 24))
+        return tiling.tile(tree, (0, 0, pw, ph), gutter=gutter, margin=margin)
+    except Exception as e:  # noqa: BLE001 - degrade, never crash
+        logger.warning("Designer: tiling preset %r failed: %s", preset, e)
+        return []
+
+
+def _normalize_region_dict(rd: Dict) -> Dict:
+    """Map LLM region shorthands onto schema.region_from_dict's expected keys.
+
+    "svg" -> shape="path" + "segments"; top-level "stroke_px" -> image_style.stroke_px.
+    Returns a new dict; the caller's parsed dict is not mutated.
+    """
+    rd = dict(rd)
+    svg = rd.pop("svg", None)
+    if svg:
+        from core.layout.svg_path import svg_to_segments
+        segs = svg_to_segments(str(svg))
+        rd["shape"] = "path"
+        rd["segments"] = [{"type": s.type, "pts": [list(p) for p in s.pts]} for s in segs]
+    stroke = rd.pop("stroke_px", None)
+    if stroke is not None:
+        istyle = dict(rd.get("image_style") or {})
+        istyle.setdefault("stroke_px", stroke)
+        rd["image_style"] = istyle
+    return rd
+
+
 def parse_response(content: str, page_px: Tuple[int, int]) -> DesignerResult:
     from gui.llm_utils import LLMResponseParser
     data = LLMResponseParser.parse_json_response(content, expected_type=dict)
@@ -175,18 +226,19 @@ def parse_response(content: str, page_px: Tuple[int, int]) -> DesignerResult:
     overlays: List[Overlay] = []
     layout = data.get("layout")
     if isinstance(layout, dict):
+        collected = []
+        collected.extend(_regions_from_tiling(layout.get("tiling"), page_px))
         if isinstance(layout.get("regions"), list):
-            collected = []
             for i, rd in enumerate(layout["regions"]):
                 if not isinstance(rd, dict):
                     continue
-                rd = dict(rd)  # don't mutate the parsed dict
+                rd = _normalize_region_dict(rd)
                 rd.setdefault("id", f"region{i + 1}")
                 rd.setdefault("kind", "image")
                 region = schema.region_from_dict(rd)
                 collected.append(schema.normalize_region(region, page_px))
-            if collected:
-                regions = collected
+        if collected:
+            regions = collected
         if isinstance(layout.get("overlays"), list):
             by_id = {r.id: r for r in (regions or [])}
             for i, od in enumerate(layout["overlays"]):

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -45,6 +45,9 @@ def build_messages(content_kind: str, page_px: Tuple[int, int], user_text: str,
         f'                "params": {{ "rows": int, "cols": int, "gutter_px": number,'
         f' "margin_px": number }} }},\n'
         f"        // optional; generates gap-free panels. rows/cols apply to \"grid\".\n"
+        f"        // tiled panels are auto-named; reference them in anchor_region/tail_to_region:\n"
+        f'        //   grid->"p{{row}}_{{col}}" (0-based); three_tiers->t0,t1,t2;\n'
+        f"        //   splash_with_strip->splash,s0,s1; diagonal_action->d0,d1; feature_L->hero,side\n"
         f'    "regions": [ {{ "id": string, "kind": "image"|"text",\n'
         f'        "shape": "rect"|"polygon"|"path",\n'
         f'        "bbox": [x,y,w,h], "points": [[x,y],...] (polygon only),\n'

--- a/core/layout/geometry.py
+++ b/core/layout/geometry.py
@@ -1,0 +1,50 @@
+"""Pure geometry helpers for path-based regions (no Qt dependency)."""
+from __future__ import annotations
+
+import math
+from typing import List, Tuple
+
+from core.layout.models import PathSegment
+
+_EXPECTED_PTS = {"move": 1, "line": 1, "quad": 2, "cubic": 3, "close": 0}
+
+
+def validate_segments(segments: List[PathSegment]) -> List[str]:
+    """Return a list of problem descriptions; empty list means valid."""
+    if not segments:
+        return ["empty segment list"]
+    issues: List[str] = []
+    if segments[0].type != "move":
+        issues.append("path must start with a 'move' segment")
+    for i, seg in enumerate(segments):
+        expected = _EXPECTED_PTS.get(seg.type)
+        if expected is None:
+            issues.append(f"segment {i}: unknown type {seg.type!r}")
+            continue
+        if len(seg.pts) != expected:
+            issues.append(
+                f"segment {i}: {seg.type} expects {expected} point(s), got {len(seg.pts)}"
+            )
+        for (px, py) in seg.pts:
+            if not (math.isfinite(px) and math.isfinite(py)):
+                issues.append(f"segment {i}: non-finite coordinate")
+                break
+    return issues
+
+
+def segments_bbox(segments: List[PathSegment]) -> Tuple[float, float, float, float]:
+    """Bounding box (x, y, w, h) of all segment points.
+
+    For curves this uses the control points, i.e. a safe superset of the visual
+    extent. bbox is positioning-only, never used for clipping, so the superset is
+    acceptable.
+    """
+    xs: List[float] = []
+    ys: List[float] = []
+    for seg in segments:
+        for (px, py) in seg.pts:
+            xs.append(px)
+            ys.append(py)
+    if not xs:
+        return (0.0, 0.0, 0.0, 0.0)
+    return (min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys))

--- a/core/layout/geometry.py
+++ b/core/layout/geometry.py
@@ -48,3 +48,16 @@ def segments_bbox(segments: List[PathSegment]) -> Tuple[float, float, float, flo
     if not xs:
         return (0.0, 0.0, 0.0, 0.0)
     return (min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys))
+
+
+def translate_segments(segments: List[PathSegment], dx: float, dy: float) -> List[PathSegment]:
+    """Return NEW PathSegments with every point offset by (dx, dy).
+
+    Pure/Qt-free. The manual editor uses this to persist a whole-panel translate
+    drag into a path region's ``segments`` (the write-back gap deferred from #5)
+    and as the offset primitive for geometry edits. The input is never mutated.
+    """
+    return [
+        PathSegment(type=seg.type, pts=[(px + dx, py + dy) for (px, py) in seg.pts])
+        for seg in segments
+    ]

--- a/core/layout/models.py
+++ b/core/layout/models.py
@@ -157,6 +157,7 @@ class Overlay:
     role: str = ""
     text_style: Optional[TextStyle] = None
     style: OverlayStyle = field(default_factory=OverlayStyle)
+    rotation: float = 0.0  # degrees clockwise about the anchor (SFX & balloons)
 
 
 @dataclass

--- a/core/layout/models.py
+++ b/core/layout/models.py
@@ -104,7 +104,7 @@ class PathSegment:
 
 @dataclass
 class Region:
-    """A selectable layout region (rect or polygon), image or text."""
+    """A selectable layout region (rect, polygon, or path), image or text."""
 
     id: str
     kind: Literal["image", "text"]

--- a/core/layout/models.py
+++ b/core/layout/models.py
@@ -91,14 +91,28 @@ class ImageBlock(BlockBase):
 
 
 @dataclass
+class PathSegment:
+    """One command of a region's vector outline (page-pixel coords).
+
+    Point counts by type: move=1, line=1, quad=2 (control, end),
+    cubic=3 (c1, c2, end), close=0. A valid path starts with a 'move'.
+    """
+
+    type: Literal["move", "line", "quad", "cubic", "close"]
+    pts: List[Tuple[float, float]] = field(default_factory=list)
+
+
+@dataclass
 class Region:
     """A selectable layout region (rect or polygon), image or text."""
 
     id: str
     kind: Literal["image", "text"]
-    shape: Literal["rect", "polygon"] = "rect"
+    shape: Literal["rect", "polygon", "path"] = "rect"
     bbox: Rect = (0, 0, 100, 100)
     points: List[Tuple[int, int]] = field(default_factory=list)  # polygon vertices, page px
+    segments: List["PathSegment"] = field(default_factory=list)  # used when shape == "path"
+    bleed: bool = False
     z: int = 0
     name: str = ""
     # content (text)

--- a/core/layout/models.py
+++ b/core/layout/models.py
@@ -52,6 +52,17 @@ class TextStyle:
 
 
 @dataclass
+class OverlayStyle:
+    """Visual style for a comic text overlay's body (balloon/caption shell)."""
+    fill: str = "#FFFFFF"
+    stroke_px: float = 2.0
+    stroke_color: str = "#000000"
+    padding_px: float = 10.0        # inset between the text box and the body edge
+    radius_px: float = 16.0         # corner roundness (speech) / scallop radius (thought)
+    max_width_px: float = 240.0     # wrap-width cap used by the renderer's auto-fit
+
+
+@dataclass
 class ImageStyle:
     """Style configuration for image blocks."""
 
@@ -128,6 +139,27 @@ class Region:
 
 
 @dataclass
+class Overlay:
+    """A declarative comic text overlay (speech/thought/caption/sfx).
+
+    Qt-free and serializable. The renderer measures the wrapped text to size the
+    body; balloons.py builds the body/tail geometry. `anchor` places the body
+    (center or top-left per `anchor_mode`); `tail_target` is a free page-pixel
+    point the tail points at (None = no tail).
+    """
+    id: str
+    kind: Literal["speech", "thought", "caption", "sfx"]
+    text: str
+    anchor: Tuple[float, float]
+    anchor_mode: Literal["center", "topleft"] = "center"
+    tail_target: Optional[Tuple[float, float]] = None
+    z: int = 0
+    role: str = ""
+    text_style: Optional[TextStyle] = None
+    style: OverlayStyle = field(default_factory=OverlayStyle)
+
+
+@dataclass
 class Snapshot:
     """One iteration of the layout designer (browsable in history)."""
 
@@ -160,6 +192,7 @@ class PageSpec:
     variables: Dict[str, str] = field(default_factory=dict)  # Template variables
     page_size: Optional[PageSize] = None
     regions: List[Region] = field(default_factory=list)
+    overlays: List[Overlay] = field(default_factory=list)
 
 
 @dataclass

--- a/core/layout/overlay_ops.py
+++ b/core/layout/overlay_ops.py
@@ -1,0 +1,70 @@
+"""Pure (Qt-free) overlay operations: stranded-anchor detection + reposition.
+
+When a regions-only redesign replaces the panels, pixel-anchored overlays can be
+left floating over empty space. These helpers detect that (anchor outside every
+region's bbox) and move the anchor onto the nearest region's bbox center.
+Deterministic; never mutates input regions.
+"""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Tuple
+
+from core.layout.models import Overlay, Region, PageSpec
+
+logger = logging.getLogger(__name__)
+
+Point = Tuple[float, float]
+
+
+def _bbox_contains(bbox, x: float, y: float) -> bool:
+    bx, by, bw, bh = bbox
+    return bx <= x <= bx + bw and by <= y <= by + bh
+
+
+def _bbox_center(bbox) -> Point:
+    bx, by, bw, bh = bbox
+    return (bx + bw / 2.0, by + bh / 2.0)
+
+
+def overlay_anchor_stranded(ov: Overlay, regions: List[Region]) -> bool:
+    """True if the overlay's anchor lies outside every region's bbox."""
+    ax, ay = ov.anchor
+    return not any(_bbox_contains(r.bbox, ax, ay) for r in regions)
+
+
+def nearest_region_center(point: Point, regions: List[Region]) -> Optional[Point]:
+    """bbox center of the region whose center is nearest ``point`` (None if empty)."""
+    if not regions:
+        return None
+    px, py = point
+    best = None
+    best_d2 = None
+    for r in regions:
+        cx, cy = _bbox_center(r.bbox)
+        d2 = (cx - px) ** 2 + (cy - py) ** 2
+        if best_d2 is None or d2 <= best_d2:
+            best_d2 = d2
+            best = (cx, cy)
+    return best
+
+
+def reposition_stranded_overlays(page: PageSpec) -> int:
+    """Move every stranded overlay's anchor to the nearest region center.
+
+    Returns the number of overlays moved. No-op (0) when the page has no regions
+    or no overlays. Logs a summary when it moves any.
+    """
+    regions = list(page.regions)
+    if not regions or not page.overlays:
+        return 0
+    moved = 0
+    for ov in page.overlays:
+        if overlay_anchor_stranded(ov, regions):
+            target = nearest_region_center(ov.anchor, regions)
+            if target is not None:
+                ov.anchor = target
+                moved += 1
+    if moved:
+        logger.info("repositioned %d stranded overlay(s) onto nearest panels", moved)
+    return moved

--- a/core/layout/polygon.py
+++ b/core/layout/polygon.py
@@ -1,0 +1,88 @@
+"""Pure straight-edge polygon math for the tiling engine (no Qt).
+
+Polygons are open rings: a list of (x, y) points with no repeated closing
+vertex. "Positive signed area" is the canonical orientation; in screen
+coordinates (y down) the interior then lies to the LEFT of each directed edge,
+so the inward normal of edge direction (dx, dy) is (-dy, dx).
+"""
+from __future__ import annotations
+
+import logging
+import math
+from typing import List, Optional, Tuple
+
+from core.layout.models import PathSegment
+
+logger = logging.getLogger(__name__)
+
+Point = Tuple[float, float]
+Poly = List[Point]
+
+EPS = 1e-9
+
+
+def signed_area(poly: Poly) -> float:
+    n = len(poly)
+    s = 0.0
+    for i in range(n):
+        x1, y1 = poly[i]
+        x2, y2 = poly[(i + 1) % n]
+        s += x1 * y2 - x2 * y1
+    return s / 2.0
+
+
+def ensure_orientation(poly: Poly) -> Poly:
+    """Return a copy oriented to positive signed area (canonical)."""
+    return list(reversed(poly)) if signed_area(poly) < 0 else list(poly)
+
+
+def _cross(o: Point, a: Point, b: Point) -> float:
+    """Cross product (a-o) x (b-o); >0 means b is left of ray o->a's... use as side test."""
+    return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+
+
+def _side(p: Point, a: Point, b: Point) -> float:
+    """>0 if p is left of directed line a->b, <0 right, ~0 on the line."""
+    return (b[0] - a[0]) * (p[1] - a[1]) - (b[1] - a[1]) * (p[0] - a[0])
+
+
+def clip_halfplane(poly: Poly, a: Point, b: Point) -> Poly:
+    """Sutherland-Hodgman clip: keep the part of poly on the LEFT of line a->b."""
+    if not poly:
+        return []
+    out: Poly = []
+    n = len(poly)
+    for i in range(n):
+        cur = poly[i]
+        nxt = poly[(i + 1) % n]
+        s_cur = _side(cur, a, b)
+        s_nxt = _side(nxt, a, b)
+        cur_in = s_cur >= -EPS
+        nxt_in = s_nxt >= -EPS
+        if cur_in:
+            out.append(cur)
+        if cur_in != nxt_in:
+            denom = (s_cur - s_nxt)
+            if abs(denom) > EPS:
+                t = s_cur / denom
+                out.append((cur[0] + t * (nxt[0] - cur[0]),
+                            cur[1] + t * (nxt[1] - cur[1])))
+    # drop consecutive duplicates introduced by clipping
+    cleaned: Poly = []
+    for p in out:
+        if not cleaned or abs(p[0] - cleaned[-1][0]) > EPS or abs(p[1] - cleaned[-1][1]) > EPS:
+            cleaned.append(p)
+    if len(cleaned) >= 2 and abs(cleaned[0][0] - cleaned[-1][0]) <= EPS and abs(cleaned[0][1] - cleaned[-1][1]) <= EPS:
+        cleaned.pop()
+    return cleaned
+
+
+def polygon_to_segments(poly: Poly) -> List[PathSegment]:
+    """Convert an open-ring polygon to move/line.../close PathSegments."""
+    if not poly:
+        return []
+    segs = [PathSegment(type="move", pts=[(float(poly[0][0]), float(poly[0][1]))])]
+    for p in poly[1:]:
+        segs.append(PathSegment(type="line", pts=[(float(p[0]), float(p[1]))]))
+    segs.append(PathSegment(type="close", pts=[]))
+    return segs

--- a/core/layout/polygon.py
+++ b/core/layout/polygon.py
@@ -36,11 +36,6 @@ def ensure_orientation(poly: Poly) -> Poly:
     return list(reversed(poly)) if signed_area(poly) < 0 else list(poly)
 
 
-def _cross(o: Point, a: Point, b: Point) -> float:
-    """Cross product (a-o) x (b-o); >0 means b is left of ray o->a's... use as side test."""
-    return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
-
-
 def _side(p: Point, a: Point, b: Point) -> float:
     """>0 if p is left of directed line a->b, <0 right, ~0 on the line."""
     return (b[0] - a[0]) * (p[1] - a[1]) - (b[1] - a[1]) * (p[0] - a[0])

--- a/core/layout/polygon.py
+++ b/core/layout/polygon.py
@@ -146,3 +146,150 @@ def inset_polygon(poly: Poly, dists: List[float], *, miter_limit: float = 4.0) -
     if len(out) < 3 or signed_area(out) <= EPS:
         return None
     return out
+
+
+def _q(p: Point) -> Point:
+    return (round(p[0], 3), round(p[1], 3))
+
+
+def _colinear_between(a: Point, b: Point, p: Point) -> bool:
+    """True if p is colinear with a-b and strictly between a and b."""
+    cross = (b[0] - a[0]) * (p[1] - a[1]) - (b[1] - a[1]) * (p[0] - a[0])
+    if abs(cross) > 1e-6:
+        return False
+    dot = (p[0] - a[0]) * (b[0] - a[0]) + (p[1] - a[1]) * (b[1] - a[1])
+    if dot <= EPS:
+        return False
+    l2 = (b[0] - a[0]) ** 2 + (b[1] - a[1]) ** 2
+    return dot < l2 - EPS
+
+
+def _subdivide(edges: List[Tuple[Point, Point]]) -> List[Tuple[Point, Point]]:
+    """Split each edge at any other edge's endpoint that lies on it (colinear)."""
+    pts: set = set()
+    for a, b in edges:
+        pts.add(a)
+        pts.add(b)
+    out: List[Tuple[Point, Point]] = []
+    for a, b in edges:
+        cuts = [p for p in pts if _colinear_between(a, b, p)]
+        cuts.sort(key=lambda p: (p[0] - a[0]) ** 2 + (p[1] - a[1]) ** 2)
+        chain = [a] + cuts + [b]
+        for i in range(len(chain) - 1):
+            out.append((chain[i], chain[i + 1]))
+    return out
+
+
+def _remove_colinear(ring: Poly) -> Poly:
+    """Remove vertices that lie exactly on the segment between their neighbors."""
+    if len(ring) < 3:
+        return ring
+    result = list(ring)
+    changed = True
+    while changed:
+        changed = False
+        n = len(result)
+        if n < 3:
+            break
+        keep = []
+        for i in range(n):
+            prev_pt = result[(i - 1) % n]
+            cur_pt = result[i]
+            next_pt = result[(i + 1) % n]
+            cross = ((cur_pt[0] - prev_pt[0]) * (next_pt[1] - prev_pt[1])
+                     - (cur_pt[1] - prev_pt[1]) * (next_pt[0] - prev_pt[0]))
+            if abs(cross) > 1e-9:
+                keep.append(cur_pt)
+            else:
+                changed = True
+        result = keep
+    return result
+
+
+def union_polygons(polys: List[Poly]) -> List[Poly]:
+    """Union edge-sharing polygons via directed-edge cancellation.
+
+    Returns one positively-oriented ring per connected component. Vertices are
+    quantized to 3 decimals so shared edges match exactly. Only valid for
+    exact-partition, edge-sharing inputs (as produced by the tiler) — not a
+    general boolean-union library.
+    """
+    from collections import Counter, defaultdict
+
+    # Build directed edge list with quantized vertices
+    edges: List[Tuple[Point, Point]] = []
+    for poly in polys:
+        ring = [_q(p) for p in ensure_orientation(poly)]
+        n = len(ring)
+        for i in range(n):
+            edges.append((ring[i], ring[(i + 1) % n]))
+
+    # Subdivide edges at colinear partial-overlap points
+    edges = _subdivide(edges)
+
+    # Cancel exact opposite pairs — interior shared edges cancel out
+    counts: Counter = Counter(edges)
+    survivors: List[Tuple[Point, Point]] = []
+    for e, cnt in counts.items():
+        a, b = e
+        opp = (b, a)
+        net = cnt - counts.get(opp, 0)
+        for _ in range(max(0, net)):
+            survivors.append(e)
+
+    if not survivors:
+        logger.warning("union_polygons: no survivor edges after cancellation")
+        return []
+
+    # Build adjacency: start_vertex -> list of edge indices
+    starts: dict = defaultdict(list)
+    for idx, e in enumerate(survivors):
+        starts[e[0]].append(idx)
+
+    # Chain survivors into closed rings using index-based tracking
+    # (id()-based tracking is unreliable: Python may reuse tuple object ids)
+    rings: List[Poly] = []
+    used: set = set()  # set of survivor indices already consumed
+
+    for start_idx, e0 in enumerate(survivors):
+        if start_idx in used:
+            continue
+
+        ring: Poly = []
+        cur_idx = start_idx
+        guard = 0
+
+        while True:
+            guard += 1
+            if guard > len(survivors) + 5:
+                logger.warning("union_polygons: ring-chaining guard triggered; breaking")
+                break
+
+            used.add(cur_idx)
+            cur = survivors[cur_idx]
+            ring.append(cur[0])
+
+            # Find the next unused edge whose start == cur's end
+            next_vertex = cur[1]
+            candidates = [i for i in starts[next_vertex] if i not in used]
+
+            if not candidates:
+                break
+
+            # Pick the next edge; if it closes back to ring[0] we're done
+            next_idx = candidates[0]
+            next_edge = survivors[next_idx]
+
+            if next_edge[0] == e0[0]:
+                # Ring would close here — mark it used and stop
+                used.add(next_idx)
+                break
+
+            cur_idx = next_idx
+
+        if len(ring) >= 3:
+            ring = _remove_colinear(ring)
+            if len(ring) >= 3:
+                rings.append(ensure_orientation(ring))
+
+    return rings

--- a/core/layout/polygon.py
+++ b/core/layout/polygon.py
@@ -111,14 +111,6 @@ def inset_polygon(poly: Poly, dists: List[float], *, miter_limit: float = 4.0) -
     n = len(poly)
     if n < 3 or len(dists) != n:
         return None
-    # check if any inset distance is too large (would cause over-inset / collapse)
-    min_edge_length = float('inf')
-    for i in range(n):
-        p, q = poly[i], poly[(i + 1) % n]
-        dist = math.hypot(q[0] - p[0], q[1] - p[1])
-        min_edge_length = min(min_edge_length, dist)
-    if min_edge_length > EPS and max(dists) >= min_edge_length / 2:
-        return None
     # offset line per edge: a point on it + its direction
     off_pt: List[Point] = []
     off_dir: List[Point] = []
@@ -142,6 +134,14 @@ def inset_polygon(poly: Poly, dists: List[float], *, miter_limit: float = 4.0) -
             if math.hypot(pt[0] - ox, pt[1] - oy) > miter_limit * (max(dists) + EPS):
                 pt = off_pt[i]
         out.append(pt)
+    # over-inset detection: if an edge flipped direction the cell collapsed
+    for i in range(n):
+        o0, o1 = poly[i], poly[(i + 1) % n]
+        n0, n1 = out[i], out[(i + 1) % n]
+        odx, ody = o1[0] - o0[0], o1[1] - o0[1]
+        ndx, ndy = n1[0] - n0[0], n1[1] - n0[1]
+        if odx * ndx + ody * ndy < 0:  # edge direction reversed
+            return None
     # collapse guards
     if len(out) < 3 or signed_area(out) <= EPS:
         return None

--- a/core/layout/polygon.py
+++ b/core/layout/polygon.py
@@ -81,3 +81,68 @@ def polygon_to_segments(poly: Poly) -> List[PathSegment]:
         segs.append(PathSegment(type="line", pts=[(float(p[0]), float(p[1]))]))
     segs.append(PathSegment(type="close", pts=[]))
     return segs
+
+
+def _unit(dx: float, dy: float) -> Tuple[float, float]:
+    h = math.hypot(dx, dy)
+    if h <= EPS:
+        return (0.0, 0.0)
+    return (dx / h, dy / h)
+
+
+def _line_intersect(p1: Point, d1: Point, p2: Point, d2: Point) -> Optional[Point]:
+    """Intersect line p1+t*d1 with p2+u*d2. None if (near-)parallel."""
+    denom = d1[0] * d2[1] - d1[1] * d2[0]
+    if abs(denom) <= EPS:
+        return None
+    t = ((p2[0] - p1[0]) * d2[1] - (p2[1] - p1[1]) * d2[0]) / denom
+    return (p1[0] + t * d1[0], p1[1] + t * d1[1])
+
+
+def inset_polygon(poly: Poly, dists: List[float], *, miter_limit: float = 4.0) -> Optional[Poly]:
+    """Offset each edge inward by dists[i]; return inset polygon or None on collapse.
+
+    Edge i runs poly[i] -> poly[i+1]. Inward normal (positive orientation,
+    screen coords) is (-dy, dx). New vertex i is the intersection of the offset
+    lines of edge i-1 and edge i (miter join); a near-parallel pair falls back to
+    the offset point (bevel-equivalent). Returns None if the result is degenerate.
+    """
+    poly = ensure_orientation(poly)
+    n = len(poly)
+    if n < 3 or len(dists) != n:
+        return None
+    # check if any inset distance is too large (would cause over-inset / collapse)
+    min_edge_length = float('inf')
+    for i in range(n):
+        p, q = poly[i], poly[(i + 1) % n]
+        dist = math.hypot(q[0] - p[0], q[1] - p[1])
+        min_edge_length = min(min_edge_length, dist)
+    if min_edge_length > EPS and max(dists) >= min_edge_length / 2:
+        return None
+    # offset line per edge: a point on it + its direction
+    off_pt: List[Point] = []
+    off_dir: List[Point] = []
+    for i in range(n):
+        p, q = poly[i], poly[(i + 1) % n]
+        dx, dy = q[0] - p[0], q[1] - p[1]
+        ux, uy = _unit(dx, dy)
+        nx, ny = -uy, ux  # inward normal for positive-area poly in screen coords
+        d = dists[i]
+        off_pt.append((p[0] + nx * d, p[1] + ny * d))
+        off_dir.append((dx, dy))
+    out: Poly = []
+    for i in range(n):
+        prev = (i - 1) % n
+        pt = _line_intersect(off_pt[prev], off_dir[prev], off_pt[i], off_dir[i])
+        if pt is None:
+            pt = off_pt[i]  # parallel consecutive edges -> use offset point
+        else:
+            # crude miter clamp: if the join shot far from the original vertex, bevel to offset point
+            ox, oy = poly[i]
+            if math.hypot(pt[0] - ox, pt[1] - oy) > miter_limit * (max(dists) + EPS):
+                pt = off_pt[i]
+        out.append(pt)
+    # collapse guards
+    if len(out) < 3 or signed_area(out) <= EPS:
+        return None
+    return out

--- a/core/layout/polygon.py
+++ b/core/layout/polygon.py
@@ -170,6 +170,8 @@ def _colinear_between(a: Point, b: Point, p: Point) -> bool:
 
 def _subdivide(edges: List[Tuple[Point, Point]]) -> List[Tuple[Point, Point]]:
     """Split each edge at any other edge's endpoint that lies on it (colinear)."""
+    # O(E^2): every edge is tested against every endpoint. Fine for tiling-scale
+    # inputs (E is a handful of panel edges); revisit if ever run on large meshes.
     pts: set = set()
     for a, b in edges:
         pts.add(a)
@@ -280,7 +282,16 @@ def union_polygons(polys: List[Poly]) -> List[Poly]:
             if not candidates:
                 break
 
-            # Pick the next edge; if it closes back to ring[0] we're done
+            # Pick the next edge; if it closes back to ring[0] we're done.
+            # candidates[0] is arbitrary when a vertex is touched by >1 surviving
+            # outgoing edge (a junction shared by 3+ cells). Safe for the only
+            # supported case — exact edge-sharing partition inputs — but log it so a
+            # mis-chained concave merge is diagnosable rather than silent.
+            if len(candidates) > 1:
+                logger.warning(
+                    "union_polygons: %d candidate edges at vertex %s; picking first "
+                    "(valid only for edge-sharing partition inputs)",
+                    len(candidates), next_vertex)
             next_idx = candidates[0]
             next_edge = survivors[next_idx]
 

--- a/core/layout/polygon.py
+++ b/core/layout/polygon.py
@@ -155,6 +155,10 @@ def _q(p: Point) -> Point:
 def _colinear_between(a: Point, b: Point, p: Point) -> bool:
     """True if p is colinear with a-b and strictly between a and b."""
     cross = (b[0] - a[0]) * (p[1] - a[1]) - (b[1] - a[1]) * (p[0] - a[0])
+    # 1e-6 (looser than module EPS) is intentional: union_polygons quantizes
+    # all vertices to 3 decimals first, so colinear points land exactly on the
+    # line and this generous threshold never mis-classifies. Do NOT feed raw
+    # (un-quantized) floats here — the tolerance assumes quantized input.
     if abs(cross) > 1e-6:
         return False
     dot = (p[0] - a[0]) * (b[0] - a[0]) + (p[1] - a[1]) * (b[1] - a[1])

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -5,12 +5,17 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtGui import (
     QColor, QBrush, QPen, QPolygonF, QImage, QPainter, QFont, QPixmap,
-    QPdfWriter, QPageSize, QPageLayout,
+    QPdfWriter, QPageSize, QPageLayout, QPainterPath,
 )
 from PySide6.QtCore import QPointF, QRectF, Qt, QSizeF, QMarginsF
 
+import logging
+
 from core.layout.models import PageSpec, Region, DocumentSpec
 from core.layout.styles import effective_text_style
+from core.layout.geometry import validate_segments
+
+logger = logging.getLogger(__name__)
 
 _PLACEHOLDER_FILL = QColor("#E9ECEF")
 _PLACEHOLDER_PEN = QColor("#ADB5BD")
@@ -34,6 +39,43 @@ def _resolve_bg(page: PageSpec) -> str:
     if page.background and page.background.startswith("#"):
         return page.background
     return "#FFFFFF"
+
+
+def region_to_painter_path(r: Region) -> QPainterPath:
+    """Build a QPainterPath for a region (rect | polygon | path).
+
+    Invalid path segments are logged and the region falls back to its bbox
+    rectangle, so a region never renders as nothing.
+    """
+    path = QPainterPath()
+    if r.shape == "path" and r.segments:
+        issues = validate_segments(r.segments)
+        if issues:
+            logger.error("Region %s has invalid path segments; falling back to bbox: %s",
+                         r.id, "; ".join(issues))
+        else:
+            for seg in r.segments:
+                if seg.type == "move":
+                    path.moveTo(*seg.pts[0])
+                elif seg.type == "line":
+                    path.lineTo(*seg.pts[0])
+                elif seg.type == "quad":
+                    (cx, cy), (ex, ey) = seg.pts
+                    path.quadTo(cx, cy, ex, ey)
+                elif seg.type == "cubic":
+                    (c1x, c1y), (c2x, c2y), (ex, ey) = seg.pts
+                    path.cubicTo(c1x, c1y, c2x, c2y, ex, ey)
+                elif seg.type == "close":
+                    path.closeSubpath()
+            if not path.isEmpty():
+                return path
+    elif r.shape == "polygon" and r.points:
+        path.addPolygon(QPolygonF([QPointF(px, py) for px, py in r.points]))
+        path.closeSubpath()
+        return path
+    x, y, w, h = r.bbox
+    path.addRect(QRectF(x, y, w, h))
+    return path
 
 
 def _apply_flags(item: QGraphicsItem, selectable: bool, region_id: str,

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -202,18 +202,29 @@ def _add_image_region(scene: QGraphicsScene, r: Region, selectable: bool,
 def _add_text_region(scene: QGraphicsScene, r: Region, selectable: bool, project_style=None,
                      *, locked: bool = True) -> None:
     x, y, w, h = r.bbox
-    # The dashed guide box is an editor-only affordance (it's also the region's
-    # selectable/movable handle). Export paths call build_scene(selectable=False),
-    # so skipping it there keeps the guides out of the rendered PNG/PDF.
+
+    # Editor-only dashed guide box doubles as the region's selectable/movable
+    # handle; export paths (selectable=False) omit it.
     box = None
     if selectable:
         box = _RegionRectItem(QRectF(x, y, w, h), r)
         box.setBrush(QBrush(Qt.transparent))
         pen = QPen(_TEXT_GUIDE_PEN, 1.5, Qt.DashLine)
-        pen.setCosmetic(True)  # constant on-screen width at any zoom -> always visible
+        pen.setCosmetic(True)
         box.setPen(pen)
         _apply_flags(box, selectable, r.id, movable=(selectable and not locked))
         scene.addItem(box)
+
+    # Clip item: text is parented here so it cannot spill past the panel shape.
+    # When a guide box exists, the clip rides under it so a drag moves both.
+    clip = _RegionPathItem(region_to_painter_path(r), r)
+    clip.setPen(QPen(Qt.NoPen))
+    clip.setBrush(QBrush(Qt.transparent))
+    clip.setFlag(QGraphicsItem.ItemClipsChildrenToShape, True)
+    if box is not None:
+        clip.setParentItem(box)
+    else:
+        scene.addItem(clip)
 
     text = QGraphicsSimpleTextItem(r.text or "")
     ts = effective_text_style(r, project_style)
@@ -224,17 +235,9 @@ def _add_text_region(scene: QGraphicsScene, r: Region, selectable: bool, project
         font.setBold(ts.weight in ("bold", "black", "semibold"))
         font.setItalic(ts.italic)
         text.setBrush(QBrush(QColor(ts.color)))
-    # Always pin a pixel size: an unresolved role/style would otherwise leave the
-    # QFont at its ~16px default, which is invisible on a 300-DPI page.
     font.setPixelSize(ts.size_px if ts and ts.size_px else _DEFAULT_TEXT_PX)
     text.setFont(font)
-    # In the editor the text is a child of the guide box so applied text stays
-    # locked to its frame and moves with it; on export there is no box, so the
-    # text is a top-level scene item.
-    if box is not None:
-        text.setParentItem(box)
-    else:
-        scene.addItem(text)
+    text.setParentItem(clip)
     text.setPos(x + 2, y + 2)
 
 

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -395,24 +395,26 @@ def build_scene(page: PageSpec, *, selectable: bool = False, style=None,
     return scene
 
 
-def render_page_to_image(page: PageSpec, *, style=None) -> QImage:
+def render_page_to_image(page: PageSpec, *, style=None, scale: float = 1.0) -> QImage:
     pw, ph = page.page_size_px
     b = max(0, int(getattr(page, "bleed_px", 0) or 0))
     cw, ch = pw + 2 * b, ph + 2 * b
-    img = QImage(cw, ch, QImage.Format_ARGB32)
+    sw, sh = max(1, round(cw * scale)), max(1, round(ch * scale))
+    img = QImage(sw, sh, QImage.Format_ARGB32)
     img.fill(QColor(_resolve_bg(page)))
     painter = QPainter(img)
     painter.setRenderHint(QPainter.Antialiasing, True)
     if b == 0:
         scene = build_scene(page, style=style)
-        scene.render(painter, QRectF(0, 0, pw, ph), QRectF(0, 0, pw, ph))
+        scene.render(painter, QRectF(0, 0, sw, sh), QRectF(0, 0, pw, ph))
         painter.end()
         return img
     # Non-bleed regions are clipped to the trim box, offset into the bleed canvas.
     painter.save()
-    painter.setClipRect(QRectF(b, b, pw, ph))
+    painter.setClipRect(QRectF(b * scale, b * scale, pw * scale, ph * scale))
     non_bleed = build_scene(page, style=style, region_filter=lambda r: not r.bleed)
-    non_bleed.render(painter, QRectF(b, b, pw, ph), QRectF(0, 0, pw, ph))
+    non_bleed.render(painter, QRectF(b * scale, b * scale, pw * scale, ph * scale),
+                     QRectF(0, 0, pw, ph))
     painter.restore()
     # Bleed regions may extend into the surrounding margin: map the full bleed box
     # in scene coords onto the whole canvas.  Use a transparent background so the
@@ -422,7 +424,7 @@ def render_page_to_image(page: PageSpec, *, style=None) -> QImage:
     bleed_scene = build_scene(page, style=style, region_filter=lambda r: r.bleed,
                               include_overlays=False)
     bleed_scene.setBackgroundBrush(Qt.transparent)
-    bleed_scene.render(painter, QRectF(0, 0, cw, ch), QRectF(-b, -b, cw, ch))
+    bleed_scene.render(painter, QRectF(0, 0, sw, sh), QRectF(-b, -b, cw, ch))
     painter.end()
     return img
 

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -299,9 +299,11 @@ def _add_overlay(scene: QGraphicsScene, ov, project_style, base_z: float) -> Non
     }.get(ov.kind, "dialogue")
     ts = effective_text_style(_overlay_as_styleable(ov, role), project_style)
 
-    # Build font from resolved text style
-    font = QFont(ts.family[0] if ts and ts.family else "DejaVu Sans",
-                 ts.size_px if ts and ts.size_px else 16)
+    # Build font from resolved text style — size via setPixelSize (PIXELS),
+    # matching _add_text_region so overlay and region text render at the same scale.
+    font = QFont()
+    font.setFamily(ts.family[0] if ts and ts.family else "DejaVu Sans")
+    font.setPixelSize(ts.size_px if ts and ts.size_px else 16)
     if ts and ts.italic:
         font.setItalic(True)
 
@@ -346,6 +348,8 @@ def _add_overlay(scene: QGraphicsScene, ov, project_style, base_z: float) -> Non
     if ts and ts.color:
         text_item.setDefaultTextColor(QColor(ts.color))
     text_item.setTextWidth(text_w)
+    # body item lives at scene origin (path holds page-space verts), so the
+    # text's parent-relative pos equals its scene pos.
     text_item.setPos(ix + pad, iy + pad)
     text_item.setZValue(z + 0.1)
     if body_item is None:  # sfx: no body, add text directly to scene

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -1,6 +1,6 @@
 """Native Qt renderer: PageSpec -> QGraphicsScene -> QImage/PNG (source of truth)."""
 from PySide6.QtWidgets import (
-    QGraphicsScene, QGraphicsRectItem, QGraphicsPolygonItem,
+    QGraphicsScene, QGraphicsRectItem,
     QGraphicsSimpleTextItem, QGraphicsItem, QGraphicsPixmapItem, QGraphicsPathItem,
 )
 from PySide6.QtGui import (
@@ -48,27 +48,30 @@ def region_to_painter_path(r: Region) -> QPainterPath:
     rectangle, so a region never renders as nothing.
     """
     path = QPainterPath()
-    if r.shape == "path" and r.segments:
-        issues = validate_segments(r.segments)
-        if issues:
-            logger.error("Region %s has invalid path segments; falling back to bbox: %s",
-                         r.id, "; ".join(issues))
+    if r.shape == "path":
+        if not r.segments:
+            logger.warning("Region %s has shape='path' but no segments; falling back to bbox", r.id)
         else:
-            for seg in r.segments:
-                if seg.type == "move":
-                    path.moveTo(*seg.pts[0])
-                elif seg.type == "line":
-                    path.lineTo(*seg.pts[0])
-                elif seg.type == "quad":
-                    (cx, cy), (ex, ey) = seg.pts
-                    path.quadTo(cx, cy, ex, ey)
-                elif seg.type == "cubic":
-                    (c1x, c1y), (c2x, c2y), (ex, ey) = seg.pts
-                    path.cubicTo(c1x, c1y, c2x, c2y, ex, ey)
-                elif seg.type == "close":
-                    path.closeSubpath()
-            if not path.isEmpty():
-                return path
+            issues = validate_segments(r.segments)
+            if issues:
+                logger.error("Region %s has invalid path segments; falling back to bbox: %s",
+                             r.id, "; ".join(issues))
+            else:
+                for seg in r.segments:
+                    if seg.type == "move":
+                        path.moveTo(*seg.pts[0])
+                    elif seg.type == "line":
+                        path.lineTo(*seg.pts[0])
+                    elif seg.type == "quad":
+                        (cx, cy), (ex, ey) = seg.pts
+                        path.quadTo(cx, cy, ex, ey)
+                    elif seg.type == "cubic":
+                        (c1x, c1y), (c2x, c2y), (ex, ey) = seg.pts
+                        path.cubicTo(c1x, c1y, c2x, c2y, ex, ey)
+                    elif seg.type == "close":
+                        path.closeSubpath()
+                if not path.isEmpty():
+                    return path
     elif r.shape == "polygon" and r.points:
         path.addPolygon(QPolygonF([QPointF(px, py) for px, py in r.points]))
         path.closeSubpath()
@@ -96,6 +99,11 @@ def _writeback_move(item) -> None:
     Handles all carry their geometry in item-local coordinates with the item at
     scene pos (0,0); a drag therefore shows up purely as ``item.pos()``, which is
     the delta to apply to the region's original geometry.
+
+    NOTE — shape="path" regions carry their geometry in ``segments``, not in
+    ``bbox``/``points``, so drag-writeback for path-shaped regions is deferred to
+    the manual-editor sub-project (#5). Image frames are currently movable=False,
+    so this is not a live bug — just a sharp edge to address in #5.
     """
     region = getattr(item, "_region", None)
     if region is None:
@@ -128,12 +136,6 @@ class _RegionMoveMixin:
 class _RegionRectItem(_RegionMoveMixin, QGraphicsRectItem):
     def __init__(self, rect: QRectF, region: Region):
         super().__init__(rect)
-        self._bind_region(region)
-
-
-class _RegionPolygonItem(_RegionMoveMixin, QGraphicsPolygonItem):
-    def __init__(self, polygon: QPolygonF, region: Region):
-        super().__init__(polygon)
         self._bind_region(region)
 
 

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -41,6 +41,29 @@ def _resolve_bg(page: PageSpec) -> str:
     return "#FFFFFF"
 
 
+def segments_to_painter_path(segments) -> QPainterPath:
+    """Convert a list of PathSegment objects into a QPainterPath.
+
+    Extracted from ``region_to_painter_path`` so overlays can reuse the same
+    move/line/quad/cubic/close switch without going through a Region wrapper.
+    """
+    path = QPainterPath()
+    for seg in segments:
+        if seg.type == "move":
+            path.moveTo(*seg.pts[0])
+        elif seg.type == "line":
+            path.lineTo(*seg.pts[0])
+        elif seg.type == "quad":
+            (cx, cy), (ex, ey) = seg.pts
+            path.quadTo(cx, cy, ex, ey)
+        elif seg.type == "cubic":
+            (c1x, c1y), (c2x, c2y), (ex, ey) = seg.pts
+            path.cubicTo(c1x, c1y, c2x, c2y, ex, ey)
+        elif seg.type == "close":
+            path.closeSubpath()
+    return path
+
+
 def region_to_painter_path(r: Region) -> QPainterPath:
     """Build a QPainterPath for a region (rect | polygon | path).
 
@@ -57,19 +80,7 @@ def region_to_painter_path(r: Region) -> QPainterPath:
                 logger.error("Region %s has invalid path segments; falling back to bbox: %s",
                              r.id, "; ".join(issues))
             else:
-                for seg in r.segments:
-                    if seg.type == "move":
-                        path.moveTo(*seg.pts[0])
-                    elif seg.type == "line":
-                        path.lineTo(*seg.pts[0])
-                    elif seg.type == "quad":
-                        (cx, cy), (ex, ey) = seg.pts
-                        path.quadTo(cx, cy, ex, ey)
-                    elif seg.type == "cubic":
-                        (c1x, c1y), (c2x, c2y), (ex, ey) = seg.pts
-                        path.cubicTo(c1x, c1y, c2x, c2y, ex, ey)
-                    elif seg.type == "close":
-                        path.closeSubpath()
+                path = segments_to_painter_path(r.segments)
                 if not path.isEmpty():
                     return path
     elif r.shape == "polygon" and r.points:
@@ -243,8 +254,107 @@ def _add_text_region(scene: QGraphicsScene, r: Region, selectable: bool, project
     text.setPos(x + 2, y + 2)
 
 
+class _OverlayPathItem(QGraphicsPathItem):
+    """A QGraphicsPathItem whose shape() returns the FILLED interior.
+
+    The default QGraphicsPathItem.shape() returns the pen-stroked outline, which
+    causes ItemClipsChildrenToShape to clip children (the text item) to a thin
+    ring — making text invisible. Overriding shape() to return self.path()
+    (the filled region) matches what _RegionPathItem does for region children.
+    """
+
+    def shape(self):
+        return self.path()
+
+
+class _OverlayStyleable:
+    """Minimal adapter exposing .text_style and .role for effective_text_style."""
+    __slots__ = ("text_style", "role")
+
+    def __init__(self, text_style, role):
+        self.text_style = text_style
+        self.role = role
+
+
+def _overlay_as_styleable(ov, role):
+    return _OverlayStyleable(ov.text_style, role)
+
+
+def _add_overlay(scene: QGraphicsScene, ov, project_style, base_z: float) -> None:
+    """Measure wrapped text, build balloon body+tail, add body and text to scene.
+
+    Resolution 2 applied: body is _OverlayPathItem (overrides shape() to filled
+    interior so text children are NOT clipped to a thin stroked ring).
+    SFX overlays have no body (overlay_to_segments returns []) — text added directly.
+    """
+    from PySide6.QtCore import Qt, QRectF
+    from PySide6.QtGui import QFont, QColor, QPen, QBrush, QFontMetricsF
+    from PySide6.QtWidgets import QGraphicsTextItem
+    from core.layout.balloons import overlay_to_segments
+
+    # Resolve role: explicit > kind-default > "dialogue"
+    role = ov.role or {
+        "speech": "dialogue", "thought": "dialogue",
+        "caption": "caption", "sfx": "sfx",
+    }.get(ov.kind, "dialogue")
+    ts = effective_text_style(_overlay_as_styleable(ov, role), project_style)
+
+    # Build font from resolved text style
+    font = QFont(ts.family[0] if ts and ts.family else "DejaVu Sans",
+                 ts.size_px if ts and ts.size_px else 16)
+    if ts and ts.italic:
+        font.setItalic(True)
+
+    # Measure wrapped text to size the body
+    fm = QFontMetricsF(font)
+    max_w = max(20.0, ov.style.max_width_px)
+    rect = fm.boundingRect(QRectF(0, 0, max_w, 100000),
+                           int(Qt.TextWordWrap), ov.text)
+    text_w, text_h = rect.width(), rect.height()
+    pad = ov.style.padding_px
+    inner_w = text_w + 2 * pad
+    inner_h = text_h + 2 * pad
+
+    # Anchor body: center or topleft
+    ax, ay = ov.anchor
+    if ov.anchor_mode == "center":
+        ix, iy = ax - inner_w / 2.0, ay - inner_h / 2.0
+    else:
+        ix, iy = ax, ay
+    inner = (ix, iy, inner_w, inner_h)
+
+    z = base_z + ov.z
+
+    # Build body geometry via balloons
+    segs = overlay_to_segments(ov.kind, inner, ov.tail_target, ov.style)
+    body_item = None
+    if segs:
+        path = segments_to_painter_path(segs)
+        body_item = _OverlayPathItem(path)
+        body_item.setBrush(QBrush(QColor(ov.style.fill)))
+        if ov.style.stroke_px > 0:
+            body_item.setPen(QPen(QColor(ov.style.stroke_color), ov.style.stroke_px))
+        else:
+            body_item.setPen(QPen(Qt.NoPen))
+        body_item.setZValue(z)
+        body_item.setFlag(QGraphicsPathItem.GraphicsItemFlag.ItemClipsChildrenToShape, True)
+        scene.addItem(body_item)
+
+    # Text item: child of body (clipped) or direct scene item (sfx, no body)
+    text_item = QGraphicsTextItem(ov.text, parent=body_item)
+    text_item.setFont(font)
+    if ts and ts.color:
+        text_item.setDefaultTextColor(QColor(ts.color))
+    text_item.setTextWidth(text_w)
+    text_item.setPos(ix + pad, iy + pad)
+    text_item.setZValue(z + 0.1)
+    if body_item is None:  # sfx: no body, add text directly to scene
+        scene.addItem(text_item)
+
+
 def build_scene(page: PageSpec, *, selectable: bool = False, style=None,
-                locked: bool = True, region_filter=None) -> QGraphicsScene:
+                locked: bool = True, region_filter=None,
+                include_overlays: bool = True) -> QGraphicsScene:
     pw, ph = page.page_size_px
     scene = QGraphicsScene(0, 0, pw, ph)
     scene.setBackgroundBrush(QBrush(QColor(_resolve_bg(page))))
@@ -254,6 +364,14 @@ def build_scene(page: PageSpec, *, selectable: bool = False, style=None,
             _add_image_region(scene, r, selectable, locked=locked)
         else:
             _add_text_region(scene, r, selectable, project_style=style, locked=locked)
+    # Overlay pass: render after all regions so overlays sit on top.
+    # Gated on include_overlays to avoid double-rendering in the bleed path
+    # (Resolution 1): overlays live in page/trim coords and render with the
+    # non-bleed scene only.
+    if include_overlays and page.overlays:
+        base_z = max((r.z for r in page.regions), default=0) + 1000
+        for ov in sorted(page.overlays, key=lambda o: o.z):
+            _add_overlay(scene, ov, style, base_z)
     return scene
 
 
@@ -279,7 +397,10 @@ def render_page_to_image(page: PageSpec, *, style=None) -> QImage:
     # Bleed regions may extend into the surrounding margin: map the full bleed box
     # in scene coords onto the whole canvas.  Use a transparent background so the
     # bleed scene does not paint over the already-rendered trim content.
-    bleed_scene = build_scene(page, style=style, region_filter=lambda r: r.bleed)
+    # include_overlays=False: overlays live in trim coords and were already rendered
+    # with the non-bleed scene above (Resolution 1 — avoids double-rendering).
+    bleed_scene = build_scene(page, style=style, region_filter=lambda r: r.bleed,
+                              include_overlays=False)
     bleed_scene.setBackgroundBrush(Qt.transparent)
     bleed_scene.render(painter, QRectF(0, 0, cw, ch), QRectF(-b, -b, cw, ch))
     painter.end()

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -358,6 +358,19 @@ def _add_overlay(scene: QGraphicsScene, ov, project_style, base_z: float) -> Non
     if body_item is None:  # sfx: no body, add text directly to scene
         scene.addItem(text_item)
 
+    # Rotation: spin the body (text rides along as its child) or, for SFX with no
+    # body, the text item — both about the overlay anchor (scene coords).
+    rot = getattr(ov, "rotation", 0.0) or 0.0
+    if rot:
+        from PySide6.QtCore import QPointF
+        if body_item is not None:
+            body_item.setTransformOriginPoint(QPointF(ax, ay))  # body sits at scene origin
+            body_item.setRotation(rot)
+        else:
+            text_item.setTransformOriginPoint(
+                QPointF(ax - text_item.x(), ay - text_item.y()))
+            text_item.setRotation(rot)
+
 
 def build_scene(page: PageSpec, *, selectable: bool = False, style=None,
                 locked: bool = True, region_filter=None,

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -367,6 +367,8 @@ def _add_overlay(scene: QGraphicsScene, ov, project_style, base_z: float) -> Non
             body_item.setTransformOriginPoint(QPointF(ax, ay))  # body sits at scene origin
             body_item.setRotation(rot)
         else:
+            # sfx text has a non-zero pos, so convert the scene anchor into the
+            # text item's local frame before using it as the rotation origin.
             text_item.setTransformOriginPoint(
                 QPointF(ax - text_item.x(), ay - text_item.y()))
             text_item.setRotation(rot)

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -1,7 +1,7 @@
 """Native Qt renderer: PageSpec -> QGraphicsScene -> QImage/PNG (source of truth)."""
 from PySide6.QtWidgets import (
     QGraphicsScene, QGraphicsRectItem, QGraphicsPolygonItem,
-    QGraphicsSimpleTextItem, QGraphicsItem, QGraphicsPixmapItem,
+    QGraphicsSimpleTextItem, QGraphicsItem, QGraphicsPixmapItem, QGraphicsPathItem,
 )
 from PySide6.QtGui import (
     QColor, QBrush, QPen, QPolygonF, QImage, QPainter, QFont, QPixmap,
@@ -143,44 +143,55 @@ class _RegionPixmapItem(_RegionMoveMixin, QGraphicsPixmapItem):
         self._bind_region(region)
 
 
+class _RegionPathItem(_RegionMoveMixin, QGraphicsPathItem):
+    def __init__(self, path: QPainterPath, region: Region):
+        super().__init__(path)
+        self._bind_region(region)
+
+    def shape(self):
+        # Clip children to the FILLED interior, not the stroked outline (the
+        # default QGraphicsPathItem.shape() would return just the pen outline).
+        return self.path()
+
+
 def _add_image_region(scene: QGraphicsScene, r: Region, selectable: bool,
                       *, locked: bool = True) -> None:
-    x, y, w, h = r.bbox
-    # Image frames are ALWAYS locked in position — only text follows the lock
-    # toggle (see _add_text_region). They stay selectable so the region can be
-    # picked to set/replace its image, just never draggable.
+    # Image frames are ALWAYS locked in position (only text follows the lock
+    # toggle); they stay selectable so the region can be picked.
     movable = False
+    istyle = r.image_style
+    stroke_px = istyle.stroke_px if istyle else 0
+    stroke_color = istyle.stroke_color if istyle else "#000000"
+    fit = istyle.fit if istyle else "cover"
+
+    path = region_to_painter_path(r)
+    frame = _RegionPathItem(path, r)
+    frame.setFlag(QGraphicsItem.ItemClipsChildrenToShape, True)
+    frame.setPen(QPen(QColor(stroke_color), stroke_px) if stroke_px > 0 else QPen(Qt.NoPen))
+
     pix = QPixmap(r.image_ref) if r.image_ref else None
     filled = pix is not None and not pix.isNull()
 
     if filled:
-        # The pixmap on top is the region's handle; the placeholder fill rides
-        # along as a child drawn behind it (negative z) so transparent PNGs read
-        # as a solid frame and the two never fight over the cursor on a drag.
-        scaled = pix.scaled(int(w), int(h), Qt.KeepAspectRatio, Qt.SmoothTransformation)
-        handle = _RegionPixmapItem(scaled, r)
-        handle.setOffset(x, y)
-        bg = QGraphicsRectItem(QRectF(x, y, w, h), handle)
-        bg.setBrush(QBrush(_PLACEHOLDER_FILL))
-        bg.setPen(QPen(_PLACEHOLDER_PEN, 1))
-        bg.setZValue(-1)
-        _apply_flags(handle, selectable, r.id, movable=movable)
-        scene.addItem(handle)
-        return
-
-    if r.shape == "polygon" and r.points:
-        poly = QPolygonF([QPointF(px, py) for px, py in r.points])
-        item = _RegionPolygonItem(poly, r)
+        frame.setBrush(QBrush(Qt.transparent))
+        x, y, w, h = r.bbox
+        mode = Qt.KeepAspectRatioByExpanding if fit == "cover" else Qt.KeepAspectRatio
+        scaled = pix.scaled(int(w), int(h), mode, Qt.SmoothTransformation)
+        child = _RegionPixmapItem(scaled, r)
+        # Center the scaled pixmap in the bbox; the parent shape clip crops the
+        # overflow (cover) or reveals panel bg in the letterbox (contain).
+        child.setOffset(x + (w - scaled.width()) / 2.0, y + (h - scaled.height()) / 2.0)
+        child.setParentItem(frame)
+        _apply_flags(child, selectable, r.id, movable=movable)
     else:
-        item = _RegionRectItem(QRectF(x, y, w, h), r)
-    item.setBrush(QBrush(_PLACEHOLDER_FILL))
-    item.setPen(QPen(_PLACEHOLDER_PEN, 1))
-    _apply_flags(item, selectable, r.id, movable=movable)
-    scene.addItem(item)
+        frame.setBrush(QBrush(_PLACEHOLDER_FILL))
+        lx, ly, _, _ = r.bbox
+        label = QGraphicsSimpleTextItem(r.name or "[image]", frame)
+        label.setPos(lx + 4, ly + 4)
+        label.setBrush(QBrush(QColor("#6C757D")))
 
-    label = QGraphicsSimpleTextItem(r.name or "[image]", item)  # child -> moves with frame
-    label.setPos(x + 4, y + 4)
-    label.setBrush(QBrush(QColor("#6C757D")))
+    _apply_flags(frame, selectable, r.id, movable=movable)
+    scene.addItem(frame)
 
 
 def _add_text_region(scene: QGraphicsScene, r: Region, selectable: bool, project_style=None,

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -242,11 +242,12 @@ def _add_text_region(scene: QGraphicsScene, r: Region, selectable: bool, project
 
 
 def build_scene(page: PageSpec, *, selectable: bool = False, style=None,
-                locked: bool = True) -> QGraphicsScene:
+                locked: bool = True, region_filter=None) -> QGraphicsScene:
     pw, ph = page.page_size_px
     scene = QGraphicsScene(0, 0, pw, ph)
     scene.setBackgroundBrush(QBrush(QColor(_resolve_bg(page))))
-    for r in sorted(page.regions, key=lambda rr: rr.z):
+    regions = page.regions if region_filter is None else [r for r in page.regions if region_filter(r)]
+    for r in sorted(regions, key=lambda rr: rr.z):
         if r.kind == "image":
             _add_image_region(scene, r, selectable, locked=locked)
         else:
@@ -256,12 +257,29 @@ def build_scene(page: PageSpec, *, selectable: bool = False, style=None,
 
 def render_page_to_image(page: PageSpec, *, style=None) -> QImage:
     pw, ph = page.page_size_px
-    scene = build_scene(page, style=style)
-    img = QImage(pw, ph, QImage.Format_ARGB32)
+    b = max(0, int(getattr(page, "bleed_px", 0) or 0))
+    cw, ch = pw + 2 * b, ph + 2 * b
+    img = QImage(cw, ch, QImage.Format_ARGB32)
     img.fill(QColor(_resolve_bg(page)))
     painter = QPainter(img)
     painter.setRenderHint(QPainter.Antialiasing, True)
-    scene.render(painter, QRectF(0, 0, pw, ph), QRectF(0, 0, pw, ph))
+    if b == 0:
+        scene = build_scene(page, style=style)
+        scene.render(painter, QRectF(0, 0, pw, ph), QRectF(0, 0, pw, ph))
+        painter.end()
+        return img
+    # Non-bleed regions are clipped to the trim box, offset into the bleed canvas.
+    painter.save()
+    painter.setClipRect(QRectF(b, b, pw, ph))
+    non_bleed = build_scene(page, style=style, region_filter=lambda r: not r.bleed)
+    non_bleed.render(painter, QRectF(b, b, pw, ph), QRectF(0, 0, pw, ph))
+    painter.restore()
+    # Bleed regions may extend into the surrounding margin: map the full bleed box
+    # in scene coords onto the whole canvas.  Use a transparent background so the
+    # bleed scene does not paint over the already-rendered trim content.
+    bleed_scene = build_scene(page, style=style, region_filter=lambda r: r.bleed)
+    bleed_scene.setBackgroundBrush(Qt.transparent)
+    bleed_scene.render(painter, QRectF(0, 0, cw, ch), QRectF(-b, -b, cw, ch))
     painter.end()
     return img
 

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -105,23 +105,25 @@ def _apply_flags(item: QGraphicsItem, selectable: bool, region_id: str,
 
 
 def _writeback_move(item) -> None:
-    """Persist a drag into the bound region's ``bbox`` (and polygon ``points``).
+    """Persist a drag into the bound region's geometry.
 
-    Handles all carry their geometry in item-local coordinates with the item at
-    scene pos (0,0); a drag therefore shows up purely as ``item.pos()``, which is
-    the delta to apply to the region's original geometry.
-
-    NOTE — shape="path" regions carry their geometry in ``segments``, not in
-    ``bbox``/``points``, so drag-writeback for path-shaped regions is deferred to
-    the manual-editor sub-project (#5). Image frames are currently movable=False,
-    so this is not a live bug — just a sharp edge to address in #5.
+    Handles carry their geometry in item-local coords with the item at scene
+    (0,0), so a drag shows up purely as ``item.pos()`` — the delta to apply to
+    the region's original geometry. For ``shape="path"`` regions the delta is
+    applied to ``segments`` (the geometry the renderer reads); rect/polygon
+    regions translate ``bbox`` and ``points``.
     """
     region = getattr(item, "_region", None)
     if region is None:
         return
     dx, dy = item.x(), item.y()
-    x, y, w, h = item._base_bbox
-    region.bbox = (round(x + dx), round(y + dy), w, h)
+    bx, by, bw, bh = item._base_bbox
+    if region.shape == "path" and getattr(item, "_base_segments", None):
+        from core.layout.geometry import translate_segments
+        region.segments = translate_segments(item._base_segments, dx, dy)
+        region.bbox = (round(bx + dx), round(by + dy), bw, bh)
+        return
+    region.bbox = (round(bx + dx), round(by + dy), bw, bh)
     if item._base_points:
         region.points = [(round(px + dx), round(py + dy)) for px, py in item._base_points]
 
@@ -137,6 +139,7 @@ class _RegionMoveMixin:
         self._region = region
         self._base_bbox = tuple(region.bbox)
         self._base_points = list(region.points)
+        self._base_segments = list(region.segments)
 
     def itemChange(self, change, value):
         if change == QGraphicsItem.ItemPositionHasChanged:

--- a/core/layout/qt_renderer.py
+++ b/core/layout/qt_renderer.py
@@ -185,6 +185,11 @@ def _add_image_region(scene: QGraphicsScene, r: Region, selectable: bool,
         _apply_flags(child, selectable, r.id, movable=movable)
     else:
         frame.setBrush(QBrush(_PLACEHOLDER_FILL))
+        if stroke_px == 0:
+            # Keep empty image placeholders outlined in the editor even when no
+            # comic-frame stroke is configured. A real stroke (stroke_px > 0) was
+            # already applied to the frame above, so only fill the gap for 0.
+            frame.setPen(QPen(_PLACEHOLDER_PEN, 1))
         lx, ly, _, _ = r.bbox
         label = QGraphicsSimpleTextItem(r.name or "[image]", frame)
         label.setPos(lx + 4, ly + 4)

--- a/core/layout/region_ops.py
+++ b/core/layout/region_ops.py
@@ -70,3 +70,25 @@ def _region_from_polygon(template: Region, poly: Poly, *, id: str) -> Region:
         text_style=template.text_style,
         image_style=template.image_style,
     )
+
+
+def split_region(region: Region, a: Point, b: Point) -> Optional[Tuple[Region, Region]]:
+    """Cut ``region`` by the line through a->b into two polygon regions.
+
+    Returns ``(left, right)`` — ``left`` is the half on the LEFT of a->b, ``right``
+    the other half (clip with the cut reversed). Returns None if the region is
+    curved/unsupported or the cut misses (either side has < 3 vertices). The input
+    region is never mutated. New ids are ``f"{region.id}_a"`` / ``f"{region.id}_b"``.
+    """
+    poly = region_to_polygon(region)
+    if poly is None:
+        return None
+    poly = ensure_orientation(poly)
+    left = clip_halfplane(poly, a, b)
+    right = clip_halfplane(poly, b, a)
+    if len(left) < 3 or len(right) < 3:
+        return None
+    return (
+        _region_from_polygon(region, left, id=f"{region.id}_a"),
+        _region_from_polygon(region, right, id=f"{region.id}_b"),
+    )

--- a/core/layout/region_ops.py
+++ b/core/layout/region_ops.py
@@ -1,0 +1,72 @@
+"""Pure (Qt-free) panel operations for the manual editor: split / merge / delete.
+
+A region is reduced to an open-ring polygon, transformed with
+``polygon.clip_halfplane`` / ``polygon.union_polygons``, and rebuilt as a
+``polygon`` Region. Curved path regions (quad/cubic) are unsupported and yield
+None so callers degrade gracefully — never crash, never corrupt the model.
+"""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Tuple
+
+from core.layout.models import Region
+from core.layout.polygon import (
+    Poly, Point, clip_halfplane, union_polygons, ensure_orientation, signed_area,
+)
+
+logger = logging.getLogger(__name__)
+
+Rect = Tuple[int, int, int, int]
+_AREA_EPS = 1.0  # sq-px tolerance for the merge area-conservation check
+
+
+def region_to_polygon(region: Region) -> Optional[Poly]:
+    """Open-ring polygon for a region, or None if unsupported/degenerate.
+
+    rect -> 4 bbox corners; polygon -> its points; path with only move/line/close
+    -> ordered anchor points; path with any quad/cubic -> None (curved).
+    """
+    if region.shape == "rect":
+        x, y, w, h = region.bbox
+        return [(float(x), float(y)), (float(x + w), float(y)),
+                (float(x + w), float(y + h)), (float(x), float(y + h))]
+    if region.shape == "polygon":
+        if len(region.points) < 3:
+            return None
+        return [(float(px), float(py)) for px, py in region.points]
+    if region.shape == "path":
+        poly: Poly = []
+        for seg in region.segments:
+            if seg.type in ("quad", "cubic"):
+                return None
+            if seg.type in ("move", "line"):
+                px, py = seg.pts[0]
+                poly.append((float(px), float(py)))
+            # close -> contributes no point
+        return poly if len(poly) >= 3 else None
+    return None
+
+
+def _poly_bbox(poly: Poly) -> Rect:
+    xs = [p[0] for p in poly]
+    ys = [p[1] for p in poly]
+    x0, y0 = min(xs), min(ys)
+    return (round(x0), round(y0), round(max(xs) - x0), round(max(ys) - y0))
+
+
+def _region_from_polygon(template: Region, poly: Poly, *, id: str) -> Region:
+    """Build a polygon Region from ``poly``, copying identity/style from template."""
+    return Region(
+        id=id,
+        kind=template.kind,
+        shape="polygon",
+        bbox=_poly_bbox(poly),
+        points=[(round(px), round(py)) for px, py in poly],
+        bleed=template.bleed,
+        z=template.z,
+        name=template.name,
+        role=template.role,
+        text_style=template.text_style,
+        image_style=template.image_style,
+    )

--- a/core/layout/region_ops.py
+++ b/core/layout/region_ops.py
@@ -92,3 +92,26 @@ def split_region(region: Region, a: Point, b: Point) -> Optional[Tuple[Region, R
         _region_from_polygon(region, left, id=f"{region.id}_a"),
         _region_from_polygon(region, right, id=f"{region.id}_b"),
     )
+
+
+def merge_regions(base: Region, other: Region) -> Optional[Region]:
+    """Union two adjacent regions into one polygon region (keeps base's identity).
+
+    Returns None if either region is curved/unsupported, or the two are not a clean
+    edge-merge: the union must yield exactly one ring whose area equals the sum of
+    the inputs' areas (no gap, no overlap). This makes the result independent of
+    ``union_polygons`` behavior on disjoint input. Inputs are never mutated.
+    """
+    p1 = region_to_polygon(base)
+    p2 = region_to_polygon(other)
+    if p1 is None or p2 is None:
+        return None
+    p1 = ensure_orientation(p1)
+    p2 = ensure_orientation(p2)
+    rings = union_polygons([p1, p2])
+    if len(rings) != 1 or len(rings[0]) < 3:
+        return None
+    merged = ensure_orientation(rings[0])
+    if abs(signed_area(merged) - (signed_area(p1) + signed_area(p2))) > _AREA_EPS:
+        return None  # gap or overlap -> not a clean adjacency merge
+    return _region_from_polygon(base, merged, id=base.id)

--- a/core/layout/region_ops.py
+++ b/core/layout/region_ops.py
@@ -7,15 +7,12 @@ None so callers degrade gracefully — never crash, never corrupt the model.
 """
 from __future__ import annotations
 
-import logging
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 from core.layout.models import Region
 from core.layout.polygon import (
     Poly, Point, clip_halfplane, union_polygons, ensure_orientation, signed_area,
 )
-
-logger = logging.getLogger(__name__)
 
 Rect = Tuple[int, int, int, int]
 _AREA_EPS = 1.0  # sq-px tolerance for the merge area-conservation check

--- a/core/layout/schema.py
+++ b/core/layout/schema.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Tuple
 from core.layout.models import (
     Region, PageSpec, DocumentSpec, PageSize, TextStyle, ImageStyle, Snapshot, ProjectStyle,
     migrate_legacy_blocks, TextBlock, ImageBlock, PathSegment,
+    Overlay, OverlayStyle,
 )
 
 
@@ -45,6 +46,27 @@ REGION_JSON_SCHEMA: Dict = {
 }
 
 
+OVERLAY_JSON_SCHEMA: Dict = {
+    "type": "object",
+    "required": ["id", "kind", "text", "anchor"],
+    "properties": {
+        "id": {"type": "string"},
+        "kind": {"enum": ["speech", "thought", "caption", "sfx"]},
+        "text": {"type": "string"},
+        "anchor": {"type": "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2},
+        "anchor_mode": {"enum": ["center", "topleft"]},
+        "tail_target": {"oneOf": [
+            {"type": "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2},
+            {"type": "null"},
+        ]},
+        "z": {"type": "integer"},
+        "role": {"type": "string"},
+        "text_style": {"type": ["object", "null"]},
+        "style": {"type": "object"},
+    },
+}
+
+
 def _style_to_dict(style):
     return asdict(style) if style is not None else None
 
@@ -79,6 +101,46 @@ def region_from_dict(d: Dict) -> Region:
         bleed=bool(d.get("bleed", False)),
         text_style=TextStyle(**_filtered(TextStyle, ts)) if ts else None,
         image_style=ImageStyle(**_filtered(ImageStyle, is_)) if is_ else None,
+    )
+
+
+def _overlay_style_to_dict(s: OverlayStyle) -> Dict:
+    return {
+        "fill": s.fill, "stroke_px": s.stroke_px, "stroke_color": s.stroke_color,
+        "padding_px": s.padding_px, "radius_px": s.radius_px, "max_width_px": s.max_width_px,
+    }
+
+
+def _overlay_style_from_dict(d: Dict) -> OverlayStyle:
+    return OverlayStyle(**_filtered(OverlayStyle, d)) if d else OverlayStyle()
+
+
+def overlay_to_dict(ov: Overlay) -> Dict:
+    d: Dict = {
+        "id": ov.id, "kind": ov.kind, "text": ov.text,
+        "anchor": [ov.anchor[0], ov.anchor[1]],
+        "anchor_mode": ov.anchor_mode,
+        "tail_target": (None if ov.tail_target is None
+                        else [ov.tail_target[0], ov.tail_target[1]]),
+        "z": ov.z, "role": ov.role,
+        "text_style": _style_to_dict(ov.text_style),
+        "style": _overlay_style_to_dict(ov.style),
+    }
+    return d
+
+
+def overlay_from_dict(d: Dict) -> Overlay:
+    anchor_raw = d["anchor"]
+    tt = d.get("tail_target")
+    ts = d.get("text_style")
+    return Overlay(
+        id=d["id"], kind=d["kind"], text=d.get("text", ""),
+        anchor=(float(anchor_raw[0]), float(anchor_raw[1])),
+        anchor_mode=d.get("anchor_mode", "center"),
+        tail_target=(None if tt is None else (float(tt[0]), float(tt[1]))),
+        z=int(d.get("z", 0)), role=d.get("role", ""),
+        text_style=TextStyle(**_filtered(TextStyle, ts)) if ts else None,
+        style=_overlay_style_from_dict(d.get("style") or {}),
     )
 
 
@@ -124,6 +186,7 @@ def page_to_dict(p: PageSpec) -> Dict:
         "page_size": asdict(p.page_size) if p.page_size else None,
         "margin_px": p.margin_px, "bleed_px": p.bleed_px, "background": p.background,
         "regions": [region_to_dict(r) for r in p.regions],
+        "overlays": [overlay_to_dict(o) for o in p.overlays],
         "variables": dict(p.variables),
     }
 
@@ -147,6 +210,7 @@ def page_from_dict(d: Dict) -> PageSpec:
         page_size=_page_size_from_dict(d.get("page_size")),
         margin_px=d.get("margin_px", 64), bleed_px=d.get("bleed_px", 0),
         background=d.get("background"), regions=regions,
+        overlays=[overlay_from_dict(o) for o in d.get("overlays", [])],
         variables=dict(d.get("variables", {})),
     )
 

--- a/core/layout/schema.py
+++ b/core/layout/schema.py
@@ -122,7 +122,7 @@ def overlay_to_dict(ov: Overlay) -> Dict:
         "anchor_mode": ov.anchor_mode,
         "tail_target": (None if ov.tail_target is None
                         else [ov.tail_target[0], ov.tail_target[1]]),
-        "z": ov.z, "role": ov.role,
+        "z": ov.z, "role": ov.role, "rotation": ov.rotation,
         "text_style": _style_to_dict(ov.text_style),
         "style": _overlay_style_to_dict(ov.style),
     }
@@ -141,6 +141,7 @@ def overlay_from_dict(d: Dict) -> Overlay:
         z=int(d.get("z", 0)), role=d.get("role", ""),
         text_style=TextStyle(**_filtered(TextStyle, ts)) if ts else None,
         style=_overlay_style_from_dict(d.get("style") or {}),
+        rotation=float(d.get("rotation", 0.0) or 0.0),
     )
 
 

--- a/core/layout/schema.py
+++ b/core/layout/schema.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Tuple
 
 from core.layout.models import (
     Region, PageSpec, DocumentSpec, PageSize, TextStyle, ImageStyle, Snapshot, ProjectStyle,
-    migrate_legacy_blocks, TextBlock, ImageBlock,
+    migrate_legacy_blocks, TextBlock, ImageBlock, PathSegment,
 )
 
 
@@ -23,9 +23,19 @@ REGION_JSON_SCHEMA: Dict = {
     "properties": {
         "id": {"type": "string"},
         "kind": {"enum": ["image", "text"]},
-        "shape": {"enum": ["rect", "polygon"]},
+        "shape": {"enum": ["rect", "polygon", "path"]},
         "bbox": {"type": "array", "items": {"type": "number"}, "minItems": 4, "maxItems": 4},
         "points": {"type": "array", "items": {"type": "array", "items": {"type": "number"}}},
+        "segments": {"type": "array", "items": {
+            "type": "object",
+            "required": ["type", "pts"],
+            "properties": {
+                "type": {"enum": ["move", "line", "quad", "cubic", "close"]},
+                "pts": {"type": "array", "items": {
+                    "type": "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2}},
+            },
+        }},
+        "bleed": {"type": "boolean"},
         "z": {"type": "integer"},
         "text": {"type": "string"},
         "role": {"type": "string"},
@@ -45,6 +55,8 @@ def region_to_dict(r: Region) -> Dict:
         "bbox": list(r.bbox), "points": [list(p) for p in r.points],
         "z": r.z, "name": r.name, "text": r.text, "role": r.role,
         "image_ref": r.image_ref, "prompt": r.prompt, "gen_settings": dict(r.gen_settings),
+        "segments": [{"type": s.type, "pts": [list(p) for p in s.pts]} for s in r.segments],
+        "bleed": r.bleed,
         "text_style": _style_to_dict(r.text_style),
         "image_style": _style_to_dict(r.image_style),
     }
@@ -61,6 +73,10 @@ def region_from_dict(d: Dict) -> Region:
         text=d.get("text", ""), role=d.get("role", ""),
         image_ref=d.get("image_ref"), prompt=d.get("prompt", ""),
         gen_settings=dict(d.get("gen_settings", {})),
+        segments=[PathSegment(type=s.get("type", "line"),
+                              pts=[tuple(p) for p in s.get("pts", [])])
+                  for s in d.get("segments", [])],
+        bleed=bool(d.get("bleed", False)),
         text_style=TextStyle(**_filtered(TextStyle, ts)) if ts else None,
         image_style=ImageStyle(**_filtered(ImageStyle, is_)) if is_ else None,
     )
@@ -163,6 +179,9 @@ def normalize_region(r: Region, page_px: Tuple[int, int]) -> Region:
         xs = [p[0] for p in r.points]
         ys = [p[1] for p in r.points]
         bbox = (min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys))
+    elif r.shape == "path" and r.segments:
+        from core.layout.geometry import segments_bbox
+        bbox = tuple(round(v) for v in segments_bbox(r.segments))
     else:
         bbox = r.bbox
     x, y, w, h = bbox

--- a/core/layout/svg_path.py
+++ b/core/layout/svg_path.py
@@ -1,0 +1,135 @@
+"""Pure (Qt-free) converter between SVG path 'd' strings and PathSegments.
+
+LLM-native curve authoring: the AI designer emits SVG path data, which this
+module parses into the PathSegment model the renderer already consumes; the
+inverse serializes segments back to a 'd' string (round-trip, export, and
+showing current geometry back to the LLM). Supports the subset
+M L H V C Q Z (absolute + relative, implicit repeats). Malformed input is
+logged and degrades to whatever parsed cleanly; it never raises.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import List, Tuple
+
+from core.layout.models import PathSegment
+
+logger = logging.getLogger(__name__)
+
+_NUM = r"[-+]?(?:\d*\.\d+|\d+\.?)(?:[eE][-+]?\d+)?"
+_TOKEN_RE = re.compile(r"([MmLlHhVvCcQqZz])|(" + _NUM + r")")
+_ARGC = {"M": 2, "L": 2, "H": 1, "V": 1, "C": 6, "Q": 4}
+
+
+def _tokenize(d: str) -> List[Tuple[str, object]]:
+    tokens: List[Tuple[str, object]] = []
+    for m in _TOKEN_RE.finditer(d or ""):
+        if m.group(1):
+            tokens.append(("cmd", m.group(1)))
+        else:
+            tokens.append(("num", float(m.group(2))))
+    return tokens
+
+
+def svg_to_segments(d: str) -> List[PathSegment]:
+    """Parse an SVG path 'd' string into PathSegments (subset M/L/H/V/C/Q/Z)."""
+    tokens = _tokenize(d)
+    segs: List[PathSegment] = []
+    i, n = 0, len(tokens)
+    cx = cy = sx = sy = 0.0
+    cmd = ""
+    while i < n:
+        kind, val = tokens[i]
+        if kind == "cmd":
+            cmd = str(val)
+            i += 1
+            if cmd in ("Z", "z"):
+                segs.append(PathSegment(type="close", pts=[]))
+                cx, cy = sx, sy
+                cmd = ""
+                continue
+        elif not cmd:
+            logger.warning("svg_to_segments: number before any command in %r; stopping", d)
+            break
+        else:
+            # implicit repeat of the previous command; M/m repeats as L/l
+            if cmd == "M":
+                cmd = "L"
+            elif cmd == "m":
+                cmd = "l"
+        c = cmd.upper()
+        rel = cmd.islower()
+        argc = _ARGC.get(c)
+        if argc is None:
+            logger.warning("svg_to_segments: unsupported command %r; stopping", cmd)
+            break
+        if i + argc > n or any(tokens[j][0] != "num" for j in range(i, i + argc)):
+            logger.warning("svg_to_segments: command %r needs %d args; stopping", cmd, argc)
+            break
+        args = [float(tokens[j][1]) for j in range(i, i + argc)]
+        i += argc
+        if c == "M":
+            x, y = args
+            if rel:
+                x, y = cx + x, cy + y
+            segs.append(PathSegment(type="move", pts=[(x, y)]))
+            cx, cy = sx, sy = x, y
+        elif c == "L":
+            x, y = args
+            if rel:
+                x, y = cx + x, cy + y
+            segs.append(PathSegment(type="line", pts=[(x, y)]))
+            cx, cy = x, y
+        elif c == "H":
+            x = args[0] + (cx if rel else 0.0)
+            segs.append(PathSegment(type="line", pts=[(x, cy)]))
+            cx = x
+        elif c == "V":
+            y = args[0] + (cy if rel else 0.0)
+            segs.append(PathSegment(type="line", pts=[(cx, y)]))
+            cy = y
+        elif c == "C":
+            pts = []
+            for k in range(0, 6, 2):
+                px, py = args[k], args[k + 1]
+                if rel:
+                    px, py = cx + px, cy + py
+                pts.append((px, py))
+            segs.append(PathSegment(type="cubic", pts=pts))
+            cx, cy = pts[-1]
+        elif c == "Q":
+            pts = []
+            for k in range(0, 4, 2):
+                px, py = args[k], args[k + 1]
+                if rel:
+                    px, py = cx + px, cy + py
+                pts.append((px, py))
+            segs.append(PathSegment(type="quad", pts=pts))
+            cx, cy = pts[-1]
+    return segs
+
+
+def _fmt(n: float) -> str:
+    return f"{n:g}"
+
+
+def segments_to_svg(segments: List[PathSegment]) -> str:
+    """Serialize PathSegments back to an absolute-coordinate SVG 'd' string."""
+    parts: List[str] = []
+    for s in segments:
+        if s.type == "move":
+            x, y = s.pts[0]
+            parts.append(f"M {_fmt(x)} {_fmt(y)}")
+        elif s.type == "line":
+            x, y = s.pts[0]
+            parts.append(f"L {_fmt(x)} {_fmt(y)}")
+        elif s.type == "quad":
+            (cx, cy), (x, y) = s.pts
+            parts.append(f"Q {_fmt(cx)} {_fmt(cy)} {_fmt(x)} {_fmt(y)}")
+        elif s.type == "cubic":
+            (c1x, c1y), (c2x, c2y), (x, y) = s.pts
+            parts.append(f"C {_fmt(c1x)} {_fmt(c1y)} {_fmt(c2x)} {_fmt(c2y)} {_fmt(x)} {_fmt(y)}")
+        elif s.type == "close":
+            parts.append("Z")
+    return " ".join(parts)

--- a/core/layout/tiling.py
+++ b/core/layout/tiling.py
@@ -11,7 +11,7 @@ from typing import List, Literal, Optional, Tuple, Union
 from core.layout.geometry import segments_bbox
 from core.layout.models import Region
 from core.layout.polygon import (
-    Poly, clip_halfplane, inset_polygon, polygon_to_segments,
+    Poly, clip_halfplane, inset_polygon, polygon_to_segments, union_polygons, EPS,
 )
 
 logger = logging.getLogger(__name__)
@@ -106,15 +106,48 @@ def _panel_to_region(panel: Poly, leaf: Leaf, rect: Rect, *, gutter: float, marg
 
 
 def tile(tree: Node, page_rect: Rect, *, gutter: float, margin: float) -> List[Region]:
-    """Partition page_rect by the slice tree and inset each leaf into a Region."""
+    """Partition page_rect, merge cells sharing a merge key, then inset each panel."""
     rx, ry, rw, rh = page_rect
     page_poly: Poly = [(rx, ry), (rx + rw, ry), (rx + rw, ry + rh), (rx, ry + rh)]
     leaves: List[Tuple[Leaf, Poly]] = []
     _collect_leaves(tree, page_poly, leaves)
+
+    # Build the panel list: each entry is (representative_leaf, panel_polygon).
+    panels: List[Tuple[Leaf, Poly]] = []
+    # group polygons by merge key, preserving first-encounter order
+    groups: dict = {}
+    order: List[Optional[str]] = []
+    for leaf, cell in leaves:
+        key = leaf.merge
+        if key is None:
+            order.append(id(leaf))
+            groups[id(leaf)] = (leaf, [(leaf, cell)])
+        else:
+            if key not in groups:
+                groups[key] = (leaf, [])
+                order.append(key)
+            groups[key][1].append((leaf, cell))
+
+    for key in order:
+        rep_leaf, leaf_cells = groups[key]
+        cells = [cell for _, cell in leaf_cells]
+        if len(cells) == 1:
+            panels.append((rep_leaf, cells[0]))
+            continue
+        rings = union_polygons(cells)
+        if len(rings) == 1:
+            panels.append((rep_leaf, rings[0]))
+        else:
+            logger.error("Tiling: merge group %r is disconnected (%d pieces); leaving unmerged",
+                         key, len(rings))
+            # fall back: emit each original cell with its own leaf identity
+            for orig_leaf, orig_cell in leaf_cells:
+                panels.append((orig_leaf, orig_cell))
+
     regions: List[Region] = []
     z = 0
-    for leaf, cell in leaves:
-        r = _panel_to_region(cell, leaf, page_rect, gutter=gutter, margin=margin, z=z)
+    for leaf, panel in panels:
+        r = _panel_to_region(panel, leaf, page_rect, gutter=gutter, margin=margin, z=z)
         if r is not None:
             regions.append(r)
             z += 1

--- a/core/layout/tiling.py
+++ b/core/layout/tiling.py
@@ -11,7 +11,7 @@ from typing import List, Literal, Optional, Tuple, Union
 from core.layout.geometry import segments_bbox
 from core.layout.models import Region
 from core.layout.polygon import (
-    Poly, clip_halfplane, inset_polygon, polygon_to_segments, EPS,
+    Poly, clip_halfplane, inset_polygon, polygon_to_segments,
 )
 
 logger = logging.getLogger(__name__)

--- a/core/layout/tiling.py
+++ b/core/layout/tiling.py
@@ -4,6 +4,7 @@ Pure (no Qt). Emits shape="path" Regions rendered by the geometry/render core.
 """
 from __future__ import annotations
 
+import dataclasses
 import logging
 from dataclasses import dataclass
 from typing import List, Literal, Optional, Tuple, Union
@@ -210,8 +211,7 @@ def apply_tiling(page: PageSpec, tree: Node, *, gutter: float, margin: float,
     next_z = (max((r.z for r in base), default=-1)) + 1
     layered: List[Region] = list(base)
     for r in floating:
-        r.z = next_z
+        layered.append(dataclasses.replace(r, z=next_z))
         next_z += 1
-        layered.append(r)
     page.regions = layered
     return page

--- a/core/layout/tiling.py
+++ b/core/layout/tiling.py
@@ -1,0 +1,121 @@
+"""Page-partition (tiling) engine: slice tree -> gap-free panels -> inset gutters.
+
+Pure (no Qt). Emits shape="path" Regions rendered by the geometry/render core.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import List, Literal, Optional, Tuple, Union
+
+from core.layout.geometry import segments_bbox
+from core.layout.models import Region
+from core.layout.polygon import (
+    Poly, clip_halfplane, inset_polygon, polygon_to_segments, EPS,
+)
+
+logger = logging.getLogger(__name__)
+
+Rect = Tuple[float, float, float, float]  # (x, y, w, h)
+_CUT_EPS = 1e-3
+
+
+@dataclass
+class Split:
+    axis: Literal["x", "y"]   # "x" = vertical cut (left/right); "y" = horizontal (top/bottom)
+    at: float                 # fraction (0,1) of the cell bbox along the axis
+    a: "Node"                 # left / top child
+    b: "Node"                 # right / bottom child
+    skew: float = 0.0         # [-1,1]; angled gutter
+
+
+@dataclass
+class Leaf:
+    id: str
+    kind: Literal["image", "text"] = "image"
+    bleed: bool = False
+    merge: Optional[str] = None
+
+
+Node = Union[Split, Leaf]
+
+
+def _cut_line(cell: Poly, split: Split) -> Tuple[Tuple[float, float], Tuple[float, float]]:
+    xs = [p[0] for p in cell]
+    ys = [p[1] for p in cell]
+    minx, maxx, miny, maxy = min(xs), max(xs), min(ys), max(ys)
+    at = min(max(split.at, _CUT_EPS), 1 - _CUT_EPS)
+    skew = max(-1.0, min(1.0, split.skew))
+    if split.axis == "x":
+        x = minx + at * (maxx - minx)
+        dx = skew * (maxx - minx) * 0.5
+        return ((x + dx, miny), (x - dx, maxy))  # downward-directed: left of it is the 'a' (west) half
+    else:
+        y = miny + at * (maxy - miny)
+        dy = skew * (maxy - miny) * 0.5
+        return ((maxx, y - dy), (minx, y + dy))  # leftward-directed: left of it is the 'a' (north/top) half
+
+
+def _collect_leaves(node: Node, cell: Poly, out: List[Tuple[Leaf, Poly]]) -> None:
+    if isinstance(node, Leaf):
+        if len(cell) >= 3:
+            out.append((node, cell))
+        else:
+            logger.warning("Tiling: leaf %s produced a degenerate cell; dropped", node.id)
+        return
+    if not isinstance(node, Split):
+        raise ValueError(f"Tiling: unknown node type {type(node)!r}")
+    if node.a is None or node.b is None:
+        raise ValueError("Tiling: Split must have both children")
+    a, b = _cut_line(cell, node)
+    _collect_leaves(node.a, clip_halfplane(cell, a, b), out)
+    _collect_leaves(node.b, clip_halfplane(cell, b, a), out)
+
+
+def _edge_is_boundary(p: Tuple[float, float], q: Tuple[float, float], rect: Rect) -> bool:
+    rx, ry, rw, rh = rect
+    sides = ((0, rx), (0, rx + rw), (1, ry), (1, ry + rh))
+    for coord, val in sides:
+        if abs(p[coord] - val) <= _CUT_EPS and abs(q[coord] - val) <= _CUT_EPS:
+            return True
+    return False
+
+
+def _inset_dists(panel: Poly, rect: Rect, *, gutter: float, margin: float, bleed: bool) -> List[float]:
+    n = len(panel)
+    dists: List[float] = []
+    for i in range(n):
+        p, q = panel[i], panel[(i + 1) % n]
+        if _edge_is_boundary(p, q, rect):
+            dists.append(0.0 if bleed else margin)
+        else:
+            dists.append(gutter / 2.0)
+    return dists
+
+
+def _panel_to_region(panel: Poly, leaf: Leaf, rect: Rect, *, gutter: float, margin: float, z: int) -> Optional[Region]:
+    dists = _inset_dists(panel, rect, gutter=gutter, margin=margin, bleed=leaf.bleed)
+    inset = inset_polygon(panel, dists)
+    if inset is None:
+        logger.warning("Tiling: panel %s too thin for gutter; dropped", leaf.id)
+        return None
+    segs = polygon_to_segments(inset)
+    bx, by, bw, bh = (round(v) for v in segments_bbox(segs))
+    return Region(id=leaf.id, kind=leaf.kind, shape="path", segments=segs,
+                  bleed=leaf.bleed, bbox=(bx, by, bw, bh), z=z)
+
+
+def tile(tree: Node, page_rect: Rect, *, gutter: float, margin: float) -> List[Region]:
+    """Partition page_rect by the slice tree and inset each leaf into a Region."""
+    rx, ry, rw, rh = page_rect
+    page_poly: Poly = [(rx, ry), (rx + rw, ry), (rx + rw, ry + rh), (rx, ry + rh)]
+    leaves: List[Tuple[Leaf, Poly]] = []
+    _collect_leaves(tree, page_poly, leaves)
+    regions: List[Region] = []
+    z = 0
+    for leaf, cell in leaves:
+        r = _panel_to_region(cell, leaf, page_rect, gutter=gutter, margin=margin, z=z)
+        if r is not None:
+            regions.append(r)
+            z += 1
+    return regions

--- a/core/layout/tiling.py
+++ b/core/layout/tiling.py
@@ -11,7 +11,7 @@ from typing import List, Literal, Optional, Tuple, Union
 from core.layout.geometry import segments_bbox
 from core.layout.models import Region
 from core.layout.polygon import (
-    Poly, clip_halfplane, inset_polygon, polygon_to_segments, union_polygons, EPS,
+    Poly, clip_halfplane, inset_polygon, polygon_to_segments, union_polygons,
 )
 
 logger = logging.getLogger(__name__)
@@ -116,7 +116,7 @@ def tile(tree: Node, page_rect: Rect, *, gutter: float, margin: float) -> List[R
     panels: List[Tuple[Leaf, Poly]] = []
     # group polygons by merge key, preserving first-encounter order
     groups: dict = {}
-    order: List[Optional[str]] = []
+    order: List[Union[int, str]] = []
     for leaf, cell in leaves:
         key = leaf.merge
         if key is None:

--- a/core/layout/tiling.py
+++ b/core/layout/tiling.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import List, Literal, Optional, Tuple, Union
 
 from core.layout.geometry import segments_bbox
-from core.layout.models import Region
+from core.layout.models import Region, PageSpec
 from core.layout.polygon import (
     Poly, clip_halfplane, inset_polygon, polygon_to_segments, union_polygons,
 )
@@ -152,3 +152,66 @@ def tile(tree: Node, page_rect: Rect, *, gutter: float, margin: float) -> List[R
             regions.append(r)
             z += 1
     return regions
+
+
+# ---------------------------------------------------------------------------
+# Preset tree builders
+# ---------------------------------------------------------------------------
+
+def grid(rows: int, cols: int, *, kind: Literal["image", "text"] = "image", prefix: str = "p") -> Node:
+    """A regular rows x cols grid (nested y-then-x splits)."""
+    if rows < 1 or cols < 1:
+        raise ValueError("grid requires rows >= 1 and cols >= 1")
+
+    def row(r: int) -> Node:
+        def col(c: int) -> Node:
+            leaf = Leaf(id=f"{prefix}{r}_{c}", kind=kind)
+            if c == cols - 1:
+                return leaf
+            return Split(axis="x", at=1.0 / (cols - c), a=leaf, b=col(c + 1))
+        return col(0)
+
+    def build(r: int) -> Node:
+        if r == rows - 1:
+            return row(r)
+        return Split(axis="y", at=1.0 / (rows - r), a=row(r), b=build(r + 1))
+
+    return build(0)
+
+
+def three_tiers() -> Node:
+    """Three full-width horizontal tiers."""
+    return Split(axis="y", at=1 / 3, a=Leaf(id="t0"),
+                 b=Split(axis="y", at=0.5, a=Leaf(id="t1"), b=Leaf(id="t2")))
+
+
+def splash_with_strip() -> Node:
+    """A large top splash panel and a bottom strip of two."""
+    return Split(axis="y", at=0.66, a=Leaf(id="splash"),
+                 b=Split(axis="x", at=0.5, a=Leaf(id="s0"), b=Leaf(id="s1")))
+
+
+def diagonal_action() -> Node:
+    """Two panels divided by a strongly angled gutter."""
+    return Split(axis="x", at=0.5, a=Leaf(id="d0"), b=Leaf(id="d1"), skew=0.6)
+
+
+def feature_L() -> Node:
+    """A concave L hero (top-left + bottom strip merged) beside a tall right panel."""
+    top = Split(axis="x", at=0.6, a=Leaf(id="hero", merge="L"), b=Leaf(id="side"))
+    return Split(axis="y", at=0.6, a=top, b=Leaf(id="hero_b", merge="L"))
+
+
+def apply_tiling(page: PageSpec, tree: Node, *, gutter: float, margin: float,
+                 floating: Tuple[Region, ...] = ()) -> PageSpec:
+    """Tile the page and layer floating panels on top (higher z). Mutates + returns page."""
+    pw, ph = page.page_size_px
+    base = tile(tree, (0, 0, pw, ph), gutter=gutter, margin=margin)
+    next_z = (max((r.z for r in base), default=-1)) + 1
+    layered: List[Region] = list(base)
+    for r in floating:
+        r.z = next_z
+        next_z += 1
+        layered.append(r)
+    page.regions = layered
+    return page

--- a/gui/layout/canvas_widget.py
+++ b/gui/layout/canvas_widget.py
@@ -43,6 +43,12 @@ class CanvasWidget(QGraphicsView):
                 return rid
         return None
 
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        scene = self.scene()
+        if scene is not None:
+            self.fitInView(scene.sceneRect(), Qt.KeepAspectRatio)
+
     def _on_selection_changed(self):
         rid = self.selected_region_id()
         self.regionSelected.emit(rid or "")

--- a/gui/layout/canvas_widget.py
+++ b/gui/layout/canvas_widget.py
@@ -11,6 +11,8 @@ from core.layout import qt_renderer
 
 class CanvasWidget(QGraphicsView):
     regionSelected = Signal(str)
+    knifeLine = Signal(float, float, float, float)  # p1x, p1y, p2x, p2y (scene px)
+    mergeTarget = Signal(str)                        # clicked region id
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -19,6 +21,8 @@ class CanvasWidget(QGraphicsView):
         self._page: Optional[PageSpec] = None
         self._scene: Optional[QGraphicsScene] = None
         self.setScene(QGraphicsScene(self))
+        self._tool_mode = "none"
+        self._knife_first = None
 
     def load_page(self, page: PageSpec, style=None, *, locked: bool = True) -> None:
         old = self._scene
@@ -42,6 +46,51 @@ class CanvasWidget(QGraphicsView):
             if rid:
                 return rid
         return None
+
+    def set_tool_mode(self, mode: str) -> None:
+        """Switch the canvas tool: "none" (normal select), "knife", or "merge"."""
+        if mode not in ("none", "knife", "merge"):
+            mode = "none"
+        self._tool_mode = mode
+        self._knife_first = None
+
+    def tool_mode(self) -> str:
+        return self._tool_mode
+
+    def _register_knife_point(self, x: float, y: float):
+        """Collect a knife click; return (x1,y1,x2,y2) on the second, else None."""
+        if self._knife_first is None:
+            self._knife_first = (x, y)
+            return None
+        x1, y1 = self._knife_first
+        self._knife_first = None
+        return (x1, y1, x, y)
+
+    def _region_id_at(self, scene_pt):
+        for it in self.scene().items(scene_pt):
+            rid = it.data(0)
+            if rid:
+                return rid
+        return None
+
+    def mousePressEvent(self, event):
+        if self._tool_mode == "knife":
+            sp = self.mapToScene(event.position().toPoint())
+            line = self._register_knife_point(sp.x(), sp.y())
+            if line is not None:
+                self._tool_mode = "none"
+                self.knifeLine.emit(*line)
+            event.accept()
+            return
+        if self._tool_mode == "merge":
+            sp = self.mapToScene(event.position().toPoint())
+            rid = self._region_id_at(sp)
+            self._tool_mode = "none"
+            if rid:
+                self.mergeTarget.emit(rid)
+            event.accept()
+            return
+        super().mousePressEvent(event)
 
     def resizeEvent(self, event):
         super().resizeEvent(event)

--- a/gui/layout/designer_panel.py
+++ b/gui/layout/designer_panel.py
@@ -146,8 +146,10 @@ class DesignerPanel(QWidget):
         if result.raw:
             self.console.log("LLM response:\n" + result.raw, "INFO")
         n = len(result.regions) if result.regions else 0
-        self.console.log(f"Proposed layout: {n} regions; {len(result.questions)} question(s).",
-                         "SUCCESS")
+        nov = len(getattr(result, "overlays", []) or [])
+        self.console.log(
+            f"Proposed layout: {n} regions; {nov} overlay(s); {len(result.questions)} question(s).",
+            "SUCCESS")
         for q in result.questions:
             self.console.log(f"Q: {q}", "WARNING")
         self.layoutProposed.emit(result)

--- a/gui/layout/export_dialog.py
+++ b/gui/layout/export_dialog.py
@@ -15,7 +15,6 @@ from PySide6.QtCore import Qt, QThread, Signal
 
 from core.config import ConfigManager
 from core.layout.models import DocumentSpec
-from core.layout import LayoutEngine
 
 logger = logging.getLogger(__name__)
 
@@ -69,84 +68,30 @@ class ExportWorker(QThread):
             self.error.emit(f"Export failed: {e}")
 
     def _export_png(self, output_path: Path, pages_to_export: List[int], num_pages: int):
-        """Export to PNG sequence."""
-        # Create engine
-        engine = LayoutEngine()
-
+        """Export to PNG sequence via the Qt renderer (comic geometry + overlays)."""
+        from core.layout import qt_renderer
         for idx, page_num in enumerate(pages_to_export):
             page = self.document.pages[page_num]
-
-            # Update progress
             progress_pct = int((idx / num_pages) * 100)
             self.progress.emit(progress_pct, f"Rendering page {page_num + 1}...")
-
-            # Render page
-            image = engine.render_page(page, dpi=self.dpi)
-
-            # Save with page number if multiple pages
+            image = qt_renderer.render_page_to_image(page, style=self.document.style)
             if num_pages > 1:
                 page_output = output_path.parent / f"{output_path.stem}_page{page_num + 1:03d}.png"
             else:
                 page_output = output_path
-
             image.save(str(page_output), "PNG")
             logger.info(f"Exported page {page_num + 1} to {page_output}")
-
         self.progress.emit(100, "Complete!")
 
     def _export_pdf(self, output_path: Path, pages_to_export: List[int], num_pages: int):
-        """Export to PDF."""
-        try:
-            from PIL import Image
-            from reportlab.pdfgen import canvas
-            from reportlab.lib.utils import ImageReader
-            import io
-
-            # Create engine
-            engine = LayoutEngine()
-
-            # Create PDF
-            c = canvas.Canvas(str(output_path))
-
-            for idx, page_num in enumerate(pages_to_export):
-                page = self.document.pages[page_num]
-
-                # Update progress
-                progress_pct = int((idx / num_pages) * 100)
-                self.progress.emit(progress_pct, f"Rendering page {page_num + 1}...")
-
-                # Render page
-                image = engine.render_page(page, dpi=self.dpi)
-
-                # Convert PIL image to reportlab format
-                img_buffer = io.BytesIO()
-                image.save(img_buffer, format='PNG')
-                img_buffer.seek(0)
-                img_reader = ImageReader(img_buffer)
-
-                # Get page size from image
-                width_px, height_px = image.size
-                # Convert pixels to points (72 points = 1 inch)
-                width_pt = (width_px / self.dpi) * 72
-                height_pt = (height_px / self.dpi) * 72
-
-                # Set page size and draw image
-                c.setPageSize((width_pt, height_pt))
-                c.drawImage(img_reader, 0, 0, width=width_pt, height=height_pt)
-
-                # Add new page if not last
-                if idx < num_pages - 1:
-                    c.showPage()
-
-                logger.info(f"Added page {page_num + 1} to PDF")
-
-            # Save PDF
-            c.save()
-            self.progress.emit(100, "Complete!")
-
-        except ImportError:
-            self.error.emit("PDF export requires 'reportlab' package. Install with: pip install reportlab")
-            return
+        """Export to PDF via the Qt renderer (comic geometry + overlays)."""
+        from dataclasses import replace
+        from core.layout import qt_renderer
+        self.progress.emit(0, "Rendering PDF...")
+        sub = replace(self.document,
+                      pages=[self.document.pages[i] for i in pages_to_export])
+        qt_renderer.export_document_pdf(sub, str(output_path), dpi=self.dpi)
+        self.progress.emit(100, "Complete!")
 
     def _export_json(self, output_path: Path):
         """Export to JSON project file."""
@@ -476,3 +421,7 @@ class ExportDialog(QDialog):
                 # QThread's destructor will wait for it
 
         super().closeEvent(event)
+
+
+# Alias so tests and external callers can reference the worker by a stable name.
+LayoutExportWorker = ExportWorker

--- a/gui/layout/export_dialog.py
+++ b/gui/layout/export_dialog.py
@@ -74,7 +74,8 @@ class ExportWorker(QThread):
             page = self.document.pages[page_num]
             progress_pct = int((idx / num_pages) * 100)
             self.progress.emit(progress_pct, f"Rendering page {page_num + 1}...")
-            image = qt_renderer.render_page_to_image(page, style=self.document.style)
+            image = qt_renderer.render_page_to_image(page, style=self.document.style,
+                                                      scale=self.dpi / 72.0)
             if num_pages > 1:
                 page_output = output_path.parent / f"{output_path.stem}_page{page_num + 1:03d}.png"
             else:

--- a/gui/layout/geometry_editor.py
+++ b/gui/layout/geometry_editor.py
@@ -4,6 +4,7 @@ The renderer rebuilds the whole scene on every refresh, so handles are
 regenerated from the model after each rebuild (see LayoutTab._refresh) rather
 than preserved. Move-only: handle generation here; dragging/commit is #5a Task 5.
 """
+import logging
 from typing import Callable, List, Optional
 
 from PySide6.QtWidgets import QGraphicsEllipseItem, QGraphicsItem
@@ -11,6 +12,8 @@ from PySide6.QtGui import QBrush, QPen, QColor
 from PySide6.QtCore import QRectF
 
 from core.layout.qt_renderer import region_to_painter_path
+
+logger = logging.getLogger(__name__)
 
 _HANDLE_R = 6.0  # handle radius in scene (page-pixel) units
 
@@ -188,8 +191,7 @@ class GeometryEditor:
         if region.shape == "path":
             issues = validate_segments(region.segments)
             if issues:
-                import logging
-                logging.getLogger(__name__).warning(
+                logger.warning(
                     "Geometry edit on %s produced invalid segments; reverting: %s",
                     region.id, "; ".join(issues))
                 if self._pre is not None:

--- a/gui/layout/geometry_editor.py
+++ b/gui/layout/geometry_editor.py
@@ -1,0 +1,140 @@
+"""Manual region-geometry editor: vertex/curve handles layered on the canvas.
+
+The renderer rebuilds the whole scene on every refresh, so handles are
+regenerated from the model after each rebuild (see LayoutTab._refresh) rather
+than preserved. Move-only: handle generation here; dragging/commit is #5a Task 5.
+"""
+from typing import Callable, List, Optional
+
+from PySide6.QtWidgets import QGraphicsEllipseItem, QGraphicsItem
+from PySide6.QtGui import QBrush, QPen, QColor
+from PySide6.QtCore import QRectF
+
+from core.layout.qt_renderer import region_to_painter_path
+
+_HANDLE_R = 6.0  # handle radius in scene (page-pixel) units
+
+
+class _EditPoint:
+    """One draggable model point: its current position + how to write a new one."""
+    __slots__ = ("x", "y", "is_control", "apply")
+
+    def __init__(self, x: float, y: float, is_control: bool,
+                 apply: Callable[[float, float], None]):
+        self.x = x
+        self.y = y
+        self.is_control = is_control
+        self.apply = apply
+
+
+def edit_points_for_region(region) -> List["_EditPoint"]:
+    """Ordered editable points for a path|polygon region (rect -> [])."""
+    pts: List[_EditPoint] = []
+    if region.shape == "polygon":
+        for i in range(len(region.points)):
+            pts.append(_polygon_point(region, i))
+    elif region.shape == "path":
+        for seg in region.segments:
+            if seg.type in ("move", "line"):
+                pts.append(_seg_point(seg, 0, is_control=False))
+            elif seg.type == "quad":
+                pts.append(_seg_point(seg, 0, is_control=True))
+                pts.append(_seg_point(seg, 1, is_control=False))
+            elif seg.type == "cubic":
+                pts.append(_seg_point(seg, 0, is_control=True))
+                pts.append(_seg_point(seg, 1, is_control=True))
+                pts.append(_seg_point(seg, 2, is_control=False))
+            # close -> no handle
+    return pts
+
+
+def _polygon_point(region, i: int) -> "_EditPoint":
+    px, py = region.points[i]
+
+    def apply(x: float, y: float):
+        region.points[i] = (round(x), round(y))
+
+    return _EditPoint(float(px), float(py), False, apply)
+
+
+def _seg_point(seg, j: int, *, is_control: bool) -> "_EditPoint":
+    px, py = seg.pts[j]
+
+    def apply(x: float, y: float):
+        seg.pts[j] = (x, y)
+
+    return _EditPoint(float(px), float(py), is_control, apply)
+
+
+class _HandleItem(QGraphicsEllipseItem):
+    """A vertex/control handle. Visual in Task 4; made draggable in Task 5."""
+
+    def __init__(self, editor: "GeometryEditor", index: int):
+        super().__init__()
+        self._editor = editor
+        self._index = index
+
+
+class GeometryEditor:
+    """Owns the edit handles for one selected path/polygon region on a canvas."""
+
+    def __init__(self, canvas, layout_tab):
+        self._canvas = canvas
+        self._tab = layout_tab
+        self._edit_region_id: Optional[str] = None
+        self._points: List[_EditPoint] = []
+        self._handles: List[_HandleItem] = []
+        self._shape_item = None
+
+    def active_region_id(self) -> Optional[str]:
+        return self._edit_region_id
+
+    def edit_points(self) -> List[_EditPoint]:
+        return self._points
+
+    def set_edit_region(self, region_id: Optional[str]) -> None:
+        self._edit_region_id = region_id or None
+        self.rebuild_handles()
+
+    def rebuild_handles(self) -> None:
+        """Re-create handles from the model for the active region.
+
+        Call after every scene rebuild — handles are not preserved across the
+        renderer's full-scene rebuild, they are reconstructed here.
+        """
+        self._clear()
+        if not self._edit_region_id:
+            return
+        region = self._tab._find_region(self._edit_region_id)
+        if region is None or region.shape not in ("path", "polygon"):
+            self._edit_region_id = None
+            return
+        scene = self._canvas.scene()
+        if scene is None:
+            return
+        self._shape_item = self._find_shape_item(scene, region)
+        self._points = edit_points_for_region(region)
+        for idx, ep in enumerate(self._points):
+            h = _HandleItem(self, idx)
+            h.setRect(QRectF(-_HANDLE_R, -_HANDLE_R, 2 * _HANDLE_R, 2 * _HANDLE_R))
+            h.setPos(ep.x, ep.y)
+            h.setZValue(1_000_000)
+            h.setBrush(QBrush(QColor("#FFFFFF") if ep.is_control else QColor("#2D7DD2")))
+            h.setPen(QPen(QColor("#2D7DD2"), 1.5))
+            scene.addItem(h)
+            self._handles.append(h)
+
+    def _find_shape_item(self, scene, region):
+        for it in scene.items():
+            if getattr(it, "_region", None) is region and hasattr(it, "setPath"):
+                return it
+        return None
+
+    def _clear(self) -> None:
+        scene = self._canvas.scene()
+        if scene is not None:
+            for h in self._handles:
+                scene.removeItem(h)
+        self._handles = []
+        self._points = []
+        self._shape_item = None

--- a/gui/layout/geometry_editor.py
+++ b/gui/layout/geometry_editor.py
@@ -67,12 +67,27 @@ def _seg_point(seg, j: int, *, is_control: bool) -> "_EditPoint":
 
 
 class _HandleItem(QGraphicsEllipseItem):
-    """A vertex/control handle. Visual in Task 4; made draggable in Task 5."""
+    """A vertex/control handle. Dragging mutates the bound model point."""
 
     def __init__(self, editor: "GeometryEditor", index: int):
         super().__init__()
         self._editor = editor
         self._index = index
+        self.setFlag(QGraphicsItem.ItemIsMovable, True)
+        self.setFlag(QGraphicsItem.ItemSendsGeometryChanges, True)
+
+    def mousePressEvent(self, event):
+        self._editor.begin_edit()
+        super().mousePressEvent(event)
+
+    def itemChange(self, change, value):
+        if change == QGraphicsItem.ItemPositionHasChanged:
+            self._editor.move_handle(self._index, self.x(), self.y())
+        return super().itemChange(change, value)
+
+    def mouseReleaseEvent(self, event):
+        super().mouseReleaseEvent(event)
+        self._editor.commit()
 
 
 class GeometryEditor:
@@ -85,6 +100,7 @@ class GeometryEditor:
         self._points: List[_EditPoint] = []
         self._handles: List[_HandleItem] = []
         self._shape_item = None
+        self._pre = None
 
     def active_region_id(self) -> Optional[str]:
         return self._edit_region_id
@@ -138,3 +154,54 @@ class GeometryEditor:
         self._handles = []
         self._points = []
         self._shape_item = None
+
+    def begin_edit(self) -> None:
+        """Snapshot pre-edit geometry (for validation revert) and freeze refreshes."""
+        region = self._tab._find_region(self._edit_region_id) if self._edit_region_id else None
+        if region is None:
+            self._pre = None
+            return
+        self._pre = (
+            [type(s)(type=s.type, pts=list(s.pts)) for s in region.segments],
+            list(region.points),
+            tuple(region.bbox),
+        )
+        self._tab.set_refresh_suspended(True)
+
+    def move_handle(self, index: int, x: float, y: float) -> None:
+        """Apply a handle's new scene position to the model + live-update the path."""
+        if not (0 <= index < len(self._points)):
+            return
+        self._points[index].apply(x, y)
+        region = self._tab._find_region(self._edit_region_id) if self._edit_region_id else None
+        if region is not None and self._shape_item is not None:
+            self._shape_item.setPath(region_to_painter_path(region))
+
+    def commit(self) -> None:
+        """Persist the edit: validate, recompute bbox, snapshot, refresh."""
+        self._tab.set_refresh_suspended(False)
+        region = self._tab._find_region(self._edit_region_id) if self._edit_region_id else None
+        if region is None:
+            self._pre = None
+            return
+        from core.layout.geometry import validate_segments, segments_bbox
+        if region.shape == "path":
+            issues = validate_segments(region.segments)
+            if issues:
+                import logging
+                logging.getLogger(__name__).warning(
+                    "Geometry edit on %s produced invalid segments; reverting: %s",
+                    region.id, "; ".join(issues))
+                if self._pre is not None:
+                    region.segments, region.points, region.bbox = self._pre
+                self._pre = None
+                self._tab._refresh()
+                return
+            bx, by, bw, bh = segments_bbox(region.segments)
+            region.bbox = (round(bx), round(by), round(bw), round(bh))
+        elif region.shape == "polygon" and region.points:
+            xs = [p[0] for p in region.points]
+            ys = [p[1] for p in region.points]
+            region.bbox = (min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys))
+        self._pre = None
+        self._tab.snapshot_and_refresh(f"edit shape: {region.name or region.id}")

--- a/gui/layout/geometry_editor.py
+++ b/gui/layout/geometry_editor.py
@@ -147,10 +147,10 @@ class GeometryEditor:
         return None
 
     def _clear(self) -> None:
-        scene = self._canvas.scene()
-        if scene is not None:
-            for h in self._handles:
-                scene.removeItem(h)
+        for h in self._handles:
+            s = h.scene()
+            if s is not None:
+                s.removeItem(h)
         self._handles = []
         self._points = []
         self._shape_item = None

--- a/gui/layout/geometry_inspector.py
+++ b/gui/layout/geometry_inspector.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Signal
 
+
 from core.layout.models import Region
 
 
@@ -17,6 +18,7 @@ class GeometryInspector(QWidget):
     bleedToggled = Signal(str, bool)        # (region_id, bleed)
     borderlessToggled = Signal(str, bool)   # (region_id, borderless)
     zChanged = Signal(str, int)             # (region_id, z)
+    editShapeToggled = Signal(str, bool)    # (region_id, on)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -52,11 +54,20 @@ class GeometryInspector(QWidget):
         z_row.addStretch(1)
         root.addLayout(z_row)
 
+        self.edit_shape_chk = QCheckBox("Edit shape (drag vertices)")
+        self.edit_shape_chk.toggled.connect(self._on_edit_shape)
+        root.addWidget(self.edit_shape_chk)
+
     def set_region(self, region: Optional[Region]):
         self._region = region
         enabled = region is not None
         for w in (self.bleed_chk, self.borderless_chk, self.z_spin):
             w.setEnabled(enabled)
+        # Edit-shape applies only to vertex-bearing shapes; reset on every change.
+        self.edit_shape_chk.blockSignals(True)
+        self.edit_shape_chk.setChecked(False)
+        self.edit_shape_chk.setEnabled(bool(region and region.shape in ("path", "polygon")))
+        self.edit_shape_chk.blockSignals(False)
         if region is None:
             self.header.setText("No region selected")
             self.shape_label.setText("")
@@ -85,3 +96,7 @@ class GeometryInspector(QWidget):
     def _on_z(self, value: int):
         if self._region is not None:
             self.zChanged.emit(self._region.id, int(value))
+
+    def _on_edit_shape(self, checked: bool):
+        if self._region is not None:
+            self.editShapeToggled.emit(self._region.id, bool(checked))

--- a/gui/layout/geometry_inspector.py
+++ b/gui/layout/geometry_inspector.py
@@ -1,0 +1,87 @@
+"""Geometry inspector: per-region bleed / borderless / z toggles.
+
+Emits intent signals; ``LayoutTab`` owns the model mutation (same split as
+ContentInspector). The "Edit shape" toggle is added in #5a Task 4.
+"""
+from typing import Optional
+
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QCheckBox, QSpinBox,
+)
+from PySide6.QtCore import Signal
+
+from core.layout.models import Region
+
+
+class GeometryInspector(QWidget):
+    bleedToggled = Signal(str, bool)        # (region_id, bleed)
+    borderlessToggled = Signal(str, bool)   # (region_id, borderless)
+    zChanged = Signal(str, int)             # (region_id, z)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._region: Optional[Region] = None
+        self._build()
+        self.set_region(None)
+
+    def _build(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        self.header = QLabel("No region selected")
+        self.header.setStyleSheet("font-weight: bold;")
+        root.addWidget(self.header)
+
+        self.shape_label = QLabel("")
+        self.shape_label.setStyleSheet("color: #666; font-size: 11px;")
+        root.addWidget(self.shape_label)
+
+        self.bleed_chk = QCheckBox("Bleed (extend to page edge)")
+        self.bleed_chk.toggled.connect(self._on_bleed)
+        root.addWidget(self.bleed_chk)
+
+        self.borderless_chk = QCheckBox("Borderless (no panel stroke)")
+        self.borderless_chk.toggled.connect(self._on_borderless)
+        root.addWidget(self.borderless_chk)
+
+        z_row = QHBoxLayout()
+        z_row.addWidget(QLabel("Z-order:"))
+        self.z_spin = QSpinBox()
+        self.z_spin.setRange(-1000, 1000)
+        self.z_spin.valueChanged.connect(self._on_z)
+        z_row.addWidget(self.z_spin)
+        z_row.addStretch(1)
+        root.addLayout(z_row)
+
+    def set_region(self, region: Optional[Region]):
+        self._region = region
+        enabled = region is not None
+        for w in (self.bleed_chk, self.borderless_chk, self.z_spin):
+            w.setEnabled(enabled)
+        if region is None:
+            self.header.setText("No region selected")
+            self.shape_label.setText("")
+            return
+        self.header.setText(f"Geometry: {region.name or region.id}")
+        self.shape_label.setText(f"shape: {region.shape}")
+        stroke = region.image_style.stroke_px if region.image_style else 0
+        self.bleed_chk.blockSignals(True)
+        self.bleed_chk.setChecked(bool(region.bleed))
+        self.bleed_chk.blockSignals(False)
+        self.borderless_chk.blockSignals(True)
+        self.borderless_chk.setChecked(stroke == 0)
+        self.borderless_chk.blockSignals(False)
+        self.z_spin.blockSignals(True)
+        self.z_spin.setValue(int(region.z))
+        self.z_spin.blockSignals(False)
+
+    def _on_bleed(self, checked: bool):
+        if self._region is not None:
+            self.bleedToggled.emit(self._region.id, bool(checked))
+
+    def _on_borderless(self, checked: bool):
+        if self._region is not None:
+            self.borderlessToggled.emit(self._region.id, bool(checked))
+
+    def _on_z(self, value: int):
+        if self._region is not None:
+            self.zChanged.emit(self._region.id, int(value))

--- a/gui/layout/geometry_inspector.py
+++ b/gui/layout/geometry_inspector.py
@@ -6,7 +6,7 @@ ContentInspector). The "Edit shape" toggle is added in #5a Task 4.
 from typing import Optional
 
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QCheckBox, QSpinBox,
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QCheckBox, QSpinBox, QPushButton,
 )
 from PySide6.QtCore import Signal
 
@@ -19,6 +19,9 @@ class GeometryInspector(QWidget):
     borderlessToggled = Signal(str, bool)   # (region_id, borderless)
     zChanged = Signal(str, int)             # (region_id, z)
     editShapeToggled = Signal(str, bool)    # (region_id, on)
+    deleteRequested = Signal(str)        # (region_id)
+    knifeToggled = Signal(str, bool)     # (region_id, on)
+    mergeToggled = Signal(str, bool)     # (region_id, on)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -58,6 +61,20 @@ class GeometryInspector(QWidget):
         self.edit_shape_chk.toggled.connect(self._on_edit_shape)
         root.addWidget(self.edit_shape_chk)
 
+        ops_row = QHBoxLayout()
+        self.delete_btn = QPushButton("Delete panel")
+        self.delete_btn.clicked.connect(self._on_delete)
+        ops_row.addWidget(self.delete_btn)
+        self.knife_btn = QPushButton("Knife (split)")
+        self.knife_btn.setCheckable(True)
+        self.knife_btn.toggled.connect(self._on_knife)
+        ops_row.addWidget(self.knife_btn)
+        self.merge_btn = QPushButton("Merge…")
+        self.merge_btn.setCheckable(True)
+        self.merge_btn.toggled.connect(self._on_merge)
+        ops_row.addWidget(self.merge_btn)
+        root.addLayout(ops_row)
+
     def set_region(self, region: Optional[Region]):
         self._region = region
         enabled = region is not None
@@ -68,6 +85,12 @@ class GeometryInspector(QWidget):
         self.edit_shape_chk.setChecked(False)
         self.edit_shape_chk.setEnabled(bool(region and region.shape in ("path", "polygon")))
         self.edit_shape_chk.blockSignals(False)
+        for btn in (self.knife_btn, self.merge_btn):
+            btn.blockSignals(True)
+            btn.setChecked(False)
+            btn.setEnabled(region is not None)
+            btn.blockSignals(False)
+        self.delete_btn.setEnabled(region is not None)
         if region is None:
             self.header.setText("No region selected")
             self.shape_label.setText("")
@@ -100,3 +123,15 @@ class GeometryInspector(QWidget):
     def _on_edit_shape(self, checked: bool):
         if self._region is not None:
             self.editShapeToggled.emit(self._region.id, bool(checked))
+
+    def _on_delete(self):
+        if self._region is not None:
+            self.deleteRequested.emit(self._region.id)
+
+    def _on_knife(self, checked: bool):
+        if self._region is not None:
+            self.knifeToggled.emit(self._region.id, bool(checked))
+
+    def _on_merge(self, checked: bool):
+        if self._region is not None:
+            self.mergeToggled.emit(self._region.id, bool(checked))

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -89,6 +89,9 @@ class LayoutTab(QWidget):
         self.canvas = CanvasWidget()
         root.addWidget(self.canvas, 1)
 
+        from gui.layout.geometry_editor import GeometryEditor
+        self.geometry_editor = GeometryEditor(self.canvas, self)
+
         self.inspector = ContentInspector(self.config)
         self.inspector.regionContentChanged.connect(self._on_region_content_changed)
         self.inspector.regionTextStyleChanged.connect(self._on_region_text_style_changed)
@@ -102,6 +105,7 @@ class LayoutTab(QWidget):
         self.geometry_inspector.bleedToggled.connect(self._on_region_bleed_toggled)
         self.geometry_inspector.borderlessToggled.connect(self._on_region_borderless_toggled)
         self.geometry_inspector.zChanged.connect(self._on_region_z_changed)
+        self.geometry_inspector.editShapeToggled.connect(self._on_region_edit_shape_toggled)
         root.addWidget(self.geometry_inspector)
 
         self.canvas.regionSelected.connect(self._on_region_selected)
@@ -141,6 +145,9 @@ class LayoutTab(QWidget):
             self.canvas.load_page(self.document.pages[0], self.document.style,
                                   locked=self._locked)
             self.status.setText(f"{self.document.title} — {self.document.pages[0].page_size_px}")
+            ge = getattr(self, "geometry_editor", None)
+            if ge is not None:
+                ge.rebuild_handles()
         self.documentChanged.emit()
 
     # --- lock state (frames + applied text stay put until unlocked) ---
@@ -239,6 +246,10 @@ class LayoutTab(QWidget):
             ts = styles.effective_text_style(region, style)
         self.inspector.set_region(region, text_style=ts)
         self.geometry_inspector.set_region(region)
+        self.geometry_editor.set_edit_region(None)
+
+    def _on_region_edit_shape_toggled(self, region_id: str, on: bool):
+        self.geometry_editor.set_edit_region(region_id if on else None)
 
     def _on_region_content_changed(self, region_id: str, value: str):
         self.set_region_content(region_id, value)

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -54,6 +54,7 @@ class LayoutTab(QWidget):
         for label, slot in [
             ("New", self.new_document), ("Open…", self._open_dialog),
             ("Save…", self._save_dialog), ("Export PDF…", self._export_dialog),
+            ("Export PNG…", self._export_png_dialog),
             ("History…", self._open_history),
             ("Export Template…", self._export_template_dialog),
             ("Import Template…", self._import_template_dialog),
@@ -650,6 +651,14 @@ class LayoutTab(QWidget):
         qt_renderer.export_document_pdf(self.document, path)
         self.status.setText(f"Exported {path}")
 
+    def export_png_to(self, path: str):
+        if self.document is None or not self.document.pages:
+            return
+        from core.layout import qt_renderer
+        style = self.document.style if self.document else None
+        qt_renderer.save_page_png(self.document.pages[0], path, style=style)
+        self.status.setText(f"Exported {path}")
+
     # --- designer + history methods ---
     def _on_design_clicked(self):
         if not self.document or not self.document.pages:
@@ -840,3 +849,12 @@ class LayoutTab(QWidget):
                 self.export_pdf_to(path)
             except Exception as e:  # noqa: BLE001 - surfaced to UI + log
                 self._report_error("export PDF", e)
+
+    def _export_png_dialog(self):
+        from PySide6.QtWidgets import QFileDialog
+        path, _ = QFileDialog.getSaveFileName(self, "Export PNG", "", "PNG Images (*.png)")
+        if path:
+            try:
+                self.export_png_to(path)
+            except Exception as e:  # noqa: BLE001
+                self._report_error("export png", e)

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -94,6 +94,9 @@ class LayoutTab(QWidget):
         from gui.layout.geometry_editor import GeometryEditor
         self.geometry_editor = GeometryEditor(self.canvas, self)
 
+        from gui.layout.overlay_editor import OverlayEditor
+        self.overlay_editor = OverlayEditor(self.canvas, self)
+
         self.inspector = ContentInspector(self.config)
         self.inspector.regionContentChanged.connect(self._on_region_content_changed)
         self.inspector.regionTextStyleChanged.connect(self._on_region_text_style_changed)
@@ -157,6 +160,9 @@ class LayoutTab(QWidget):
             ge = getattr(self, "geometry_editor", None)
             if ge is not None:
                 ge.rebuild_handles()
+            oe = getattr(self, "overlay_editor", None)
+            if oe is not None:
+                oe.rebuild_handles()
         self.documentChanged.emit()
 
     def set_refresh_suspended(self, on: bool):

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -97,6 +97,15 @@ class LayoutTab(QWidget):
         from gui.layout.overlay_editor import OverlayEditor
         self.overlay_editor = OverlayEditor(self.canvas, self)
 
+        from gui.layout.overlay_inspector import OverlayInspector
+        self.overlay_inspector = OverlayInspector()
+        self.overlay_inspector.addRequested.connect(self._add_overlay)
+        self.overlay_inspector.deleteRequested.connect(self._delete_overlay)
+        self.overlay_inspector.rotationChanged.connect(self._set_overlay_rotation)
+        self.overlay_inspector.overlaySelected.connect(self._on_overlay_selected)
+        self.overlay_inspector.editToggled.connect(self._on_overlay_edit_toggled)
+        root.addWidget(self.overlay_inspector)
+
         self.inspector = ContentInspector(self.config)
         self.inspector.regionContentChanged.connect(self._on_region_content_changed)
         self.inspector.regionTextStyleChanged.connect(self._on_region_text_style_changed)
@@ -163,6 +172,9 @@ class LayoutTab(QWidget):
             oe = getattr(self, "overlay_editor", None)
             if oe is not None:
                 oe.rebuild_handles()
+            oi = getattr(self, "overlay_inspector", None)
+            if oi is not None and self.document and self.document.pages:
+                oi.set_page(self.document.pages[0])
         self.documentChanged.emit()
 
     def set_refresh_suspended(self, on: bool):
@@ -441,6 +453,72 @@ class LayoutTab(QWidget):
             self.history.append(f"z: {region.name or region.id}")
         self._refresh()
 
+    # --- overlay handlers ---
+    _OVERLAY_DEFAULT_TEXT = {
+        "speech": "Dialogue", "thought": "Thinking…",
+        "caption": "Caption", "sfx": "POW!",
+    }
+
+    def _new_overlay_id(self, page) -> str:
+        n = 1
+        existing = {o.id for o in page.overlays}
+        while f"ov{n}" in existing:
+            n += 1
+        return f"ov{n}"
+
+    def _add_overlay(self, kind: str) -> bool:
+        from core.layout.models import Overlay
+        page = self._current_page()
+        if page is None or kind not in ("speech", "thought", "caption", "sfx"):
+            return False
+        pw, ph = page.page_size_px
+        cx, cy = pw / 2.0, ph / 2.0
+        tail = (cx, cy + 80.0) if kind in ("speech", "thought") else None
+        ov = Overlay(id=self._new_overlay_id(page), kind=kind,
+                     text=self._OVERLAY_DEFAULT_TEXT.get(kind, ""),
+                     anchor=(cx, cy), tail_target=tail)
+        page.overlays.append(ov)
+        self.snapshot_and_refresh(f"add {kind} overlay")
+        self.overlay_inspector.set_selected(ov.id)
+        return True
+
+    def _find_overlay(self, overlay_id):
+        page = self._current_page()
+        if page is None:
+            return None
+        for ov in page.overlays:
+            if ov.id == overlay_id:
+                return ov
+        return None
+
+    def _delete_overlay(self, overlay_id: str) -> bool:
+        page = self._current_page()
+        if page is None:
+            return False
+        for i, ov in enumerate(page.overlays):
+            if ov.id == overlay_id:
+                if self.overlay_editor.active_overlay_id() == overlay_id:
+                    self.overlay_editor.set_edit_overlay(None)
+                del page.overlays[i]
+                self.snapshot_and_refresh(f"delete overlay: {overlay_id}")
+                return True
+        return False
+
+    def _set_overlay_rotation(self, overlay_id: str, deg: int) -> bool:
+        ov = self._find_overlay(overlay_id)
+        if ov is None:
+            return False
+        ov.rotation = float(deg)
+        self.snapshot_and_refresh(f"rotate overlay: {overlay_id}")
+        return True
+
+    def _on_overlay_selected(self, overlay_id: str):
+        self.overlay_inspector.set_selected(overlay_id)
+        self.overlay_editor.set_edit_overlay(None)
+
+    def _on_overlay_edit_toggled(self, overlay_id: str, on: bool):
+        self.overlay_editor.set_edit_overlay(overlay_id if on else None)
+
     def set_region_content(self, region_id: str, value: str):
         """Apply edited content to a region and re-render (programmatic API)."""
         region = self._find_region(region_id)
@@ -604,6 +682,10 @@ class LayoutTab(QWidget):
         if getattr(result, "overlays", None):
             self.document.pages[0].overlays = list(result.overlays)
             applied = True
+        elif result.regions:
+            # Regions-only redesign: tidy overlays stranded over the new panels.
+            from core.layout.overlay_ops import reposition_stranded_overlays
+            reposition_stranded_overlays(self.document.pages[0])
         if applied:
             self.history.append(user_text or "design")
             self._refresh()

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -328,6 +328,10 @@ class LayoutTab(QWidget):
             self._knife_region_id = region_id
             self.canvas.set_tool_mode("knife")
             self.status.setText("Knife: click two points to cut the panel")
+            insp = self.geometry_inspector
+            insp.knife_btn.blockSignals(True)
+            insp.knife_btn.setChecked(True)
+            insp.knife_btn.blockSignals(False)
         else:
             self._knife_region_id = None
             self.canvas.set_tool_mode("none")
@@ -337,6 +341,7 @@ class LayoutTab(QWidget):
         self._knife_region_id = None
         if rid:
             self._apply_knife(rid, (x1, y1), (x2, y2))
+        self._reset_region_tools()
 
     def _on_region_merge_toggled(self, region_id: str, on: bool):
         if on:
@@ -352,6 +357,19 @@ class LayoutTab(QWidget):
         self._merge_base_id = None
         if base:
             self._apply_merge(base, other_id)
+        self._reset_region_tools()
+
+    def _reset_region_tools(self):
+        """Disarm knife/merge: clear canvas tool mode, stashed ids, and uncheck the
+        inspector toggles (without re-emitting their toggled signals)."""
+        self.canvas.set_tool_mode("none")
+        self._knife_region_id = None
+        self._merge_base_id = None
+        insp = self.geometry_inspector
+        for btn in (insp.knife_btn, insp.merge_btn):
+            btn.blockSignals(True)
+            btn.setChecked(False)
+            btn.blockSignals(False)
 
     def _on_region_selected(self, region_id: str):
         region = self._find_region(region_id)
@@ -362,6 +380,7 @@ class LayoutTab(QWidget):
         self.inspector.set_region(region, text_style=ts)
         self.geometry_inspector.set_region(region)
         self.geometry_editor.set_edit_region(None)
+        self._reset_region_tools()
 
     def _on_region_edit_shape_toggled(self, region_id: str, on: bool):
         self.geometry_editor.set_edit_region(region_id if on else None)

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -42,6 +42,8 @@ class LayoutTab(QWidget):
         self.history: Optional[History] = None
         self._prompt_worker = None  # keep alive so the QThread isn't GC'd mid-run
         self._locked = self._load_locked()
+        self._knife_region_id = None
+        self._merge_base_id = None
         self._build()
         self._restore_session_or_new()
 
@@ -106,9 +108,14 @@ class LayoutTab(QWidget):
         self.geometry_inspector.borderlessToggled.connect(self._on_region_borderless_toggled)
         self.geometry_inspector.zChanged.connect(self._on_region_z_changed)
         self.geometry_inspector.editShapeToggled.connect(self._on_region_edit_shape_toggled)
+        self.geometry_inspector.deleteRequested.connect(self._on_region_delete_requested)
+        self.geometry_inspector.knifeToggled.connect(self._on_region_knife_toggled)
+        self.geometry_inspector.mergeToggled.connect(self._on_region_merge_toggled)
         root.addWidget(self.geometry_inspector)
 
         self.canvas.regionSelected.connect(self._on_region_selected)
+        self.canvas.knifeLine.connect(self._on_canvas_knife_line)
+        self.canvas.mergeTarget.connect(self._on_canvas_merge_target)
 
         self.status = QLabel("")
         root.addWidget(self.status)
@@ -312,6 +319,39 @@ class LayoutTab(QWidget):
         del page.regions[oi]  # replacing base did not change length, so oi is valid
         self.snapshot_and_refresh(f"merge panels: {base_id} + {other_id}")
         return True
+
+    def _on_region_delete_requested(self, region_id: str):
+        self._apply_delete(region_id)
+
+    def _on_region_knife_toggled(self, region_id: str, on: bool):
+        if on:
+            self._knife_region_id = region_id
+            self.canvas.set_tool_mode("knife")
+            self.status.setText("Knife: click two points to cut the panel")
+        else:
+            self._knife_region_id = None
+            self.canvas.set_tool_mode("none")
+
+    def _on_canvas_knife_line(self, x1: float, y1: float, x2: float, y2: float):
+        rid = self._knife_region_id
+        self._knife_region_id = None
+        if rid:
+            self._apply_knife(rid, (x1, y1), (x2, y2))
+
+    def _on_region_merge_toggled(self, region_id: str, on: bool):
+        if on:
+            self._merge_base_id = region_id
+            self.canvas.set_tool_mode("merge")
+            self.status.setText("Merge: click an adjacent panel")
+        else:
+            self._merge_base_id = None
+            self.canvas.set_tool_mode("none")
+
+    def _on_canvas_merge_target(self, other_id: str):
+        base = self._merge_base_id
+        self._merge_base_id = None
+        if base:
+            self._apply_merge(base, other_id)
 
     def _on_region_selected(self, region_id: str):
         region = self._find_region(region_id)

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -141,6 +141,8 @@ class LayoutTab(QWidget):
         self._refresh()
 
     def _refresh(self):
+        if getattr(self, "_suspend_refresh", False):
+            return
         if self.document and self.document.pages:
             self.canvas.load_page(self.document.pages[0], self.document.style,
                                   locked=self._locked)
@@ -149,6 +151,15 @@ class LayoutTab(QWidget):
             if ge is not None:
                 ge.rebuild_handles()
         self.documentChanged.emit()
+
+    def set_refresh_suspended(self, on: bool):
+        """Block scene rebuilds during an active handle drag (else handles vanish)."""
+        self._suspend_refresh = bool(on)
+
+    def snapshot_and_refresh(self, prompt: str):
+        if self.history is not None:
+            self.history.append(prompt)
+        self._refresh()
 
     # --- lock state (frames + applied text stay put until unlocked) ---
     def _load_locked(self) -> bool:

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -405,8 +405,14 @@ class LayoutTab(QWidget):
                 self.document.style = styles.default_style_for(kind)
                 if hasattr(self, "style_panel"):
                     self.style_panel.set_style(self.document.style)
+        applied = False
         if result.regions:
             self.document.pages[0].regions = list(result.regions)
+            applied = True
+        if getattr(result, "overlays", None):
+            self.document.pages[0].overlays = list(result.overlays)
+            applied = True
+        if applied:
             self.history.append(user_text or "design")
             self._refresh()
         elif result.questions:

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -302,7 +302,6 @@ class LayoutTab(QWidget):
         return True
 
     def _apply_knife(self, region_id: str, a, b) -> bool:
-        import logging
         page = self._current_page()
         idx = self._region_index(region_id)
         if page is None or idx is None:
@@ -310,7 +309,7 @@ class LayoutTab(QWidget):
         from core.layout.region_ops import split_region
         out = split_region(page.regions[idx], a, b)
         if out is None:
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "knife: cut missed or unsupported shape for region %s", region_id)
             self.status.setText("Cannot split — the cut line missed the panel")
             return False
@@ -319,7 +318,6 @@ class LayoutTab(QWidget):
         return True
 
     def _apply_merge(self, base_id: str, other_id: str) -> bool:
-        import logging
         page = self._current_page()
         if page is None or base_id == other_id:
             return False
@@ -330,7 +328,7 @@ class LayoutTab(QWidget):
         from core.layout.region_ops import merge_regions
         merged = merge_regions(page.regions[bi], page.regions[oi])
         if merged is None:
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "merge: regions %s + %s are not adjacent", base_id, other_id)
             self.status.setText("Cannot merge — panels are not adjacent")
             return False

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -249,6 +249,70 @@ class LayoutTab(QWidget):
                 return r
         return None
 
+    def _current_page(self):
+        if not self.document or not self.document.pages:
+            return None
+        return self.document.pages[0]
+
+    def _region_index(self, region_id: str):
+        page = self._current_page()
+        if page is None:
+            return None
+        for i, r in enumerate(page.regions):
+            if r.id == region_id:
+                return i
+        return None
+
+    def _apply_delete(self, region_id: str) -> bool:
+        page = self._current_page()
+        idx = self._region_index(region_id)
+        if page is None or idx is None:
+            return False
+        if self.geometry_editor.active_region_id() == region_id:
+            self.geometry_editor.set_edit_region(None)
+        region = page.regions[idx]
+        del page.regions[idx]
+        self.snapshot_and_refresh(f"delete panel: {region.name or region.id}")
+        return True
+
+    def _apply_knife(self, region_id: str, a, b) -> bool:
+        import logging
+        page = self._current_page()
+        idx = self._region_index(region_id)
+        if page is None or idx is None:
+            return False
+        from core.layout.region_ops import split_region
+        out = split_region(page.regions[idx], a, b)
+        if out is None:
+            logging.getLogger(__name__).warning(
+                "knife: cut missed or unsupported shape for region %s", region_id)
+            self.status.setText("Cannot split — the cut line missed the panel")
+            return False
+        page.regions[idx:idx + 1] = list(out)
+        self.snapshot_and_refresh(f"split panel: {region_id}")
+        return True
+
+    def _apply_merge(self, base_id: str, other_id: str) -> bool:
+        import logging
+        page = self._current_page()
+        if page is None or base_id == other_id:
+            return False
+        bi = self._region_index(base_id)
+        oi = self._region_index(other_id)
+        if bi is None or oi is None:
+            return False
+        from core.layout.region_ops import merge_regions
+        merged = merge_regions(page.regions[bi], page.regions[oi])
+        if merged is None:
+            logging.getLogger(__name__).warning(
+                "merge: regions %s + %s are not adjacent", base_id, other_id)
+            self.status.setText("Cannot merge — panels are not adjacent")
+            return False
+        page.regions[bi] = merged
+        del page.regions[oi]  # replacing base did not change length, so oi is valid
+        self.snapshot_and_refresh(f"merge panels: {base_id} + {other_id}")
+        return True
+
     def _on_region_selected(self, region_id: str):
         region = self._find_region(region_id)
         ts = None

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -22,6 +22,8 @@ from gui.layout.content_inspector import ContentInspector
 
 logger = logging.getLogger("imageai.layout.tab")
 
+_DEFAULT_STROKE_PX = 4  # panel stroke applied when "borderless" is unchecked
+
 
 class LayoutTab(QWidget):
     documentChanged = Signal()
@@ -94,6 +96,14 @@ class LayoutTab(QWidget):
         self.inspector.regionPromptSuggestRequested.connect(self._on_region_prompt_suggest)
         self.inspector.regionSendToImageRequested.connect(self._on_region_send_to_image)
         root.addWidget(self.inspector)
+
+        from gui.layout.geometry_inspector import GeometryInspector
+        self.geometry_inspector = GeometryInspector()
+        self.geometry_inspector.bleedToggled.connect(self._on_region_bleed_toggled)
+        self.geometry_inspector.borderlessToggled.connect(self._on_region_borderless_toggled)
+        self.geometry_inspector.zChanged.connect(self._on_region_z_changed)
+        root.addWidget(self.geometry_inspector)
+
         self.canvas.regionSelected.connect(self._on_region_selected)
 
         self.status = QLabel("")
@@ -228,6 +238,7 @@ class LayoutTab(QWidget):
             style = self.document.style if self.document else None
             ts = styles.effective_text_style(region, style)
         self.inspector.set_region(region, text_style=ts)
+        self.geometry_inspector.set_region(region)
 
     def _on_region_content_changed(self, region_id: str, value: str):
         self.set_region_content(region_id, value)
@@ -247,6 +258,36 @@ class LayoutTab(QWidget):
             size_px=size_px, line_height=base.line_height, color=base.color,
             align=base.align, wrap=base.wrap, letter_spacing=base.letter_spacing,
         )
+        self._refresh()
+
+    def _on_region_bleed_toggled(self, region_id: str, bleed: bool):
+        region = self._find_region(region_id)
+        if region is None:
+            return
+        region.bleed = bool(bleed)
+        if self.history is not None:
+            self.history.append(f"bleed: {region.name or region.id}")
+        self._refresh()
+
+    def _on_region_borderless_toggled(self, region_id: str, borderless: bool):
+        region = self._find_region(region_id)
+        if region is None:
+            return
+        from core.layout.models import ImageStyle
+        if region.image_style is None:
+            region.image_style = ImageStyle()
+        region.image_style.stroke_px = 0 if borderless else _DEFAULT_STROKE_PX
+        if self.history is not None:
+            self.history.append(f"borderless: {region.name or region.id}")
+        self._refresh()
+
+    def _on_region_z_changed(self, region_id: str, z: int):
+        region = self._find_region(region_id)
+        if region is None:
+            return
+        region.z = int(z)
+        if self.history is not None:
+            self.history.append(f"z: {region.name or region.id}")
         self._refresh()
 
     def set_region_content(self, region_id: str, value: str):

--- a/gui/layout/overlay_editor.py
+++ b/gui/layout/overlay_editor.py
@@ -1,0 +1,133 @@
+"""Manual overlay editor: body/tail drag handles layered on the canvas.
+
+Mirrors GeometryEditor: handles are regenerated from the model after each scene
+rebuild (LayoutTab._refresh), not preserved. Move-only. Tail drags snap to the
+nearest region center on commit.
+"""
+from typing import List, Optional
+
+from PySide6.QtWidgets import QGraphicsEllipseItem, QGraphicsItem
+from PySide6.QtGui import QBrush, QPen, QColor
+from PySide6.QtCore import QRectF
+
+_HANDLE_R = 6.0
+_SNAP_RADIUS = 40.0  # px: tail snaps to a region center within this distance
+
+
+class _OvHandle(QGraphicsEllipseItem):
+    """A draggable overlay handle. ``kind`` is "body" or "tail"."""
+
+    def __init__(self, editor: "OverlayEditor", kind: str):
+        super().__init__()
+        self._editor = editor
+        self._kind = kind
+        self.setFlag(QGraphicsItem.ItemIsMovable, True)
+        self.setFlag(QGraphicsItem.ItemSendsGeometryChanges, True)
+
+    def mousePressEvent(self, event):
+        self._editor.begin_edit()
+        super().mousePressEvent(event)
+
+    def itemChange(self, change, value):
+        if change == QGraphicsItem.ItemPositionHasChanged:
+            self._editor.move_handle(self._kind, self.x(), self.y())
+        return super().itemChange(change, value)
+
+    def mouseReleaseEvent(self, event):
+        super().mouseReleaseEvent(event)
+        self._editor.commit()
+
+
+class OverlayEditor:
+    """Owns body/tail drag handles for one selected overlay on a canvas."""
+
+    def __init__(self, canvas, layout_tab):
+        self._canvas = canvas
+        self._tab = layout_tab
+        self._edit_id: Optional[str] = None
+        self._handles: List[_OvHandle] = []
+        self._pre = None
+
+    def active_overlay_id(self) -> Optional[str]:
+        return self._edit_id
+
+    def set_edit_overlay(self, overlay_id: Optional[str]) -> None:
+        self._edit_id = overlay_id or None
+        self.rebuild_handles()
+
+    def _find_overlay(self, overlay_id):
+        page = self._tab._current_page()
+        if page is None or not overlay_id:
+            return None
+        for ov in page.overlays:
+            if ov.id == overlay_id:
+                return ov
+        return None
+
+    def _clear(self):
+        for h in self._handles:
+            s = h.scene()
+            if s is not None:
+                s.removeItem(h)
+        self._handles = []
+
+    def rebuild_handles(self) -> None:
+        self._clear()
+        ov = self._find_overlay(self._edit_id)
+        if ov is None:
+            self._edit_id = None
+            return
+        scene = self._canvas.scene()
+        if scene is None:
+            return
+        self._add_handle("body", ov.anchor)
+        if ov.tail_target is not None:
+            self._add_handle("tail", ov.tail_target)
+
+    def _add_handle(self, kind: str, pos):
+        scene = self._canvas.scene()
+        h = _OvHandle(self, kind)
+        h.setRect(QRectF(-_HANDLE_R, -_HANDLE_R, 2 * _HANDLE_R, 2 * _HANDLE_R))
+        h.setPos(pos[0], pos[1])
+        h.setZValue(1_000_000)
+        h.setBrush(QBrush(QColor("#E84A5F") if kind == "tail" else QColor("#2D7DD2")))
+        h.setPen(QPen(QColor("#FFFFFF"), 1.5))
+        scene.addItem(h)
+        self._handles.append(h)
+
+    def begin_edit(self) -> None:
+        ov = self._find_overlay(self._edit_id)
+        if ov is None:
+            self._pre = None
+            return
+        self._pre = (ov.anchor, ov.tail_target)
+        self._tab.set_refresh_suspended(True)
+
+    def move_handle(self, kind: str, x: float, y: float) -> None:
+        ov = self._find_overlay(self._edit_id)
+        if ov is None:
+            return
+        if kind == "body":
+            ov.anchor = (x, y)
+        elif kind == "tail":
+            ov.tail_target = (x, y)
+
+    def commit(self) -> None:
+        self._tab.set_refresh_suspended(False)
+        ov = self._find_overlay(self._edit_id)
+        if ov is None:
+            self._pre = None
+            return
+        # Tail snaps to the nearest region center within the snap radius.
+        if ov.tail_target is not None:
+            from core.layout.overlay_ops import nearest_region_center
+            page = self._tab._current_page()
+            regions = list(page.regions) if page is not None else []
+            center = nearest_region_center(ov.tail_target, regions)
+            if center is not None:
+                dx = center[0] - ov.tail_target[0]
+                dy = center[1] - ov.tail_target[1]
+                if (dx * dx + dy * dy) ** 0.5 <= _SNAP_RADIUS:
+                    ov.tail_target = center
+        self._pre = None
+        self._tab.snapshot_and_refresh(f"edit overlay: {ov.id}")

--- a/gui/layout/overlay_inspector.py
+++ b/gui/layout/overlay_inspector.py
@@ -1,0 +1,126 @@
+"""Overlay inspector: list + author comic text overlays.
+
+Emits intent signals only; ``LayoutTab`` owns all model mutation (same split as
+Geometry/Content inspectors).
+"""
+from typing import Optional
+
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QListWidget, QListWidgetItem,
+    QPushButton, QSpinBox, QCheckBox,
+)
+from PySide6.QtCore import Signal, Qt
+
+from core.layout.models import PageSpec, Overlay
+
+
+class OverlayInspector(QWidget):
+    addRequested = Signal(str)        # (kind)
+    deleteRequested = Signal(str)     # (overlay_id)
+    rotationChanged = Signal(str, int)  # (overlay_id, degrees)
+    overlaySelected = Signal(str)     # (overlay_id)
+    editToggled = Signal(str, bool)   # (overlay_id, on)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._selected_id: Optional[str] = None
+        self._build()
+        self.set_selected(None)
+
+    def _build(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.addWidget(QLabel("Overlays"))
+
+        self.overlay_list = QListWidget()
+        self.overlay_list.itemSelectionChanged.connect(self._on_row_changed)
+        root.addWidget(self.overlay_list)
+
+        add_row = QHBoxLayout()
+        self.add_speech_btn = QPushButton("+Speech")
+        self.add_thought_btn = QPushButton("+Thought")
+        self.add_caption_btn = QPushButton("+Caption")
+        self.add_sfx_btn = QPushButton("+SFX")
+        for btn, kind in ((self.add_speech_btn, "speech"),
+                          (self.add_thought_btn, "thought"),
+                          (self.add_caption_btn, "caption"),
+                          (self.add_sfx_btn, "sfx")):
+            btn.clicked.connect(lambda _checked=False, k=kind: self.addRequested.emit(k))
+            add_row.addWidget(btn)
+        root.addLayout(add_row)
+
+        edit_row = QHBoxLayout()
+        self.delete_btn = QPushButton("Delete overlay")
+        self.delete_btn.clicked.connect(self._on_delete)
+        edit_row.addWidget(self.delete_btn)
+        self.edit_chk = QCheckBox("Edit on canvas")
+        self.edit_chk.toggled.connect(self._on_edit)
+        edit_row.addWidget(self.edit_chk)
+        edit_row.addStretch(1)
+        root.addLayout(edit_row)
+
+        rot_row = QHBoxLayout()
+        rot_row.addWidget(QLabel("Rotation:"))
+        self.rotation_spin = QSpinBox()
+        self.rotation_spin.setRange(0, 359)
+        self.rotation_spin.setSuffix("°")
+        self.rotation_spin.valueChanged.connect(self._on_rotation)
+        rot_row.addWidget(self.rotation_spin)
+        rot_row.addStretch(1)
+        root.addLayout(rot_row)
+
+    def set_page(self, page: Optional[PageSpec]):
+        self.overlay_list.blockSignals(True)
+        self.overlay_list.clear()
+        if page is not None:
+            for ov in page.overlays:
+                item = QListWidgetItem(f"{ov.kind}: {ov.text[:20]}")
+                item.setData(Qt.UserRole, ov.id)
+                item._rotation = int(getattr(ov, "rotation", 0) or 0)
+                self.overlay_list.addItem(item)
+        self.overlay_list.blockSignals(False)
+        self.set_selected(self._selected_id)
+
+    def set_selected(self, overlay_id: Optional[str]):
+        self._selected_id = overlay_id
+        enabled = overlay_id is not None
+        for w in (self.delete_btn, self.rotation_spin, self.edit_chk):
+            w.setEnabled(enabled)
+        # reflect rotation + edit toggle from the listed item, if present
+        rot = 0
+        for i in range(self.overlay_list.count()):
+            it = self.overlay_list.item(i)
+            if it.data(Qt.UserRole) == overlay_id:
+                self.overlay_list.blockSignals(True)
+                self.overlay_list.setCurrentRow(i)
+                self.overlay_list.blockSignals(False)
+                rot = getattr(it, "_rotation", 0)
+                break
+        self.edit_chk.blockSignals(True)
+        self.edit_chk.setChecked(False)
+        self.edit_chk.blockSignals(False)
+        self.rotation_spin.blockSignals(True)
+        self.rotation_spin.setValue(int(rot))
+        self.rotation_spin.blockSignals(False)
+
+    def _selected_overlay_id(self) -> Optional[str]:
+        it = self.overlay_list.currentItem()
+        return it.data(Qt.UserRole) if it is not None else None
+
+    def _on_row_changed(self):
+        oid = self._selected_overlay_id()
+        if oid is not None:
+            self._selected_id = oid
+            self.overlaySelected.emit(oid)
+
+    def _on_delete(self):
+        if self._selected_id is not None:
+            self.deleteRequested.emit(self._selected_id)
+
+    def _on_rotation(self, value: int):
+        if self._selected_id is not None:
+            self.rotationChanged.emit(self._selected_id, int(value))
+
+    def _on_edit(self, checked: bool):
+        if self._selected_id is not None:
+            self.editToggled.emit(self._selected_id, bool(checked))

--- a/tests/layout/test_balloons.py
+++ b/tests/layout/test_balloons.py
@@ -1,0 +1,55 @@
+from core.layout.balloons import caption_body, speech_body, overlay_to_segments
+from core.layout.models import OverlayStyle
+from core.layout.geometry import validate_segments, segments_bbox
+
+
+INNER = (10.0, 20.0, 80.0, 40.0)  # x, y, w, h
+
+
+def _contains(bbox, inner, tol=1e-6):
+    bx, by, bw, bh = bbox
+    ix, iy, iw, ih = inner
+    return (bx <= ix + tol and by <= iy + tol
+            and bx + bw >= ix + iw - tol and by + bh >= iy + ih - tol)
+
+
+def test_caption_body_is_rectangle():
+    segs = caption_body(INNER)
+    assert validate_segments(segs) == []
+    assert [s.type for s in segs] == ["move", "line", "line", "line", "close"]
+    assert _contains(segments_bbox(segs), INNER)
+
+
+def test_speech_body_valid_rounded_and_contains_inner():
+    segs = speech_body(INNER, radius=12.0)
+    assert validate_segments(segs) == []
+    assert any(s.type == "cubic" for s in segs)        # rounded corners
+    bbox = segments_bbox(segs)
+    assert _contains(bbox, INNER)
+    # rounded rect bbox equals inner bounds (corner controls stay inside)
+    assert abs(bbox[2] - INNER[2]) < 1e-6 and abs(bbox[3] - INNER[3]) < 1e-6
+
+
+def test_speech_radius_clamped_to_half_extent():
+    # radius larger than half the smaller side must not invert the body
+    segs = speech_body((0.0, 0.0, 20.0, 10.0), radius=999.0)
+    assert validate_segments(segs) == []
+    assert segments_bbox(segs)[2:] == (20.0, 10.0)
+
+
+def test_overlay_to_segments_caption_and_speech_and_sfx():
+    style = OverlayStyle(radius_px=10.0)
+    assert overlay_to_segments("caption", INNER, None, style) == caption_body(INNER)
+    speech = overlay_to_segments("speech", INNER, None, style)
+    assert validate_segments(speech) == []
+    assert any(s.type == "cubic" for s in speech)      # speech uses rounded body
+    assert overlay_to_segments("sfx", INNER, None, style) == []  # sfx has no body
+
+
+def test_overlay_to_segments_degenerate_logs_and_empty(caplog):
+    import logging
+    style = OverlayStyle()
+    with caplog.at_level(logging.WARNING):
+        assert overlay_to_segments("speech", (0.0, 0.0, 0.0, 30.0), None, style) == []
+    assert any("degenerate" in r.message.lower() or "non-positive" in r.message.lower()
+               for r in caplog.records)

--- a/tests/layout/test_balloons.py
+++ b/tests/layout/test_balloons.py
@@ -1,4 +1,4 @@
-from core.layout.balloons import caption_body, speech_body, overlay_to_segments
+from core.layout.balloons import caption_body, speech_body, overlay_to_segments, thought_body, thought_trail
 from core.layout.models import OverlayStyle
 from core.layout.geometry import validate_segments, segments_bbox
 
@@ -95,3 +95,33 @@ def test_speech_tail_single_closed_ring():
     segs = overlay_to_segments("speech", INNER, (50.0, 120.0), style)
     assert sum(1 for s in segs if s.type == "move") == 1   # one subpath
     assert sum(1 for s in segs if s.type == "close") == 1
+
+
+def test_thought_body_is_valid_cloud_containing_inner():
+    segs = thought_body(INNER, scallop=8.0)
+    assert validate_segments(segs) == []
+    assert any(s.type == "quad" for s in segs)         # scalloped bumps
+    assert _contains(segments_bbox(segs), INNER)
+
+
+def test_thought_trail_marches_toward_target_with_count_subpaths():
+    trail = thought_trail((50.0, 40.0), (90.0, 90.0), count=3)
+    assert validate_segments(trail) == []
+    assert sum(1 for s in trail if s.type == "move") == 3   # 3 ellipse subpaths
+    # last (smallest) bubble is nearest the target
+    xs = [s.pts[0][0] for s in trail if s.type == "move"]
+    assert xs[-1] > xs[0]  # progressing toward target.x = 90
+
+
+def test_overlay_thought_has_body_plus_trail():
+    style = OverlayStyle(radius_px=10.0)
+    segs = overlay_to_segments("thought", INNER, (95.0, 95.0), style)
+    assert validate_segments(segs) == []
+    moves = sum(1 for s in segs if s.type == "move")
+    assert moves == 1 + 3   # body + 3 trail bubbles
+
+
+def test_overlay_thought_no_target_body_only():
+    style = OverlayStyle(radius_px=10.0)
+    segs = overlay_to_segments("thought", INNER, None, style)
+    assert sum(1 for s in segs if s.type == "move") == 1   # body only, no trail

--- a/tests/layout/test_balloons.py
+++ b/tests/layout/test_balloons.py
@@ -53,3 +53,45 @@ def test_overlay_to_segments_degenerate_logs_and_empty(caplog):
         assert overlay_to_segments("speech", (0.0, 0.0, 0.0, 30.0), None, style) == []
     assert any("degenerate" in r.message.lower() or "non-positive" in r.message.lower()
                for r in caplog.records)
+
+
+def _all_points(segs):
+    return [p for s in segs for p in s.pts]
+
+
+def test_speech_tail_reaches_target_below():
+    style = OverlayStyle(radius_px=10.0)
+    target = (50.0, 120.0)  # well below INNER (which ends at y=60)
+    segs = overlay_to_segments("speech", INNER, target, style)
+    assert validate_segments(segs) == []
+    # the tail tip is an exact vertex on the outline
+    assert any(abs(px - target[0]) < 1e-6 and abs(py - target[1]) < 1e-6
+               for px, py in _all_points(segs))
+    # bbox now extends below the body to reach the target
+    bbox = segments_bbox(segs)
+    assert bbox[1] + bbox[3] >= target[1] - 1e-6
+
+
+def test_speech_tail_target_above():
+    style = OverlayStyle(radius_px=10.0)
+    target = (50.0, -30.0)  # above the body
+    segs = overlay_to_segments("speech", INNER, target, style)
+    assert validate_segments(segs) == []
+    assert any(abs(py - target[1]) < 1e-6 for _, py in _all_points(segs))
+    assert segments_bbox(segs)[1] <= target[1] + 1e-6  # bbox reaches up to target
+
+
+def test_speech_no_target_has_no_tail():
+    style = OverlayStyle(radius_px=10.0)
+    segs = overlay_to_segments("speech", INNER, None, style)
+    # bbox stays within the inner bounds (no tail protrusion)
+    bbox = segments_bbox(segs)
+    assert bbox[1] >= INNER[1] - 1e-6
+    assert bbox[1] + bbox[3] <= INNER[1] + INNER[3] + 1e-6
+
+
+def test_speech_tail_single_closed_ring():
+    style = OverlayStyle(radius_px=10.0)
+    segs = overlay_to_segments("speech", INNER, (50.0, 120.0), style)
+    assert sum(1 for s in segs if s.type == "move") == 1   # one subpath
+    assert sum(1 for s in segs if s.type == "close") == 1

--- a/tests/layout/test_bleed_render.py
+++ b/tests/layout/test_bleed_render.py
@@ -1,0 +1,40 @@
+from PySide6.QtGui import QImage
+from PySide6.QtCore import Qt
+from core.layout.models import Region, PageSpec
+from core.layout import qt_renderer
+
+
+def _solid_png(tmp_path, color, size=(200, 60)):
+    im = QImage(size[0], size[1], QImage.Format_RGB32)
+    im.fill(color)
+    p = tmp_path / "ref.png"
+    assert im.save(str(p))
+    return str(p)
+
+
+def test_canvas_grows_by_bleed(qapp):
+    page = PageSpec(page_size_px=(200, 150), bleed_px=20, background="#FFFFFF")
+    img = qt_renderer.render_page_to_image(page)
+    assert img.width() == 240 and img.height() == 190
+
+
+def test_bleed_region_paints_into_margin(qapp, tmp_path):
+    ref = _solid_png(tmp_path, Qt.red)
+    # geometry spans y in [-20, 20] (into the top bleed) across the full width
+    page = PageSpec(page_size_px=(200, 150), bleed_px=20, background="#FFFFFF", regions=[
+        Region(id="b", kind="image", bbox=(0, -20, 200, 40), image_ref=ref, bleed=True)])
+    img = qt_renderer.render_page_to_image(page)
+    # device (100, 5) is inside the top bleed band [0,20)
+    c = img.pixelColor(100, 5)
+    assert c.red() > 200 and c.green() < 80
+
+
+def test_non_bleed_region_is_clipped_at_trim(qapp, tmp_path):
+    ref = _solid_png(tmp_path, Qt.red)
+    page = PageSpec(page_size_px=(200, 150), bleed_px=20, background="#FFFFFF", regions=[
+        Region(id="n", kind="image", bbox=(0, -20, 200, 40), image_ref=ref, bleed=False)])
+    img = qt_renderer.render_page_to_image(page)
+    margin = img.pixelColor(100, 5)    # top bleed band -> clipped away -> bg
+    inside = img.pixelColor(100, 25)   # within trim (device y >= 20) -> red
+    assert margin.red() > 200 and margin.green() > 200
+    assert inside.red() > 200 and inside.green() < 80

--- a/tests/layout/test_canvas_tool_mode.py
+++ b/tests/layout/test_canvas_tool_mode.py
@@ -1,0 +1,18 @@
+from gui.layout.canvas_widget import CanvasWidget
+
+
+def test_knife_two_click_state(qapp):
+    c = CanvasWidget()
+    c.set_tool_mode("knife")
+    assert c.tool_mode() == "knife"
+    assert c._register_knife_point(10.0, 20.0) is None       # first click stored
+    assert c._register_knife_point(30.0, 40.0) == (10.0, 20.0, 30.0, 40.0)
+
+
+def test_set_tool_mode_resets_and_validates(qapp):
+    c = CanvasWidget()
+    c.set_tool_mode("knife")
+    c._register_knife_point(1.0, 1.0)        # half-entered knife
+    c.set_tool_mode("bogus")                 # invalid -> "none" + reset
+    assert c.tool_mode() == "none"
+    assert c._knife_first is None

--- a/tests/layout/test_designer.py
+++ b/tests/layout/test_designer.py
@@ -193,3 +193,10 @@ def test_tiling_and_explicit_regions_coexist():
     res = designer.parse_response(content, (300, 300))
     ids = [r.id for r in res.regions]
     assert "x" in ids and len(ids) == 4  # 3 tiers + 1 explicit region
+
+
+def test_build_messages_documents_new_capabilities():
+    msgs = designer.build_messages("comic", (1000, 800), "a dynamic comic page")
+    joined = " ".join(m["content"] for m in msgs)
+    for token in ("svg", "tiling", "grid", "overlays", "speech", "anchor_region", "bleed"):
+        assert token in joined, token

--- a/tests/layout/test_designer.py
+++ b/tests/layout/test_designer.py
@@ -144,3 +144,12 @@ def test_parse_overlay_unknown_kind_skipped():
                ' "overlays": [{"id":"o1","kind":"bubble","text":"x","anchor":[10,10]}]}}')
     res = designer.parse_response(content, (200, 200))
     assert res.overlays == []
+
+
+def test_parse_overlay_bad_z_degrades_to_zero():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","bbox":[0,0,100,100]}],'
+               ' "overlays": [{"id":"o1","kind":"sfx","text":"x","anchor":[10,10],"z":"top"},'
+               ' {"id":"o2","kind":"sfx","text":"y","anchor":[20,20],"z":null}]}}')
+    res = designer.parse_response(content, (200, 200))
+    assert [o.id for o in res.overlays] == ["o1", "o2"]
+    assert all(o.z == 0 for o in res.overlays)

--- a/tests/layout/test_designer.py
+++ b/tests/layout/test_designer.py
@@ -202,6 +202,15 @@ def test_build_messages_documents_new_capabilities():
         assert token in joined, token
 
 
+def test_build_messages_documents_tiled_panel_ids():
+    # The prompt must teach the LLM how tiled panels are named, so overlays can
+    # be anchored to them via anchor_region/tail_to_region.
+    msgs = designer.build_messages("comic", (1000, 800), "a dynamic comic page")
+    joined = " ".join(m["content"] for m in msgs)
+    for token in ("p{row}_{col}", "t0", "splash", "s0", "d0", "hero", "side"):
+        assert token in joined, token
+
+
 def test_parse_overlay_bad_coords_drop_only_that_overlay():
     content = ('{"layout": {"regions": [{"id":"p1","kind":"image","bbox":[0,0,100,100]}],'
                ' "overlays": [{"id":"bad","kind":"speech","text":"x","anchor":[null,null]},'

--- a/tests/layout/test_designer.py
+++ b/tests/layout/test_designer.py
@@ -153,3 +153,43 @@ def test_parse_overlay_bad_z_degrades_to_zero():
     res = designer.parse_response(content, (200, 200))
     assert [o.id for o in res.overlays] == ["o1", "o2"]
     assert all(o.z == 0 for o in res.overlays)
+
+
+def test_parse_svg_path_region():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","shape":"path",'
+               ' "svg":"M10 10 L90 10 L90 90 Z","bleed":true}]}}')
+    res = designer.parse_response(content, (200, 200))
+    r = res.regions[0]
+    assert r.shape == "path"
+    assert [s.type for s in r.segments] == ["move", "line", "line", "close"]
+    assert r.bleed is True
+
+
+def test_parse_region_stroke_px_maps_to_image_style():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","shape":"rect",'
+               ' "bbox":[0,0,100,100],"stroke_px":6}]}}')
+    res = designer.parse_response(content, (200, 200))
+    assert res.regions[0].image_style is not None
+    assert res.regions[0].image_style.stroke_px == 6
+
+
+def test_parse_tiling_preset_expands_to_panels():
+    content = '{"layout": {"tiling": {"preset":"grid","params":{"rows":2,"cols":2,"gutter_px":10}}}}'
+    res = designer.parse_response(content, (400, 400))
+    assert res.regions is not None and len(res.regions) == 4
+    assert all(r.shape == "path" for r in res.regions)
+
+
+def test_unknown_tiling_preset_degrades_keeps_explicit_regions():
+    content = ('{"layout": {"tiling": {"preset":"spiral"},'
+               ' "regions":[{"id":"a","kind":"image","bbox":[0,0,50,50]}]}}')
+    res = designer.parse_response(content, (200, 200))
+    assert [r.id for r in res.regions] == ["a"]  # unknown preset ignored; explicit region kept
+
+
+def test_tiling_and_explicit_regions_coexist():
+    content = ('{"layout": {"tiling": {"preset":"three_tiers"},'
+               ' "regions":[{"id":"x","kind":"text","bbox":[0,0,40,20],"role":"caption"}]}}')
+    res = designer.parse_response(content, (300, 300))
+    ids = [r.id for r in res.regions]
+    assert "x" in ids and len(ids) == 4  # 3 tiers + 1 explicit region

--- a/tests/layout/test_designer.py
+++ b/tests/layout/test_designer.py
@@ -200,3 +200,12 @@ def test_build_messages_documents_new_capabilities():
     joined = " ".join(m["content"] for m in msgs)
     for token in ("svg", "tiling", "grid", "overlays", "speech", "anchor_region", "bleed"):
         assert token in joined, token
+
+
+def test_parse_overlay_bad_coords_drop_only_that_overlay():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","bbox":[0,0,100,100]}],'
+               ' "overlays": [{"id":"bad","kind":"speech","text":"x","anchor":[null,null]},'
+               ' {"id":"bad2","kind":"sfx","text":"y","anchor":["left","top"]},'
+               ' {"id":"ok","kind":"sfx","text":"z","anchor":[50,50]}]}}')
+    res = designer.parse_response(content, (200, 200))
+    assert [o.id for o in res.overlays] == ["ok"]

--- a/tests/layout/test_designer.py
+++ b/tests/layout/test_designer.py
@@ -100,3 +100,47 @@ def test_every_provider_display_name_resolves_to_a_registry_id_with_models():
         _, registry_id = designer.resolve_provider_ids(display)
         assert get_provider_models(registry_id), \
             f"{display!r} -> {registry_id!r} resolves to no models"
+
+
+def test_designer_result_overlays_defaults_empty():
+    res = designer.parse_response(
+        '{"layout": {"regions": [{"id":"a","kind":"image","bbox":[0,0,100,100]}]}}',
+        (200, 200))
+    assert res.overlays == []
+
+
+def test_parse_overlay_raw_pixel_anchor():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","bbox":[0,0,200,200]}],'
+               ' "overlays": [{"id":"o1","kind":"speech","text":"Hi",'
+               ' "anchor":[50,40],"tail_target":[50,120]}]}}')
+    res = designer.parse_response(content, (300, 300))
+    assert len(res.overlays) == 1
+    ov = res.overlays[0]
+    assert ov.kind == "speech" and ov.text == "Hi"
+    assert ov.anchor == (50.0, 40.0)
+    assert ov.tail_target == (50.0, 120.0)
+
+
+def test_parse_overlay_region_relative_anchor_resolves_to_pixels():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","bbox":[100,100,200,100]}],'
+               ' "overlays": [{"id":"o1","kind":"speech","text":"Yo","anchor_region":"p1",'
+               ' "anchor_offset":[0.5,0.5],"tail_to_region":"p1"}]}}')
+    res = designer.parse_response(content, (500, 500))
+    ov = res.overlays[0]
+    assert ov.anchor == (200.0, 150.0)        # 100 + 0.5*200, 100 + 0.5*100
+    assert ov.tail_target == (200.0, 150.0)   # region center
+
+
+def test_parse_overlay_unknown_region_dropped_but_others_kept():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","bbox":[0,0,100,100]}],'
+               ' "overlays": [{"id":"bad","kind":"speech","text":"x","anchor_region":"nope"},'
+               ' {"id":"ok","kind":"sfx","text":"BOOM","anchor":[50,50]}]}}')
+    res = designer.parse_response(content, (200, 200))
+    assert [o.id for o in res.overlays] == ["ok"]
+
+
+def test_parse_overlay_unknown_kind_skipped():
+    content = ('{"layout": {"regions": [{"id":"p1","kind":"image","bbox":[0,0,100,100]}],'
+               ' "overlays": [{"id":"o1","kind":"bubble","text":"x","anchor":[10,10]}]}}')
+    res = designer.parse_response(content, (200, 200))
+    assert res.overlays == []

--- a/tests/layout/test_export_qt.py
+++ b/tests/layout/test_export_qt.py
@@ -32,3 +32,30 @@ def test_render_page_to_image_scale_doubles_dimensions(qapp):
     base = qt_renderer.render_page_to_image(page)
     scaled = qt_renderer.render_page_to_image(page, scale=2.0)
     assert (scaled.width(), scaled.height()) == (base.width() * 2, base.height() * 2)
+
+
+def _doc():
+    from core.layout.models import DocumentSpec, PageSpec, Region
+    return DocumentSpec(title="t", pages=[PageSpec(
+        page_size_px=(200, 150),
+        regions=[Region(id="r", kind="image", shape="rect", bbox=(0, 0, 100, 100))],
+        overlays=[])])
+
+
+def test_export_worker_pdf_executes_via_qt(qapp, tmp_path):
+    # Execute the PDF worker path (not just grep its source): proves
+    # export_document_pdf(dpi=...) actually accepts the kwarg and renders.
+    from gui.layout.export_dialog import ExportWorker
+    out = tmp_path / "doc.pdf"
+    worker = ExportWorker(_doc(), "pdf", str(out), dpi=300)
+    worker._export_pdf(out, [0], 1)
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_export_worker_png_executes_via_qt(qapp, tmp_path):
+    # Execute the PNG worker path end-to-end through the Qt renderer (dpi -> scale).
+    from gui.layout.export_dialog import ExportWorker
+    out = tmp_path / "doc.png"
+    worker = ExportWorker(_doc(), "png", str(out), dpi=144)
+    worker._export_png(out, [0], 1)
+    assert out.exists() and out.stat().st_size > 0

--- a/tests/layout/test_export_qt.py
+++ b/tests/layout/test_export_qt.py
@@ -23,3 +23,12 @@ def test_export_worker_uses_qt_renderer(qapp):
     src = inspect.getsource(export_dialog.LayoutExportWorker)
     assert "qt_renderer" in src
     assert "engine.render_page" not in src  # PIL render path removed
+
+
+def test_render_page_to_image_scale_doubles_dimensions(qapp):
+    from core.layout import qt_renderer
+    from core.layout.models import PageSpec
+    page = PageSpec(page_size_px=(200, 150), regions=[], overlays=[])
+    base = qt_renderer.render_page_to_image(page)
+    scaled = qt_renderer.render_page_to_image(page, scale=2.0)
+    assert (scaled.width(), scaled.height()) == (base.width() * 2, base.height() * 2)

--- a/tests/layout/test_export_qt.py
+++ b/tests/layout/test_export_qt.py
@@ -1,0 +1,25 @@
+import os
+from gui.layout.layout_tab import LayoutTab
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def test_export_png_to_writes_file(qapp, tmp_path):
+    tab = LayoutTab(config=FakeConfig())
+    out = tmp_path / "page.png"
+    tab.export_png_to(str(out))
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_export_worker_uses_qt_renderer(qapp):
+    # The PIL LayoutEngine must no longer be used for image rendering in the worker.
+    import inspect
+    from gui.layout import export_dialog
+    src = inspect.getsource(export_dialog.LayoutExportWorker)
+    assert "qt_renderer" in src
+    assert "engine.render_page" not in src  # PIL render path removed

--- a/tests/layout/test_geometry.py
+++ b/tests/layout/test_geometry.py
@@ -1,5 +1,5 @@
 from core.layout.models import PathSegment
-from core.layout.geometry import validate_segments, segments_bbox
+from core.layout.geometry import validate_segments, segments_bbox, translate_segments
 
 
 def _triangle():
@@ -44,3 +44,30 @@ def test_bbox_includes_cubic_control_points():
             PathSegment(type="cubic", pts=[(0.0, 20.0), (20.0, 20.0), (10.0, 0.0)])]
     # superset using control points: x in [0,20], y in [0,20]
     assert segments_bbox(segs) == (0.0, 0.0, 20.0, 20.0)
+
+
+def test_translate_segments_offsets_all_point_types():
+    segs = [
+        PathSegment(type="move", pts=[(10.0, 10.0)]),
+        PathSegment(type="line", pts=[(90.0, 10.0)]),
+        PathSegment(type="cubic", pts=[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]),
+        PathSegment(type="close", pts=[]),
+    ]
+    out = translate_segments(segs, 5.0, -2.0)
+    assert out[0].pts == [(15.0, 8.0)]
+    assert out[1].pts == [(95.0, 8.0)]
+    assert out[2].pts == [(6.0, 0.0), (8.0, 2.0), (10.0, 4.0)]
+    assert out[3].pts == []
+    assert [s.type for s in out] == ["move", "line", "cubic", "close"]
+
+
+def test_translate_segments_does_not_mutate_input():
+    segs = [PathSegment(type="move", pts=[(0.0, 0.0)])]
+    out = translate_segments(segs, 1.0, 1.0)
+    assert out[0] is not segs[0]
+    assert segs[0].pts == [(0.0, 0.0)]
+
+
+def test_translate_segments_zero_delta_keeps_values():
+    segs = [PathSegment(type="line", pts=[(3.0, 4.0)])]
+    assert translate_segments(segs, 0.0, 0.0)[0].pts == [(3.0, 4.0)]

--- a/tests/layout/test_geometry.py
+++ b/tests/layout/test_geometry.py
@@ -1,0 +1,47 @@
+import math
+from core.layout.models import PathSegment
+from core.layout.geometry import validate_segments, segments_bbox
+
+
+def _triangle():
+    return [
+        PathSegment(type="move", pts=[(0.0, 0.0)]),
+        PathSegment(type="line", pts=[(10.0, 0.0)]),
+        PathSegment(type="line", pts=[(5.0, 8.0)]),
+        PathSegment(type="close", pts=[]),
+    ]
+
+
+def test_valid_path_has_no_issues():
+    assert validate_segments(_triangle()) == []
+
+
+def test_empty_is_invalid():
+    assert validate_segments([]) == ["empty segment list"]
+
+
+def test_must_start_with_move():
+    segs = [PathSegment(type="line", pts=[(1.0, 1.0)])]
+    assert any("must start with a 'move'" in m for m in validate_segments(segs))
+
+
+def test_wrong_point_count_flagged():
+    segs = [PathSegment(type="move", pts=[(0.0, 0.0)]),
+            PathSegment(type="cubic", pts=[(1.0, 1.0)])]  # cubic needs 3
+    assert any("cubic expects 3" in m for m in validate_segments(segs))
+
+
+def test_non_finite_flagged():
+    segs = [PathSegment(type="move", pts=[(0.0, float("nan"))])]
+    assert any("non-finite" in m for m in validate_segments(segs))
+
+
+def test_bbox_of_triangle():
+    assert segments_bbox(_triangle()) == (0.0, 0.0, 10.0, 8.0)
+
+
+def test_bbox_includes_cubic_control_points():
+    segs = [PathSegment(type="move", pts=[(0.0, 0.0)]),
+            PathSegment(type="cubic", pts=[(0.0, 20.0), (20.0, 20.0), (10.0, 0.0)])]
+    # superset using control points: x in [0,20], y in [0,20]
+    assert segments_bbox(segs) == (0.0, 0.0, 20.0, 20.0)

--- a/tests/layout/test_geometry.py
+++ b/tests/layout/test_geometry.py
@@ -1,4 +1,3 @@
-import math
 from core.layout.models import PathSegment
 from core.layout.geometry import validate_segments, segments_bbox
 

--- a/tests/layout/test_geometry_editor.py
+++ b/tests/layout/test_geometry_editor.py
@@ -1,0 +1,61 @@
+from gui.layout.layout_tab import LayoutTab
+from gui.layout.geometry_editor import edit_points_for_region
+from core.layout.models import Region, PathSegment
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _diamond_path():
+    return Region(id="p1", kind="image", shape="path", bbox=(0, 0, 100, 100), segments=[
+        PathSegment(type="move", pts=[(50.0, 0.0)]),
+        PathSegment(type="line", pts=[(100.0, 50.0)]),
+        PathSegment(type="cubic", pts=[(80.0, 80.0), (60.0, 100.0), (50.0, 100.0)]),
+        PathSegment(type="close", pts=[]),
+    ])
+
+
+def test_edit_points_for_path_region():
+    pts = edit_points_for_region(_diamond_path())
+    # move(1 anchor) + line(1 anchor) + cubic(2 controls + 1 anchor) + close(0) = 5
+    assert len(pts) == 5
+    assert (pts[0].x, pts[0].y) == (50.0, 0.0)
+    assert pts[2].is_control is True and pts[3].is_control is True
+    assert pts[4].is_control is False and (pts[4].x, pts[4].y) == (50.0, 100.0)
+
+
+def test_edit_points_for_polygon_region():
+    r = Region(id="q1", kind="image", shape="polygon", points=[(0, 0), (40, 0), (40, 30)],
+               bbox=(0, 0, 40, 30))
+    pts = edit_points_for_region(r)
+    assert len(pts) == 3
+    assert all(not p.is_control for p in pts)
+    assert (pts[1].x, pts[1].y) == (40.0, 0.0)
+
+
+def test_edit_points_rect_region_empty():
+    r = Region(id="t1", kind="text", shape="rect", bbox=(0, 0, 50, 20))
+    assert edit_points_for_region(r) == []
+
+
+def test_handles_appear_and_survive_refresh(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = [_diamond_path()]
+    tab._refresh()
+    tab.geometry_editor.set_edit_region("p1")
+    assert len(tab.geometry_editor._handles) == 5
+    tab._refresh()  # full scene rebuild
+    assert len(tab.geometry_editor._handles) == 5  # regenerated, not lost
+
+
+def test_edit_mode_off_clears_handles(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = [_diamond_path()]
+    tab._refresh()
+    tab.geometry_editor.set_edit_region("p1")
+    tab.geometry_editor.set_edit_region(None)
+    assert tab.geometry_editor._handles == []

--- a/tests/layout/test_geometry_editor_drag.py
+++ b/tests/layout/test_geometry_editor_drag.py
@@ -1,0 +1,68 @@
+from gui.layout.layout_tab import LayoutTab
+from core.layout.models import Region, PathSegment
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tri():
+    return Region(id="p1", kind="image", shape="path", bbox=(10, 10, 40, 40), segments=[
+        PathSegment(type="move", pts=[(10.0, 10.0)]),
+        PathSegment(type="line", pts=[(50.0, 10.0)]),
+        PathSegment(type="line", pts=[(50.0, 50.0)]),
+        PathSegment(type="close", pts=[]),
+    ])
+
+
+def _editing_tab():
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = [_tri()]
+    tab._refresh()
+    tab.geometry_editor.set_edit_region("p1")
+    return tab
+
+
+def test_move_handle_mutates_segment_point(qapp):
+    tab = _editing_tab()
+    tab.geometry_editor.begin_edit()
+    tab.geometry_editor.move_handle(0, 20.0, 5.0)  # drag the 'move' anchor
+    seg0 = tab.document.pages[0].regions[0].segments[0]
+    assert seg0.pts == [(20.0, 5.0)]
+
+
+def test_commit_recomputes_bbox_and_snapshots(qapp):
+    tab = _editing_tab()
+    before = len(tab.history.snapshots())
+    tab.geometry_editor.begin_edit()
+    tab.geometry_editor.move_handle(2, 90.0, 90.0)  # move the 2nd line endpoint out
+    tab.geometry_editor.commit()
+    r = tab.document.pages[0].regions[0]
+    assert r.segments[2].pts == [(90.0, 90.0)]
+    assert r.bbox == (10, 10, 80, 80)  # segments_bbox over (10,10),(50,10),(90,90)
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_begin_edit_suspends_refresh_commit_resumes(qapp):
+    tab = _editing_tab()
+    tab.geometry_editor.begin_edit()
+    assert tab._suspend_refresh is True
+    tab.geometry_editor.commit()
+    assert tab._suspend_refresh is False
+
+
+def test_polygon_vertex_edit_commits(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = [Region(id="q1", kind="image", shape="polygon",
+                                            points=[(0, 0), (40, 0), (40, 30)], bbox=(0, 0, 40, 30))]
+    tab._refresh()
+    tab.geometry_editor.set_edit_region("q1")
+    tab.geometry_editor.begin_edit()
+    tab.geometry_editor.move_handle(2, 60.0, 50.0)
+    tab.geometry_editor.commit()
+    r = tab.document.pages[0].regions[0]
+    assert r.points[2] == (60, 50)
+    assert r.bbox == (0, 0, 60, 50)

--- a/tests/layout/test_geometry_inspector.py
+++ b/tests/layout/test_geometry_inspector.py
@@ -1,0 +1,52 @@
+from gui.layout.geometry_inspector import GeometryInspector
+from gui.layout.layout_tab import LayoutTab
+from core.layout.models import Region, ImageStyle
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def test_inspector_reflects_region_and_emits(qapp):
+    insp = GeometryInspector()
+    r = Region(id="p1", kind="image", shape="path", bbox=(0, 0, 100, 100),
+               bleed=True, z=3, image_style=ImageStyle(stroke_px=6))
+    insp.set_region(r)
+    assert insp.bleed_chk.isChecked() is True
+    assert insp.borderless_chk.isChecked() is False  # stroke 6 -> not borderless
+    assert insp.z_spin.value() == 3
+
+    seen = []
+    insp.bleedToggled.connect(lambda rid, b: seen.append(("bleed", rid, b)))
+    insp.bleed_chk.setChecked(False)
+    assert seen == [("bleed", "p1", False)]
+
+
+def test_layout_tab_geometry_handlers_write_model(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    page = tab.document.pages[0]
+    page.regions = [Region(id="p1", kind="image", shape="path", bbox=(0, 0, 100, 100),
+                           image_style=ImageStyle(stroke_px=6))]
+
+    tab._on_region_bleed_toggled("p1", True)
+    assert page.regions[0].bleed is True
+
+    tab._on_region_borderless_toggled("p1", True)
+    assert page.regions[0].image_style.stroke_px == 0
+    tab._on_region_borderless_toggled("p1", False)
+    assert page.regions[0].image_style.stroke_px == 4
+
+    tab._on_region_z_changed("p1", 12)
+    assert page.regions[0].z == 12
+
+
+def test_borderless_creates_image_style_when_absent(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    page = tab.document.pages[0]
+    page.regions = [Region(id="p1", kind="image", shape="path", bbox=(0, 0, 100, 100))]
+    tab._on_region_borderless_toggled("p1", False)
+    assert page.regions[0].image_style is not None
+    assert page.regions[0].image_style.stroke_px == 4

--- a/tests/layout/test_image_clip_stroke.py
+++ b/tests/layout/test_image_clip_stroke.py
@@ -55,13 +55,25 @@ def test_concave_notch_is_background(qapp, tmp_path):
 
 
 def test_borderless_when_stroke_zero(qapp, tmp_path):
+    ref = _solid_png(tmp_path, Qt.blue)
     page = PageSpec(page_size_px=(200, 150), regions=[
         Region(id="e", kind="image", bbox=(10, 10, 80, 80),
-               image_style=ImageStyle(stroke_px=0))])
+               image_ref=ref, image_style=ImageStyle(stroke_px=0))])
     scene = qt_renderer.build_scene(page)
     frame = [it for it in scene.items()
-             if it.data(0) == "e" and hasattr(it, "path")][0]
+             if it.data(0) == "e" and hasattr(it, "path")
+             and not isinstance(it, QGraphicsPixmapItem)][0]
     assert frame.pen().style() == Qt.NoPen
+
+
+def test_empty_region_keeps_placeholder_outline(qapp):
+    page = PageSpec(page_size_px=(200, 150), regions=[
+        Region(id="e2", kind="image", bbox=(10, 10, 80, 80))])
+    scene = qt_renderer.build_scene(page)
+    frame = [it for it in scene.items()
+             if it.data(0) == "e2" and hasattr(it, "path")
+             and not isinstance(it, QGraphicsPixmapItem)][0]
+    assert frame.pen().style() != Qt.NoPen
 
 
 def test_stroke_pen_when_stroke_positive(qapp):

--- a/tests/layout/test_image_clip_stroke.py
+++ b/tests/layout/test_image_clip_stroke.py
@@ -1,0 +1,85 @@
+from PySide6.QtGui import QImage
+from PySide6.QtWidgets import QGraphicsItem, QGraphicsPixmapItem
+from PySide6.QtCore import Qt
+
+from core.layout.models import Region, PageSpec, PathSegment, ImageStyle
+from core.layout import qt_renderer
+
+
+def _solid_png(tmp_path, color, name="src.png", size=(80, 80)):
+    im = QImage(size[0], size[1], QImage.Format_RGB32)
+    im.fill(color)
+    p = tmp_path / name
+    assert im.save(str(p))
+    return str(p)
+
+
+def _triangle_segments():
+    # apex at bottom-center, wide top edge; bbox (100,10,90,80)
+    return [PathSegment(type="move", pts=[(100.0, 10.0)]),
+            PathSegment(type="line", pts=[(190.0, 10.0)]),
+            PathSegment(type="line", pts=[(145.0, 90.0)]),
+            PathSegment(type="close", pts=[])]
+
+
+def test_image_is_clipped_to_triangle(qapp, tmp_path):
+    ref = _solid_png(tmp_path, Qt.red, size=(90, 80))
+    page = PageSpec(page_size_px=(200, 150), background="#FFFFFF", regions=[
+        Region(id="t", kind="image", shape="path", segments=_triangle_segments(),
+               bbox=(100, 10, 90, 80), image_ref=ref)])
+    img = qt_renderer.render_page_to_image(page)
+    inside = img.pixelColor(145, 30)     # near top-center of triangle
+    outside = img.pixelColor(105, 85)    # bbox corner OUTSIDE the triangle
+    assert inside.red() > 200 and inside.green() < 80      # red image
+    assert outside.red() > 200 and outside.green() > 200   # white page bg (clipped away)
+
+
+def test_concave_notch_is_background(qapp, tmp_path):
+    ref = _solid_png(tmp_path, Qt.red, size=(100, 100))
+    # L-shape (concave): outer 0..100 square with a notch cut out of the top-right
+    segs = [PathSegment(type="move", pts=[(0.0, 0.0)]),
+            PathSegment(type="line", pts=[(50.0, 0.0)]),
+            PathSegment(type="line", pts=[(50.0, 50.0)]),
+            PathSegment(type="line", pts=[(100.0, 50.0)]),
+            PathSegment(type="line", pts=[(100.0, 100.0)]),
+            PathSegment(type="line", pts=[(0.0, 100.0)]),
+            PathSegment(type="close", pts=[])]
+    page = PageSpec(page_size_px=(120, 120), background="#FFFFFF", regions=[
+        Region(id="L", kind="image", shape="path", segments=segs,
+               bbox=(0, 0, 100, 100), image_ref=ref)])
+    img = qt_renderer.render_page_to_image(page)
+    notch = img.pixelColor(75, 25)   # inside bbox, inside the removed notch
+    body = img.pixelColor(25, 25)    # solid part of the L
+    assert notch.red() > 200 and notch.green() > 200   # background
+    assert body.red() > 200 and body.green() < 80      # red image
+
+
+def test_borderless_when_stroke_zero(qapp, tmp_path):
+    page = PageSpec(page_size_px=(200, 150), regions=[
+        Region(id="e", kind="image", bbox=(10, 10, 80, 80),
+               image_style=ImageStyle(stroke_px=0))])
+    scene = qt_renderer.build_scene(page)
+    frame = [it for it in scene.items()
+             if it.data(0) == "e" and hasattr(it, "path")][0]
+    assert frame.pen().style() == Qt.NoPen
+
+
+def test_stroke_pen_when_stroke_positive(qapp):
+    page = PageSpec(page_size_px=(200, 150), regions=[
+        Region(id="e", kind="image", bbox=(10, 10, 80, 80),
+               image_style=ImageStyle(stroke_px=4, stroke_color="#FF0000"))])
+    scene = qt_renderer.build_scene(page)
+    frame = [it for it in scene.items()
+             if it.data(0) == "e" and hasattr(it, "path")][0]
+    assert frame.pen().widthF() == 4
+    assert frame.pen().color().red() == 255
+
+
+def test_filled_image_region_still_selectable(qapp, tmp_path):
+    ref = _solid_png(tmp_path, Qt.white)
+    page = PageSpec(page_size_px=(200, 150), regions=[
+        Region(id="img1", kind="image", bbox=(10, 10, 80, 80), image_ref=ref)])
+    scene = qt_renderer.build_scene(page, selectable=True)
+    pix = [it for it in scene.items() if isinstance(it, QGraphicsPixmapItem)]
+    assert pix and (pix[0].flags() & QGraphicsItem.ItemIsSelectable)
+    assert pix[0].data(0) == "img1"

--- a/tests/layout/test_layout_lock_and_session.py
+++ b/tests/layout/test_layout_lock_and_session.py
@@ -58,11 +58,17 @@ def test_applied_text_is_child_of_its_frame_and_moves_with_it(qapp):
     scene = qt_renderer.build_scene(_page(), selectable=True, locked=False)
     box = next(it for it in scene.items()
                if isinstance(it, QGraphicsRectItem) and it.data(0) == "txt")
-    children = [c for c in box.childItems() if isinstance(c, QGraphicsSimpleTextItem)]
-    assert children, "applied text must be locked to its frame (a child of the box)"
-    before = children[0].scenePos()
+    # Text is now a grandchild of the box (box -> clip -> text) so that the clip
+    # item can enforce the panel-shape boundary.  Walk descendants to find it.
+    def _descendants(item):
+        for child in item.childItems():
+            yield child
+            yield from _descendants(child)
+    texts = [c for c in _descendants(box) if isinstance(c, QGraphicsSimpleTextItem)]
+    assert texts, "applied text must be a descendant of its frame and move with it"
+    before = texts[0].scenePos()
     box.setPos(15, 15)
-    after = children[0].scenePos()
+    after = texts[0].scenePos()
     assert (after.x() - before.x(), after.y() - before.y()) == (15, 15)
 
 

--- a/tests/layout/test_layout_tab_designer_overlays.py
+++ b/tests/layout/test_layout_tab_designer_overlays.py
@@ -1,0 +1,32 @@
+from gui.layout.layout_tab import LayoutTab
+from core.layout import designer
+from core.layout.models import Overlay
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def test_apply_designer_result_writes_overlays(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    res = designer.DesignerResult(
+        regions=[designer.Region(id="p1", kind="image", bbox=(0, 0, 200, 200))],
+        overlays=[Overlay(id="o1", kind="speech", text="Hi", anchor=(50.0, 40.0))],
+    )
+    tab.apply_designer_result(res, user_text="v1")
+    page = tab.document.pages[0]
+    assert [r.id for r in page.regions] == ["p1"]
+    assert [o.id for o in page.overlays] == ["o1"]
+
+
+def test_apply_designer_result_overlays_only(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    res = designer.DesignerResult(
+        regions=None,
+        overlays=[Overlay(id="o1", kind="sfx", text="BOOM", anchor=(20.0, 20.0))],
+    )
+    tab.apply_designer_result(res, user_text="add sfx")
+    assert [o.id for o in tab.document.pages[0].overlays] == ["o1"]

--- a/tests/layout/test_overlay_editor.py
+++ b/tests/layout/test_overlay_editor.py
@@ -1,0 +1,62 @@
+from gui.layout.layout_tab import LayoutTab
+from core.layout.models import Region, Overlay
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tab(overlays, regions=None):
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = regions or []
+    tab.document.pages[0].overlays = overlays
+    tab._refresh()
+    return tab
+
+
+def test_body_handle_only_when_no_tail(qapp):
+    tab = _tab([Overlay(id="o", kind="caption", text="x", anchor=(50.0, 50.0))])
+    tab.overlay_editor.set_edit_overlay("o")
+    kinds = sorted(h._kind for h in tab.overlay_editor._handles)
+    assert kinds == ["body"]
+
+
+def test_body_and_tail_handles_when_tail(qapp):
+    tab = _tab([Overlay(id="o", kind="speech", text="x", anchor=(50.0, 50.0),
+                        tail_target=(80.0, 90.0))])
+    tab.overlay_editor.set_edit_overlay("o")
+    kinds = sorted(h._kind for h in tab.overlay_editor._handles)
+    assert kinds == ["body", "tail"]
+
+
+def test_move_body_commits_anchor(qapp):
+    tab = _tab([Overlay(id="o", kind="caption", text="x", anchor=(50.0, 50.0))])
+    tab.overlay_editor.set_edit_overlay("o")
+    before = len(tab.history.snapshots())
+    tab.overlay_editor.begin_edit()
+    tab.overlay_editor.move_handle("body", 120.0, 130.0)
+    tab.overlay_editor.commit()
+    assert tab.document.pages[0].overlays[0].anchor == (120.0, 130.0)
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_tail_commit_snaps_to_region_center(qapp):
+    tab = _tab(
+        [Overlay(id="o", kind="speech", text="x", anchor=(50.0, 50.0), tail_target=(60.0, 60.0))],
+        regions=[Region(id="r", kind="image", shape="rect", bbox=(200, 200, 100, 100))],
+    )
+    tab.overlay_editor.set_edit_overlay("o")
+    tab.overlay_editor.begin_edit()
+    tab.overlay_editor.move_handle("tail", 248.0, 248.0)  # near region center (250,250)
+    tab.overlay_editor.commit()
+    assert tab.document.pages[0].overlays[0].tail_target == (250.0, 250.0)
+
+
+def test_edit_off_clears_handles(qapp):
+    tab = _tab([Overlay(id="o", kind="caption", text="x", anchor=(50.0, 50.0))])
+    tab.overlay_editor.set_edit_overlay("o")
+    tab.overlay_editor.set_edit_overlay(None)
+    assert tab.overlay_editor._handles == []

--- a/tests/layout/test_overlay_inspector.py
+++ b/tests/layout/test_overlay_inspector.py
@@ -1,0 +1,39 @@
+from PySide6.QtCore import Qt
+from gui.layout.overlay_inspector import OverlayInspector
+from core.layout.models import PageSpec, Overlay
+
+
+def _page(overlays):
+    return PageSpec(page_size_px=(400, 400), regions=[], overlays=overlays)
+
+
+def test_set_page_lists_overlays(qapp):
+    insp = OverlayInspector()
+    insp.set_page(_page([
+        Overlay(id="o1", kind="speech", text="hi", anchor=(10.0, 10.0)),
+        Overlay(id="o2", kind="sfx", text="POW", anchor=(20.0, 20.0)),
+    ]))
+    assert insp.overlay_list.count() == 2
+
+
+def test_add_buttons_emit_kind(qapp):
+    insp = OverlayInspector()
+    seen = []
+    insp.addRequested.connect(lambda k: seen.append(k))
+    insp.add_speech_btn.click()
+    insp.add_sfx_btn.click()
+    assert seen == ["speech", "sfx"]
+
+
+def test_rotation_and_delete_emit_for_selected(qapp):
+    insp = OverlayInspector()
+    insp.set_page(_page([Overlay(id="o1", kind="sfx", text="x", anchor=(0.0, 0.0), rotation=10.0)]))
+    insp.set_selected("o1")
+    assert insp.rotation_spin.value() == 10
+    rot, dele = [], []
+    insp.rotationChanged.connect(lambda i, d: rot.append((i, d)))
+    insp.deleteRequested.connect(lambda i: dele.append(i))
+    insp.rotation_spin.setValue(90)
+    insp.delete_btn.click()
+    assert rot == [("o1", 90)]
+    assert dele == ["o1"]

--- a/tests/layout/test_overlay_model.py
+++ b/tests/layout/test_overlay_model.py
@@ -1,0 +1,47 @@
+from core.layout.models import Overlay, OverlayStyle, PageSpec, TextStyle
+
+
+def test_overlay_style_defaults():
+    s = OverlayStyle()
+    assert s.fill == "#FFFFFF"
+    assert s.stroke_px == 2.0
+    assert s.stroke_color == "#000000"
+    assert s.padding_px == 10.0
+    assert s.radius_px == 16.0
+    assert s.max_width_px == 240.0
+
+
+def test_overlay_defaults_and_fields():
+    ov = Overlay(id="o1", kind="speech", text="Hi!", anchor=(50.0, 40.0))
+    assert ov.kind == "speech"
+    assert ov.anchor == (50.0, 40.0)
+    assert ov.anchor_mode == "center"
+    assert ov.tail_target is None
+    assert ov.z == 0
+    assert ov.role == ""
+    assert ov.text_style is None
+    assert isinstance(ov.style, OverlayStyle)
+
+
+def test_overlay_independent_style_instances():
+    a = Overlay(id="a", kind="caption", text="x", anchor=(0.0, 0.0))
+    b = Overlay(id="b", kind="caption", text="y", anchor=(0.0, 0.0))
+    a.style.fill = "#FFEE00"
+    assert b.style.fill == "#FFFFFF"  # default_factory -> no shared mutable default
+
+
+def test_overlay_with_tail_and_text_style():
+    ts = TextStyle(family=["Arial", "Helvetica"])
+    ov = Overlay(id="o2", kind="thought", text="hmm", anchor=(10.0, 10.0),
+                 tail_target=(5.0, 30.0), z=3, role="dialogue", text_style=ts)
+    assert ov.tail_target == (5.0, 30.0)
+    assert ov.z == 3
+    assert ov.role == "dialogue"
+    assert ov.text_style is ts
+
+
+def test_pagespec_overlays_default_empty():
+    page = PageSpec(page_size_px=(100, 100))
+    assert page.overlays == []
+    page.overlays.append(Overlay(id="o", kind="sfx", text="BOOM", anchor=(20.0, 20.0)))
+    assert len(page.overlays) == 1

--- a/tests/layout/test_overlay_ops.py
+++ b/tests/layout/test_overlay_ops.py
@@ -1,0 +1,48 @@
+from core.layout.models import PageSpec, Region, Overlay
+from core.layout.overlay_ops import (
+    overlay_anchor_stranded, nearest_region_center, reposition_stranded_overlays,
+)
+
+
+def _regions():
+    return [
+        Region(id="a", kind="image", shape="rect", bbox=(0, 0, 100, 100)),
+        Region(id="b", kind="image", shape="rect", bbox=(200, 0, 100, 100)),
+    ]
+
+
+def test_stranded_true_when_outside_all_bboxes():
+    ov = Overlay(id="o", kind="sfx", text="x", anchor=(150.0, 50.0))  # in the gap
+    assert overlay_anchor_stranded(ov, _regions()) is True
+
+
+def test_stranded_false_when_inside_a_bbox():
+    ov = Overlay(id="o", kind="sfx", text="x", anchor=(50.0, 50.0))  # inside region a
+    assert overlay_anchor_stranded(ov, _regions()) is False
+
+
+def test_nearest_region_center_picks_closest():
+    assert nearest_region_center((150.0, 50.0), _regions()) == (250.0, 50.0)
+    assert nearest_region_center((140.0, 50.0), _regions()) == (50.0, 50.0)
+
+
+def test_nearest_region_center_none_when_no_regions():
+    assert nearest_region_center((10.0, 10.0), []) is None
+
+
+def test_reposition_moves_only_stranded():
+    page = PageSpec(page_size_px=(400, 400), regions=_regions(), overlays=[
+        Overlay(id="in", kind="sfx", text="x", anchor=(50.0, 50.0)),    # inside a
+        Overlay(id="out", kind="sfx", text="y", anchor=(150.0, 50.0)),  # stranded -> nearest b
+    ])
+    moved = reposition_stranded_overlays(page)
+    assert moved == 1
+    by_id = {o.id: o.anchor for o in page.overlays}
+    assert by_id["in"] == (50.0, 50.0)        # untouched
+    assert by_id["out"] == (250.0, 50.0)      # moved to region b center
+
+
+def test_reposition_noop_without_regions():
+    page = PageSpec(page_size_px=(400, 400), regions=[], overlays=[
+        Overlay(id="o", kind="sfx", text="x", anchor=(10.0, 10.0))])
+    assert reposition_stranded_overlays(page) == 0

--- a/tests/layout/test_overlay_render.py
+++ b/tests/layout/test_overlay_render.py
@@ -36,3 +36,49 @@ def test_overlays_render_count_and_kinds(qapp):
     page.overlays.append(Overlay(id="sfx", kind="sfx", text="BOOM", anchor=(120.0, 120.0)))
     img = qt_renderer.render_page_to_image(page)
     assert img.width() == 200 and img.height() == 200  # renders without error
+
+
+def _is_white(img, x, y):
+    c = img.pixelColor(x, y)
+    return c.red() > 240 and c.green() > 240 and c.blue() > 240
+
+
+def test_speech_body_fill_and_background(qapp):
+    # blue page so the white balloon fill is unambiguous
+    page = PageSpec(page_size_px=(220, 180), background="#1144CC")
+    page.overlays.append(Overlay(
+        id="b", kind="speech", text="Hello there friend, how are you",
+        anchor=(110.0, 70.0), tail_target=(110.0, 165.0),
+        style=OverlayStyle(fill="#FFFFFF", stroke_px=3.0)))
+    img = qt_renderer.render_page_to_image(page)
+    assert _is_white(img, 110, 70)              # inside the balloon body -> white fill
+    assert not _is_white(img, 5, 5)             # page corner -> blue background
+    # tail extends downward toward the target (a non-background pixel below the body)
+    assert any(not (img.pixelColor(110, y).blue() > 200 and img.pixelColor(110, y).red() < 80)
+               for y in range(110, 160))
+
+
+def test_overlay_z_order_higher_on_top(qapp):
+    page = PageSpec(page_size_px=(200, 200), background="#FFFFFF")
+    page.overlays.append(Overlay(id="low", kind="caption", text="LOW",
+                                 anchor=(60.0, 60.0), anchor_mode="topleft", z=0,
+                                 style=OverlayStyle(fill="#FF0000")))
+    page.overlays.append(Overlay(id="high", kind="caption", text="HIGH",
+                                 anchor=(70.0, 70.0), anchor_mode="topleft", z=5,
+                                 style=OverlayStyle(fill="#00AA00")))
+    img = qt_renderer.render_page_to_image(page)
+    # in the overlap region the higher-z (green) overlay wins
+    c = img.pixelColor(95, 95)
+    assert c.green() > c.red()
+
+
+def test_caption_and_sfx_render(qapp):
+    page = PageSpec(page_size_px=(200, 120), background="#FFFFFF")
+    page.overlays.append(Overlay(id="cap", kind="caption", text="Meanwhile...",
+                                 anchor=(8.0, 8.0), anchor_mode="topleft",
+                                 style=OverlayStyle(fill="#FFFFAA")))
+    page.overlays.append(Overlay(id="sfx", kind="sfx", text="KRAK", anchor=(150.0, 60.0)))
+    img = qt_renderer.render_page_to_image(page)
+    # caption box has its yellow fill
+    c = img.pixelColor(20, 20)
+    assert c.red() > 200 and c.green() > 200 and c.blue() < 200

--- a/tests/layout/test_overlay_render.py
+++ b/tests/layout/test_overlay_render.py
@@ -1,0 +1,38 @@
+"""Renderer overlay pass: smoke tests for Task 6 (measure -> balloons -> draw).
+
+Full pixel-level assertions live in Task 7; these tests verify:
+  1. A speech overlay with a filled+stroked body produces visible dark stroke pixels.
+  2. Multiple overlay kinds (caption, sfx) render without error.
+"""
+from core.layout.models import PageSpec, Overlay, OverlayStyle
+from core.layout import qt_renderer
+
+
+def qt_renderer_pixel_is_dark(img, x, y):
+    c = img.pixelColor(x, y)
+    return c.red() < 80 and c.green() < 80 and c.blue() < 80
+
+
+def test_speech_overlay_renders_body_and_text(qapp):
+    page = PageSpec(page_size_px=(200, 160), background="#FFFFFF")
+    page.overlays.append(Overlay(
+        id="b1", kind="speech", text="Hello there friend",
+        anchor=(100.0, 70.0), tail_target=(100.0, 150.0),
+        style=OverlayStyle(fill="#FFFFFF", stroke_px=3.0, stroke_color="#000000")))
+    img = qt_renderer.render_page_to_image(page)
+    assert img.width() == 200 and img.height() == 160
+    # a black stroked outline pixel exists somewhere on the body perimeter
+    found_stroke = any(
+        qt_renderer_pixel_is_dark(img, x, y)
+        for x in range(40, 160) for y in range(40, 110)
+    )
+    assert found_stroke
+
+
+def test_overlays_render_count_and_kinds(qapp):
+    page = PageSpec(page_size_px=(200, 200), background="#FFFFFF")
+    page.overlays.append(Overlay(id="cap", kind="caption", text="Narration",
+                                 anchor=(10.0, 10.0), anchor_mode="topleft"))
+    page.overlays.append(Overlay(id="sfx", kind="sfx", text="BOOM", anchor=(120.0, 120.0)))
+    img = qt_renderer.render_page_to_image(page)
+    assert img.width() == 200 and img.height() == 200  # renders without error

--- a/tests/layout/test_overlay_render_rotation.py
+++ b/tests/layout/test_overlay_render_rotation.py
@@ -1,0 +1,27 @@
+from core.layout.models import PageSpec, Overlay
+from core.layout import qt_renderer
+
+
+def _page(overlays):
+    return PageSpec(page_size_px=(400, 400), regions=[], overlays=overlays)
+
+
+def test_sfx_overlay_rotation_applied(qapp):
+    ov = Overlay(id="s", kind="sfx", text="POW", anchor=(200.0, 200.0), rotation=30.0)
+    scene = qt_renderer.build_scene(_page([ov]))
+    rots = [it.rotation() for it in scene.items() if hasattr(it, "rotation")]
+    assert any(abs(r - 30.0) < 1e-6 for r in rots)
+
+
+def test_speech_overlay_rotation_applied(qapp):
+    ov = Overlay(id="b", kind="speech", text="hi", anchor=(200.0, 200.0), rotation=45.0)
+    scene = qt_renderer.build_scene(_page([ov]))
+    rots = [it.rotation() for it in scene.items() if hasattr(it, "rotation")]
+    assert any(abs(r - 45.0) < 1e-6 for r in rots)
+
+
+def test_zero_rotation_no_transform(qapp):
+    ov = Overlay(id="b", kind="speech", text="hi", anchor=(200.0, 200.0))
+    scene = qt_renderer.build_scene(_page([ov]))
+    rots = [it.rotation() for it in scene.items() if hasattr(it, "rotation")]
+    assert all(abs(r) < 1e-6 for r in rots)

--- a/tests/layout/test_overlay_rotation.py
+++ b/tests/layout/test_overlay_rotation.py
@@ -1,0 +1,30 @@
+from core.layout.models import Overlay
+from core.layout.schema import overlay_to_dict, overlay_from_dict
+
+
+def _ov(**kw):
+    base = dict(id="o1", kind="sfx", text="BOOM", anchor=(100.0, 100.0))
+    base.update(kw)
+    return Overlay(**base)
+
+
+def test_rotation_defaults_to_zero():
+    assert _ov().rotation == 0.0
+
+
+def test_rotation_round_trips():
+    d = overlay_to_dict(_ov(rotation=37.5))
+    assert d["rotation"] == 37.5
+    assert overlay_from_dict(d).rotation == 37.5
+
+
+def test_rotation_missing_key_loads_zero():
+    d = overlay_to_dict(_ov())
+    del d["rotation"]
+    assert overlay_from_dict(d).rotation == 0.0
+
+
+def test_rotation_non_numeric_degrades_to_zero():
+    d = overlay_to_dict(_ov())
+    d["rotation"] = None
+    assert overlay_from_dict(d).rotation == 0.0

--- a/tests/layout/test_overlay_schema.py
+++ b/tests/layout/test_overlay_schema.py
@@ -1,0 +1,49 @@
+"""Tests for Overlay / OverlayStyle serialization in core.layout.schema."""
+from core.layout.models import Overlay, OverlayStyle, TextStyle
+from core.layout.schema import overlay_to_dict, overlay_from_dict
+
+
+def _roundtrip(ov):
+    return overlay_from_dict(overlay_to_dict(ov))
+
+
+def test_speech_overlay_roundtrip_with_tail_and_style():
+    ov = Overlay(id="o1", kind="speech", text="Hi!", anchor=(50.0, 40.0),
+                 anchor_mode="center", tail_target=(50.0, 90.0), z=2, role="dialogue",
+                 style=OverlayStyle(fill="#FFEE00", stroke_px=3.0, padding_px=12.0,
+                                    radius_px=20.0, max_width_px=180.0))
+    r = _roundtrip(ov)
+    assert r.id == "o1" and r.kind == "speech" and r.text == "Hi!"
+    assert r.anchor == (50.0, 40.0) and r.tail_target == (50.0, 90.0)
+    assert r.z == 2 and r.role == "dialogue"
+    assert r.style.fill == "#FFEE00" and r.style.stroke_px == 3.0
+    assert r.style.padding_px == 12.0 and r.style.radius_px == 20.0
+    assert r.style.max_width_px == 180.0
+
+
+def test_overlay_roundtrip_each_kind():
+    for kind in ("speech", "thought", "caption", "sfx"):
+        ov = Overlay(id=kind, kind=kind, text="x", anchor=(1.0, 2.0))
+        assert _roundtrip(ov).kind == kind
+
+
+def test_overlay_roundtrip_with_text_style():
+    ov = Overlay(id="t", kind="caption", text="cap", anchor=(0.0, 0.0),
+                 text_style=TextStyle(family=["Arial"], size_px=30, color="#112233"))
+    r = _roundtrip(ov)
+    assert r.text_style is not None
+    assert r.text_style.size_px == 30 and r.text_style.color == "#112233"
+
+
+def test_overlay_from_dict_defaults_when_missing_optionals():
+    r = overlay_from_dict({"id": "m", "kind": "sfx", "text": "BOOM", "anchor": [5.0, 6.0]})
+    assert r.anchor == (5.0, 6.0)
+    assert r.tail_target is None and r.role == ""
+    assert isinstance(r.style, OverlayStyle) and r.style.fill == "#FFFFFF"
+
+
+def test_pagespec_without_overlays_loads_empty():
+    # an older page dict (no "overlays" key) must deserialize to overlays == []
+    from core.layout.schema import page_from_dict
+    page = page_from_dict({"page_size_px": [100, 100], "regions": []})
+    assert page.overlays == []

--- a/tests/layout/test_overlay_wiring.py
+++ b/tests/layout/test_overlay_wiring.py
@@ -1,0 +1,56 @@
+from gui.layout.layout_tab import LayoutTab
+from core.layout.models import Region, Overlay
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tab():
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = []
+    tab.document.pages[0].overlays = []
+    tab._refresh()
+    return tab
+
+
+def test_add_overlay_appends_and_snapshots(qapp):
+    tab = _tab()
+    before = len(tab.history.snapshots())
+    tab._add_overlay("speech")
+    ovs = tab.document.pages[0].overlays
+    assert len(ovs) == 1 and ovs[0].kind == "speech"
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_delete_overlay_removes_and_snapshots(qapp):
+    tab = _tab()
+    tab._add_overlay("sfx")
+    oid = tab.document.pages[0].overlays[0].id
+    before = len(tab.history.snapshots())
+    tab._delete_overlay(oid)
+    assert tab.document.pages[0].overlays == []
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_set_overlay_rotation_writes_model(qapp):
+    tab = _tab()
+    tab._add_overlay("sfx")
+    oid = tab.document.pages[0].overlays[0].id
+    tab._set_overlay_rotation(oid, 75)
+    assert tab.document.pages[0].overlays[0].rotation == 75
+
+
+def test_apply_designer_regions_only_repositions_overlays(qapp):
+    tab = _tab()
+    tab.document.pages[0].overlays = [
+        Overlay(id="o", kind="sfx", text="x", anchor=(5.0, 5.0))]  # will be stranded
+
+    class R:  # minimal designer result: regions only, no overlays
+        regions = [Region(id="r", kind="image", shape="rect", bbox=(200, 200, 100, 100))]
+        overlays = []
+    tab.apply_designer_result(R())
+    assert tab.document.pages[0].overlays[0].anchor == (250.0, 250.0)

--- a/tests/layout/test_polygon.py
+++ b/tests/layout/test_polygon.py
@@ -85,3 +85,48 @@ def test_inset_large_dist_on_short_edge_not_falsely_collapsed():
     out = inset_polygon(rect, [0.5, 1.2, 0.5, 0.6])
     assert out is not None
     assert signed_area(out) > 0
+
+
+from core.layout.polygon import union_polygons
+
+
+def test_union_two_adjacent_squares_is_rectangle():
+    left = [(0.0, 0.0), (5.0, 0.0), (5.0, 10.0), (0.0, 10.0)]
+    right = [(5.0, 0.0), (10.0, 0.0), (10.0, 10.0), (5.0, 10.0)]
+    rings = union_polygons([left, right])
+    assert len(rings) == 1
+    ring = rings[0]
+    xs = sorted({round(x, 3) for x, _ in ring})
+    ys = sorted({round(y, 3) for _, y in ring})
+    assert xs == [0.0, 10.0] and ys == [0.0, 10.0]
+    assert len(ring) == 4  # the shared interior edge is gone
+
+
+def test_union_makes_concave_L():
+    # bottom wide strip + top-left square -> L shape
+    bottom = [(0.0, 6.0), (10.0, 6.0), (10.0, 10.0), (0.0, 10.0)]
+    topleft = [(0.0, 0.0), (4.0, 0.0), (4.0, 6.0), (0.0, 6.0)]
+    rings = union_polygons([bottom, topleft])
+    assert len(rings) == 1
+    assert len(rings[0]) == 6  # L-shape has 6 vertices (one reflex)
+
+
+def test_union_partial_shared_edge():
+    # right cell is shorter than left's full edge -> partial colinear overlap
+    left = [(0.0, 0.0), (5.0, 0.0), (5.0, 10.0), (0.0, 10.0)]
+    right = [(5.0, 0.0), (10.0, 0.0), (10.0, 5.0), (5.0, 5.0)]
+    rings = union_polygons([left, right])
+    assert len(rings) == 1
+    assert abs(_area(rings[0]) - 75.0) < 1e-6  # 50 + 25
+
+
+def test_union_disconnected_returns_two_rings():
+    a = [(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)]
+    b = [(8.0, 8.0), (10.0, 8.0), (10.0, 10.0), (8.0, 10.0)]
+    rings = union_polygons([a, b])
+    assert len(rings) == 2
+
+
+def _area(poly):
+    from core.layout.polygon import signed_area
+    return abs(signed_area(poly))

--- a/tests/layout/test_polygon.py
+++ b/tests/layout/test_polygon.py
@@ -1,0 +1,44 @@
+from core.layout.polygon import (
+    signed_area, ensure_orientation, clip_halfplane, polygon_to_segments,
+)
+
+
+SQUARE = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]  # positive area in screen coords
+
+
+def test_signed_area_positive_for_canonical_square():
+    assert signed_area(SQUARE) == 100.0
+
+
+def test_ensure_orientation_flips_negative():
+    rev = list(reversed(SQUARE))
+    assert signed_area(rev) == -100.0
+    fixed = ensure_orientation(rev)
+    assert signed_area(fixed) == 100.0
+
+
+def test_ensure_orientation_keeps_positive():
+    assert ensure_orientation(SQUARE) == SQUARE
+
+
+def test_clip_halfplane_keeps_left_half():
+    # vertical line downward through x=5: a=(5,0)->b=(5,10); left of downward is x<5
+    clipped = clip_halfplane(SQUARE, (5.0, 0.0), (5.0, 10.0))
+    xs = sorted({round(x, 3) for x, _ in clipped})
+    assert xs == [0.0, 5.0]  # west half only
+    assert abs(signed_area(clipped)) == 50.0
+
+
+def test_clip_halfplane_other_side_by_reversing():
+    clipped = clip_halfplane(SQUARE, (5.0, 10.0), (5.0, 0.0))  # reversed -> east half
+    xs = sorted({round(x, 3) for x, _ in clipped})
+    assert xs == [5.0, 10.0]
+
+
+def test_polygon_to_segments_round_trip_shape():
+    segs = polygon_to_segments([(1.0, 2.0), (3.0, 2.0), (2.0, 5.0)])
+    assert [s.type for s in segs] == ["move", "line", "line", "close"]
+    assert segs[0].pts == [(1.0, 2.0)]
+    assert segs[1].pts == [(3.0, 2.0)]
+    assert segs[2].pts == [(2.0, 5.0)]
+    assert segs[3].pts == []

--- a/tests/layout/test_polygon.py
+++ b/tests/layout/test_polygon.py
@@ -76,3 +76,12 @@ def test_inset_concave_L_keeps_reflex():
 def test_inset_collapse_returns_none():
     sq = [(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]
     assert inset_polygon(sq, [3.0, 3.0, 3.0, 3.0]) is None  # 3+3 > 4 each axis -> collapse
+
+
+def test_inset_large_dist_on_short_edge_not_falsely_collapsed():
+    # 10x2 rectangle; a big inset (1.2) on a short (len-2) edge still leaves
+    # plenty of width -> must NOT collapse (the old heuristic wrongly dropped this).
+    rect = [(0.0, 0.0), (10.0, 0.0), (10.0, 2.0), (0.0, 2.0)]
+    out = inset_polygon(rect, [0.5, 1.2, 0.5, 0.6])
+    assert out is not None
+    assert signed_area(out) > 0

--- a/tests/layout/test_polygon.py
+++ b/tests/layout/test_polygon.py
@@ -1,5 +1,5 @@
 from core.layout.polygon import (
-    signed_area, ensure_orientation, clip_halfplane, polygon_to_segments,
+    signed_area, ensure_orientation, clip_halfplane, polygon_to_segments, inset_polygon,
 )
 
 
@@ -42,3 +42,37 @@ def test_polygon_to_segments_round_trip_shape():
     assert segs[1].pts == [(3.0, 2.0)]
     assert segs[2].pts == [(2.0, 5.0)]
     assert segs[3].pts == []
+
+
+def test_inset_square_uniform():
+    sq = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]
+    out = inset_polygon(sq, [1.0, 1.0, 1.0, 1.0])
+    xs = sorted({round(x, 3) for x, _ in out})
+    ys = sorted({round(y, 3) for _, y in out})
+    assert xs == [1.0, 9.0]
+    assert ys == [1.0, 9.0]
+
+
+def test_inset_square_per_edge_distances():
+    # edges: 0:(0,0)->(10,0) top, 1:(10,0)->(10,10) right, 2:(10,10)->(0,10) bottom, 3:(0,10)->(0,0) left
+    sq = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]
+    out = inset_polygon(sq, [2.0, 1.0, 2.0, 1.0])  # top/bottom in 2, left/right in 1
+    xs = sorted({round(x, 3) for x, _ in out})
+    ys = sorted({round(y, 3) for _, y in out})
+    assert xs == [1.0, 9.0]   # left/right edges moved 1
+    assert ys == [2.0, 8.0]   # top/bottom edges moved 2
+
+
+def test_inset_concave_L_keeps_reflex():
+    # L-shape (concave): 6 vertices, positive area
+    L = [(0.0, 0.0), (10.0, 0.0), (10.0, 4.0), (4.0, 4.0), (4.0, 10.0), (0.0, 10.0)]
+    out = inset_polygon(L, [1.0] * 6)
+    assert out is not None
+    assert len(out) == 6                      # still an L (one reflex vertex)
+    assert signed_area(out) > 0
+    assert signed_area(out) < signed_area(L)  # shrunk
+
+
+def test_inset_collapse_returns_none():
+    sq = [(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]
+    assert inset_polygon(sq, [3.0, 3.0, 3.0, 3.0]) is None  # 3+3 > 4 each axis -> collapse

--- a/tests/layout/test_region_ops.py
+++ b/tests/layout/test_region_ops.py
@@ -72,3 +72,30 @@ def test_split_curved_path_none():
         PathSegment(type="close", pts=[]),
     ])
     assert split_region(r, (10.0, 0.0), (10.0, 50.0)) is None
+
+
+from core.layout.region_ops import merge_regions
+
+
+def test_merge_adjacent_squares():
+    left = Region(id="L", kind="image", shape="rect", bbox=(0, 0, 50, 100), z=3)
+    right = Region(id="R", kind="image", shape="rect", bbox=(50, 0, 50, 100))
+    m = merge_regions(left, right)
+    assert m is not None
+    assert m.id == "L" and m.shape == "polygon" and m.z == 3
+    assert m.bbox == (0, 0, 100, 100)
+
+
+def test_merge_disjoint_returns_none():
+    left = Region(id="L", kind="image", shape="rect", bbox=(0, 0, 50, 100))
+    far = Region(id="R", kind="image", shape="rect", bbox=(60, 0, 50, 100))
+    assert merge_regions(left, far) is None
+
+
+def test_merge_curved_returns_none():
+    left = Region(id="L", kind="image", shape="rect", bbox=(0, 0, 50, 100))
+    curved = Region(id="C", kind="image", shape="path", bbox=(0, 0, 3, 3), segments=[
+        PathSegment(type="move", pts=[(0.0, 0.0)]),
+        PathSegment(type="cubic", pts=[(1.0, 1.0), (2.0, 2.0), (3.0, 3.0)]),
+    ])
+    assert merge_regions(left, curved) is None

--- a/tests/layout/test_region_ops.py
+++ b/tests/layout/test_region_ops.py
@@ -1,0 +1,38 @@
+from core.layout.models import Region, PathSegment
+from core.layout.region_ops import region_to_polygon
+
+
+def test_region_to_polygon_rect():
+    r = Region(id="r", kind="image", shape="rect", bbox=(10, 20, 100, 40))
+    assert region_to_polygon(r) == [
+        (10.0, 20.0), (110.0, 20.0), (110.0, 60.0), (10.0, 60.0)]
+
+
+def test_region_to_polygon_polygon():
+    r = Region(id="p", kind="image", shape="polygon",
+               points=[(0, 0), (40, 0), (40, 30)], bbox=(0, 0, 40, 30))
+    assert region_to_polygon(r) == [(0.0, 0.0), (40.0, 0.0), (40.0, 30.0)]
+
+
+def test_region_to_polygon_straight_path():
+    r = Region(id="q", kind="image", shape="path", bbox=(0, 0, 50, 50), segments=[
+        PathSegment(type="move", pts=[(0.0, 0.0)]),
+        PathSegment(type="line", pts=[(50.0, 0.0)]),
+        PathSegment(type="line", pts=[(50.0, 50.0)]),
+        PathSegment(type="close", pts=[]),
+    ])
+    assert region_to_polygon(r) == [(0.0, 0.0), (50.0, 0.0), (50.0, 50.0)]
+
+
+def test_region_to_polygon_curved_path_none():
+    r = Region(id="c", kind="image", shape="path", bbox=(0, 0, 50, 50), segments=[
+        PathSegment(type="move", pts=[(0.0, 0.0)]),
+        PathSegment(type="cubic", pts=[(10.0, 10.0), (20.0, 20.0), (50.0, 50.0)]),
+        PathSegment(type="close", pts=[]),
+    ])
+    assert region_to_polygon(r) is None
+
+
+def test_region_to_polygon_degenerate_polygon_none():
+    r = Region(id="d", kind="image", shape="polygon", points=[(0, 0), (1, 1)], bbox=(0, 0, 1, 1))
+    assert region_to_polygon(r) is None

--- a/tests/layout/test_region_ops.py
+++ b/tests/layout/test_region_ops.py
@@ -36,3 +36,39 @@ def test_region_to_polygon_curved_path_none():
 def test_region_to_polygon_degenerate_polygon_none():
     r = Region(id="d", kind="image", shape="polygon", points=[(0, 0), (1, 1)], bbox=(0, 0, 1, 1))
     assert region_to_polygon(r) is None
+
+
+from core.layout.region_ops import split_region
+
+
+def _square(id="s"):
+    return Region(id=id, kind="image", shape="rect", bbox=(0, 0, 100, 100),
+                  bleed=True, z=5)
+
+
+def test_split_square_vertical_midline():
+    out = split_region(_square(), (50.0, 0.0), (50.0, 100.0))
+    assert out is not None
+    a, b = out
+    assert a.shape == "polygon" and b.shape == "polygon"
+    assert a.id == "s_a" and b.id == "s_b"
+    assert a.bleed is True and a.z == 5  # identity/style copied
+    xranges = sorted([
+        (min(p[0] for p in a.points), max(p[0] for p in a.points)),
+        (min(p[0] for p in b.points), max(p[0] for p in b.points)),
+    ])
+    assert xranges == [(0, 50), (50, 100)]
+
+
+def test_split_miss_returns_none():
+    # vertical line entirely to the right of the square -> one side empty
+    assert split_region(_square(), (200.0, 0.0), (200.0, 100.0)) is None
+
+
+def test_split_curved_path_none():
+    r = Region(id="c", kind="image", shape="path", bbox=(0, 0, 50, 50), segments=[
+        PathSegment(type="move", pts=[(0.0, 0.0)]),
+        PathSegment(type="quad", pts=[(25.0, 25.0), (50.0, 0.0)]),
+        PathSegment(type="close", pts=[]),
+    ])
+    assert split_region(r, (10.0, 0.0), (10.0, 50.0)) is None

--- a/tests/layout/test_region_ops_gui.py
+++ b/tests/layout/test_region_ops_gui.py
@@ -1,0 +1,66 @@
+from gui.layout.layout_tab import LayoutTab
+from core.layout.models import Region
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tab_with(regions):
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = regions
+    tab._refresh()
+    return tab
+
+
+def test_apply_delete_removes_and_snapshots(qapp):
+    tab = _tab_with([
+        Region(id="a", kind="image", shape="rect", bbox=(0, 0, 50, 50)),
+        Region(id="b", kind="image", shape="rect", bbox=(50, 0, 50, 50)),
+    ])
+    before = len(tab.history.snapshots())
+    assert tab._apply_delete("a") is True
+    assert [r.id for r in tab.document.pages[0].regions] == ["b"]
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_apply_knife_splits_in_place(qapp):
+    tab = _tab_with([Region(id="x", kind="image", shape="rect", bbox=(0, 0, 100, 100))])
+    before = len(tab.history.snapshots())
+    assert tab._apply_knife("x", (50.0, 0.0), (50.0, 100.0)) is True
+    assert [r.id for r in tab.document.pages[0].regions] == ["x_a", "x_b"]
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_apply_knife_miss_no_change(qapp):
+    tab = _tab_with([Region(id="x", kind="image", shape="rect", bbox=(0, 0, 100, 100))])
+    before = len(tab.history.snapshots())
+    assert tab._apply_knife("x", (200.0, 0.0), (200.0, 100.0)) is False
+    assert [r.id for r in tab.document.pages[0].regions] == ["x"]
+    assert len(tab.history.snapshots()) == before
+
+
+def test_apply_merge_combines(qapp):
+    tab = _tab_with([
+        Region(id="L", kind="image", shape="rect", bbox=(0, 0, 50, 100)),
+        Region(id="R", kind="image", shape="rect", bbox=(50, 0, 50, 100)),
+    ])
+    before = len(tab.history.snapshots())
+    assert tab._apply_merge("L", "R") is True
+    assert [r.id for r in tab.document.pages[0].regions] == ["L"]
+    assert tab.document.pages[0].regions[0].bbox == (0, 0, 100, 100)
+    assert len(tab.history.snapshots()) == before + 1
+
+
+def test_apply_merge_disjoint_no_change(qapp):
+    tab = _tab_with([
+        Region(id="L", kind="image", shape="rect", bbox=(0, 0, 50, 100)),
+        Region(id="R", kind="image", shape="rect", bbox=(60, 0, 50, 100)),
+    ])
+    before = len(tab.history.snapshots())
+    assert tab._apply_merge("L", "R") is False
+    assert len(tab.document.pages[0].regions) == 2
+    assert len(tab.history.snapshots()) == before

--- a/tests/layout/test_region_ops_wiring.py
+++ b/tests/layout/test_region_ops_wiring.py
@@ -1,0 +1,50 @@
+from gui.layout.layout_tab import LayoutTab
+from gui.layout.geometry_inspector import GeometryInspector
+from core.layout.models import Region
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def _tab_with(regions):
+    tab = LayoutTab(config=FakeConfig())
+    tab.document.pages[0].regions = regions
+    tab._refresh()
+    return tab
+
+
+def test_inspector_emits_delete_and_toggles(qapp):
+    insp = GeometryInspector()
+    r = Region(id="p", kind="image", shape="polygon",
+               points=[(0, 0), (10, 0), (10, 10)], bbox=(0, 0, 10, 10))
+    insp.set_region(r)
+    seen = []
+    insp.deleteRequested.connect(lambda rid: seen.append(("del", rid)))
+    insp.knifeToggled.connect(lambda rid, on: seen.append(("knife", rid, on)))
+    insp.delete_btn.click()
+    insp.knife_btn.setChecked(True)
+    assert ("del", "p") in seen
+    assert ("knife", "p", True) in seen
+
+
+def test_knife_wiring_end_to_end(qapp):
+    tab = _tab_with([Region(id="x", kind="image", shape="rect", bbox=(0, 0, 100, 100))])
+    tab._on_region_knife_toggled("x", True)
+    assert tab.canvas.tool_mode() == "knife"
+    tab.canvas.knifeLine.emit(50.0, 0.0, 50.0, 100.0)
+    assert [r.id for r in tab.document.pages[0].regions] == ["x_a", "x_b"]
+
+
+def test_merge_wiring_end_to_end(qapp):
+    tab = _tab_with([
+        Region(id="L", kind="image", shape="rect", bbox=(0, 0, 50, 100)),
+        Region(id="R", kind="image", shape="rect", bbox=(50, 0, 50, 100)),
+    ])
+    tab._on_region_merge_toggled("L", True)
+    assert tab.canvas.tool_mode() == "merge"
+    tab.canvas.mergeTarget.emit("R")
+    assert [r.id for r in tab.document.pages[0].regions] == ["L"]

--- a/tests/layout/test_region_ops_wiring.py
+++ b/tests/layout/test_region_ops_wiring.py
@@ -48,3 +48,24 @@ def test_merge_wiring_end_to_end(qapp):
     assert tab.canvas.tool_mode() == "merge"
     tab.canvas.mergeTarget.emit("R")
     assert [r.id for r in tab.document.pages[0].regions] == ["L"]
+
+
+def test_op_completion_unchecks_tool_button(qapp):
+    tab = _tab_with([Region(id="x", kind="image", shape="rect", bbox=(0, 0, 100, 100))])
+    tab._on_region_knife_toggled("x", True)
+    assert tab.geometry_inspector.knife_btn.isChecked() is True
+    tab.canvas.knifeLine.emit(50.0, 0.0, 50.0, 100.0)
+    assert tab.geometry_inspector.knife_btn.isChecked() is False
+    assert tab.canvas.tool_mode() == "none"
+
+
+def test_selection_change_disarms_tool(qapp):
+    tab = _tab_with([
+        Region(id="a", kind="image", shape="rect", bbox=(0, 0, 50, 50)),
+        Region(id="b", kind="image", shape="rect", bbox=(50, 0, 50, 50)),
+    ])
+    tab._on_region_knife_toggled("a", True)
+    assert tab.canvas.tool_mode() == "knife"
+    tab._on_region_selected("b")
+    assert tab.canvas.tool_mode() == "none"
+    assert tab._knife_region_id is None

--- a/tests/layout/test_region_path_builder.py
+++ b/tests/layout/test_region_path_builder.py
@@ -1,0 +1,34 @@
+from core.layout.models import Region, PathSegment
+from core.layout import qt_renderer
+
+
+def test_rect_region_path_matches_bbox(qapp):
+    r = Region(id="r", kind="image", shape="rect", bbox=(10, 20, 30, 40))
+    p = qt_renderer.region_to_painter_path(r)
+    b = p.boundingRect()
+    assert (round(b.x()), round(b.y()), round(b.width()), round(b.height())) == (10, 20, 30, 40)
+
+
+def test_polygon_region_path_matches_points(qapp):
+    r = Region(id="r", kind="image", shape="polygon", points=[(0, 0), (50, 0), (25, 40)])
+    b = qt_renderer.region_to_painter_path(r).boundingRect()
+    assert (round(b.x()), round(b.y()), round(b.width()), round(b.height())) == (0, 0, 50, 40)
+
+
+def test_path_region_builds_from_segments(qapp):
+    segs = [PathSegment(type="move", pts=[(0.0, 0.0)]),
+            PathSegment(type="line", pts=[(60.0, 0.0)]),
+            PathSegment(type="line", pts=[(30.0, 50.0)]),
+            PathSegment(type="close", pts=[])]
+    b = qt_renderer.region_to_painter_path(
+        Region(id="r", kind="image", shape="path", segments=segs)).boundingRect()
+    assert (round(b.x()), round(b.y()), round(b.width()), round(b.height())) == (0, 0, 60, 50)
+
+
+def test_invalid_segments_fall_back_to_bbox(qapp):
+    # cubic with too few points -> invalid -> bbox rect
+    segs = [PathSegment(type="move", pts=[(0.0, 0.0)]),
+            PathSegment(type="cubic", pts=[(1.0, 1.0)])]
+    r = Region(id="r", kind="image", shape="path", segments=segs, bbox=(5, 5, 20, 20))
+    b = qt_renderer.region_to_painter_path(r).boundingRect()
+    assert (round(b.x()), round(b.y()), round(b.width()), round(b.height())) == (5, 5, 20, 20)

--- a/tests/layout/test_region_path_builder.py
+++ b/tests/layout/test_region_path_builder.py
@@ -32,3 +32,13 @@ def test_invalid_segments_fall_back_to_bbox(qapp):
     r = Region(id="r", kind="image", shape="path", segments=segs, bbox=(5, 5, 20, 20))
     b = qt_renderer.region_to_painter_path(r).boundingRect()
     assert (round(b.x()), round(b.y()), round(b.width()), round(b.height())) == (5, 5, 20, 20)
+
+
+def test_empty_path_segments_falls_back_and_logs(qapp, caplog):
+    import logging
+    from core.layout.models import Region
+    r = Region(id="ep", kind="image", shape="path", segments=[], bbox=(5, 5, 20, 20))
+    with caplog.at_level(logging.WARNING):
+        b = qt_renderer.region_to_painter_path(r).boundingRect()
+    assert (round(b.x()), round(b.y()), round(b.width()), round(b.height())) == (5, 5, 20, 20)
+    assert any("no segments" in rec.message or "shape='path'" in rec.message for rec in caplog.records)

--- a/tests/layout/test_region_path_fields.py
+++ b/tests/layout/test_region_path_fields.py
@@ -1,0 +1,22 @@
+from core.layout.models import Region, PathSegment
+
+
+def test_region_defaults_have_empty_segments_and_no_bleed():
+    r = Region(id="r", kind="image")
+    assert r.shape == "rect"
+    assert r.segments == []
+    assert r.bleed is False
+
+
+def test_region_accepts_path_shape_and_segments():
+    segs = [
+        PathSegment(type="move", pts=[(0.0, 0.0)]),
+        PathSegment(type="line", pts=[(10.0, 0.0)]),
+        PathSegment(type="cubic", pts=[(10.0, 5.0), (5.0, 10.0), (0.0, 10.0)]),
+        PathSegment(type="close", pts=[]),
+    ]
+    r = Region(id="r", kind="image", shape="path", segments=segs, bleed=True)
+    assert r.shape == "path"
+    assert r.segments[2].type == "cubic"
+    assert len(r.segments[2].pts) == 3
+    assert r.bleed is True

--- a/tests/layout/test_schema_path.py
+++ b/tests/layout/test_schema_path.py
@@ -1,0 +1,35 @@
+from core.layout.models import Region, PathSegment
+from core.layout.schema import (
+    region_to_dict, region_from_dict, normalize_region, REGION_JSON_SCHEMA,
+)
+
+
+def _segs():
+    return [
+        PathSegment(type="move", pts=[(10.0, 10.0)]),
+        PathSegment(type="line", pts=[(90.0, 10.0)]),
+        PathSegment(type="line", pts=[(50.0, 80.0)]),
+        PathSegment(type="close", pts=[]),
+    ]
+
+
+def test_path_region_round_trips():
+    r = Region(id="p", kind="image", shape="path", segments=_segs(), bleed=True)
+    r2 = region_from_dict(region_to_dict(r))
+    assert r2.shape == "path"
+    assert r2.bleed is True
+    assert [s.type for s in r2.segments] == ["move", "line", "line", "close"]
+    assert r2.segments[1].pts == [(90.0, 10.0)]
+
+
+def test_schema_advertises_path_segments_bleed():
+    assert "path" in REGION_JSON_SCHEMA["properties"]["shape"]["enum"]
+    assert "segments" in REGION_JSON_SCHEMA["properties"]
+    assert "bleed" in REGION_JSON_SCHEMA["properties"]
+
+
+def test_normalize_region_derives_bbox_from_segments():
+    r = Region(id="p", kind="image", shape="path", segments=_segs())
+    n = normalize_region(r, (200, 200))
+    # bbox = bounding box of points (10,10)-(90,80)
+    assert n.bbox == (10, 10, 80, 70)

--- a/tests/layout/test_svg_path.py
+++ b/tests/layout/test_svg_path.py
@@ -1,0 +1,67 @@
+from core.layout.models import PathSegment
+from core.layout.svg_path import svg_to_segments, segments_to_svg
+
+
+def test_parse_basic_absolute_commands():
+    segs = svg_to_segments("M10 10 L90 10 L90 90 Z")
+    assert [s.type for s in segs] == ["move", "line", "line", "close"]
+    assert segs[0].pts == [(10.0, 10.0)]
+    assert segs[2].pts == [(90.0, 90.0)]
+
+
+def test_h_and_v_commands():
+    segs = svg_to_segments("M10 10 H50 V40")
+    assert segs[1].type == "line" and segs[1].pts == [(50.0, 10.0)]
+    assert segs[2].type == "line" and segs[2].pts == [(50.0, 40.0)]
+
+
+def test_relative_commands_accumulate():
+    segs = svg_to_segments("m10 10 l20 0 l0 20 z")
+    assert segs[0].pts == [(10.0, 10.0)]
+    assert segs[1].pts == [(30.0, 10.0)]
+    assert segs[2].pts == [(30.0, 30.0)]
+    assert segs[3].type == "close"
+
+
+def test_implicit_line_after_moveto():
+    # extra coordinate pairs after M are implicit L
+    segs = svg_to_segments("M0 0 10 0 10 10")
+    assert [s.type for s in segs] == ["move", "line", "line"]
+    assert segs[2].pts == [(10.0, 10.0)]
+
+
+def test_cubic_command():
+    segs = svg_to_segments("M0 0 C1 2 3 4 5 6")
+    assert segs[1].type == "cubic"
+    assert segs[1].pts == [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
+
+
+def test_quad_command():
+    segs = svg_to_segments("M0 0 Q1 2 3 4")
+    assert segs[1].type == "quad"
+    assert segs[1].pts == [(1.0, 2.0), (3.0, 4.0)]
+
+
+def test_round_trip_segments_to_svg_to_segments():
+    segs = [
+        PathSegment(type="move", pts=[(10.0, 10.0)]),
+        PathSegment(type="line", pts=[(90.0, 10.0)]),
+        PathSegment(type="cubic", pts=[(95.0, 10.0), (95.0, 15.0), (95.0, 20.0)]),
+        PathSegment(type="quad", pts=[(50.0, 80.0), (10.0, 20.0)]),
+        PathSegment(type="close", pts=[]),
+    ]
+    assert svg_to_segments(segments_to_svg(segs)) == segs
+
+
+def test_malformed_input_degrades_without_raising():
+    # 'C' needs 6 args; only 3 given -> keep the valid move, stop, no crash
+    segs = svg_to_segments("M0 0 C1 2 3")
+    assert segs == [PathSegment(type="move", pts=[(0.0, 0.0)])]
+
+
+def test_number_before_command_returns_empty():
+    assert svg_to_segments("10 10 L20 20") == []
+
+
+def test_empty_string_returns_empty():
+    assert svg_to_segments("") == []

--- a/tests/layout/test_text_clip.py
+++ b/tests/layout/test_text_clip.py
@@ -1,0 +1,24 @@
+from PySide6.QtWidgets import QGraphicsItem, QGraphicsSimpleTextItem
+from core.layout.models import Region, PageSpec
+from core.layout import qt_renderer
+
+
+def test_text_is_child_of_a_clipping_path_item(qapp):
+    page = PageSpec(page_size_px=(400, 200), regions=[
+        Region(id="t", kind="text", bbox=(0, 0, 100, 40), text="Hello world")])
+    scene = qt_renderer.build_scene(page)  # export path (selectable=False)
+    texts = [it for it in scene.items() if isinstance(it, QGraphicsSimpleTextItem)]
+    assert texts, "expected a text item"
+    parent = texts[0].parentItem()
+    assert parent is not None
+    assert bool(parent.flags() & QGraphicsItem.ItemClipsChildrenToShape)
+
+
+def test_guide_box_still_editor_only(qapp):
+    from PySide6.QtWidgets import QGraphicsRectItem
+    page = PageSpec(page_size_px=(400, 200), regions=[
+        Region(id="t", kind="text", bbox=(0, 0, 100, 40), text="Hi")])
+    editor = qt_renderer.build_scene(page, selectable=True)
+    assert any(isinstance(it, QGraphicsRectItem) and it.data(0) == "t" for it in editor.items())
+    export = qt_renderer.build_scene(page, selectable=False)
+    assert not any(isinstance(it, QGraphicsRectItem) and it.data(0) == "t" for it in export.items())

--- a/tests/layout/test_tiling.py
+++ b/tests/layout/test_tiling.py
@@ -1,0 +1,37 @@
+from core.layout.tiling import Split, Leaf, tile
+
+
+def _bbox(region):
+    return tuple(round(v) for v in __import__("core.layout.geometry", fromlist=["segments_bbox"]).segments_bbox(region.segments))
+
+
+def test_single_leaf_full_page_has_margin():
+    tree = Leaf(id="only")
+    regions = tile(tree, (0, 0, 100, 100), gutter=10, margin=8)
+    assert len(regions) == 1
+    x, y, w, h = _bbox(regions[0])
+    # all four edges are page boundary -> inset by margin (8) on each side
+    assert (x, y, w, h) == (8, 8, 84, 84)
+
+
+def test_grid_2x2_gutters_and_margin():
+    # vertical split into left/right, each split into top/bottom
+    col = lambda pfx: Split(axis="y", at=0.5, a=Leaf(id=pfx + "t"), b=Leaf(id=pfx + "b"))
+    tree = Split(axis="x", at=0.5, a=col("L"), b=col("R"))
+    regions = {r.id: _bbox(r) for r in tile(tree, (0, 0, 100, 100), gutter=10, margin=10)}
+    assert len(regions) == 4
+    # left-top panel: left/top edges are page border (margin 10), right/bottom are interior (gutter/2 = 5)
+    # page split at x=50, y=50 -> Lt cell is (0,0,50,50); inset L/T by 10, R/B by 5
+    assert regions["Lt"] == (10, 10, 35, 35)   # x:10..45, y:10..45
+    assert regions["Rb"] == (55, 55, 35, 35)   # mirror
+    # gutter between Lt and Rt = (55 - 45) = 10 == gutter
+    assert regions["Rt"][0] - (regions["Lt"][0] + regions["Lt"][2]) == 10
+
+
+def test_angled_cut_produces_non_axis_aligned_edge():
+    tree = Split(axis="x", at=0.5, a=Leaf(id="L"), b=Leaf(id="R"), skew=0.5)
+    regions = {r.id: r for r in tile(tree, (0, 0, 100, 100), gutter=8, margin=8)}
+    left = regions["L"]
+    # the shared (interior) edge is slanted: its two endpoints differ in x
+    xs = sorted({round(p.pts[0][0], 2) for p in left.segments if p.pts})
+    assert max(xs) - min(xs) > 1.0  # not a single vertical line -> angled

--- a/tests/layout/test_tiling.py
+++ b/tests/layout/test_tiling.py
@@ -1,4 +1,5 @@
 from core.layout.tiling import Split, Leaf, tile
+from core.layout.geometry import segments_bbox
 
 
 def _bbox(region):
@@ -35,3 +36,41 @@ def test_angled_cut_produces_non_axis_aligned_edge():
     # the shared (interior) edge is slanted: its two endpoints differ in x
     xs = sorted({round(p.pts[0][0], 2) for p in left.segments if p.pts})
     assert max(xs) - min(xs) > 1.0  # not a single vertical line -> angled
+
+
+def test_merge_group_forms_one_concave_panel():
+    # 3 cells; merge top-left + bottom (full width) into an L; top-right stays.
+    # layout: top tier split L/R; bottom tier full width.
+    top = Split(axis="x", at=0.5, a=Leaf(id="tl", merge="hero"), b=Leaf(id="tr"))
+    tree = Split(axis="y", at=0.5, a=top, b=Leaf(id="bottom", merge="hero"))
+    regions = {r.id: r for r in tile(tree, (0, 0, 100, 100), gutter=6, margin=6)}
+    # merged panel takes the first-encountered merged leaf's id ("tl"); "bottom" is absorbed
+    assert "tl" in regions and "bottom" not in regions and "tr" in regions
+    assert len(regions) == 2
+    hero = regions["tl"]
+    # concave L panel has more than 4 vertices (move + N lines + close)
+    line_pts = [s for s in hero.segments if s.type == "line"]
+    assert len(line_pts) >= 5  # L-shape -> >=6 vertices total
+
+
+def test_bleed_leaf_boundary_edges_reach_page_rect():
+    tree = Split(axis="x", at=0.5, a=Leaf(id="L", bleed=True), b=Leaf(id="R"))
+    regions = {r.id: r for r in tile(tree, (0, 0, 100, 100), gutter=10, margin=10)}
+    lx, ly, lw, lh = (round(v) for v in segments_bbox(regions["L"].segments))
+    # bleed: left/top/bottom boundary edges NOT inset (reach 0,0 and y=0..100); only the
+    # interior right edge insets by gutter/2 (5).
+    assert lx == 0 and ly == 0
+    assert lh == 100
+    assert lx + lw == 45  # 50 (cut) - 5 (interior gutter/2)
+
+
+def test_disconnected_merge_is_logged_and_unmerged(caplog):
+    import logging
+    # two non-adjacent cells share a merge key -> cannot union -> stay separate
+    top = Split(axis="x", at=0.5, a=Leaf(id="tl", merge="x"), b=Leaf(id="tr"))
+    tree = Split(axis="y", at=0.5, a=top, b=Split(axis="x", at=0.5, a=Leaf(id="bl"), b=Leaf(id="br", merge="x")))
+    with caplog.at_level(logging.ERROR):
+        regions = {r.id: r for r in tile(tree, (0, 0, 100, 100), gutter=6, margin=6)}
+    # tl and br are diagonal (not edge-adjacent) -> union yields 2 rings -> unmerged
+    assert "tl" in regions and "br" in regions
+    assert any("merge" in rec.message.lower() for rec in caplog.records)

--- a/tests/layout/test_tiling_apply.py
+++ b/tests/layout/test_tiling_apply.py
@@ -1,5 +1,5 @@
 from core.layout.models import PageSpec, Region
-from core.layout.tiling import grid, three_tiers, diagonal_action, feature_L, apply_tiling, tile
+from core.layout.tiling import grid, three_tiers, splash_with_strip, diagonal_action, feature_L, apply_tiling, tile
 from core.layout.geometry import validate_segments
 from core.layout.schema import region_to_dict, region_from_dict
 
@@ -9,7 +9,7 @@ def test_grid_preset_counts():
 
 
 def test_named_presets_build_and_tile():
-    for tree in (three_tiers(), diagonal_action(), feature_L()):
+    for tree in (three_tiers(), splash_with_strip(), diagonal_action(), feature_L()):
         regions = tile(tree, (0, 0, 200, 300), gutter=8, margin=10)
         assert regions  # non-empty
         for r in regions:

--- a/tests/layout/test_tiling_apply.py
+++ b/tests/layout/test_tiling_apply.py
@@ -1,0 +1,37 @@
+from core.layout.models import PageSpec, Region
+from core.layout.tiling import grid, three_tiers, diagonal_action, feature_L, apply_tiling, tile
+from core.layout.geometry import validate_segments
+from core.layout.schema import region_to_dict, region_from_dict
+
+
+def test_grid_preset_counts():
+    assert len(tile(grid(2, 3), (0, 0, 120, 90), gutter=6, margin=6)) == 6
+
+
+def test_named_presets_build_and_tile():
+    for tree in (three_tiers(), diagonal_action(), feature_L()):
+        regions = tile(tree, (0, 0, 200, 300), gutter=8, margin=10)
+        assert regions  # non-empty
+        for r in regions:
+            assert r.shape == "path"
+            assert validate_segments(r.segments) == []  # every emitted region is a valid path
+
+
+def test_emitted_regions_round_trip_through_schema():
+    regions = tile(grid(2, 2), (0, 0, 100, 100), gutter=6, margin=6)
+    for r in regions:
+        r2 = region_from_dict(region_to_dict(r))
+        assert r2.shape == "path"
+        assert [s.type for s in r2.segments] == [s.type for s in r.segments]
+
+
+def test_apply_tiling_seeds_regions_and_layers_floating():
+    page = PageSpec(page_size_px=(100, 100))
+    floating = (Region(id="float1", kind="image", bbox=(20, 20, 30, 30)),)
+    out = apply_tiling(page, grid(2, 2), gutter=6, margin=6, floating=floating)
+    ids = [r.id for r in out.regions]
+    assert "float1" in ids
+    base = [r for r in out.regions if r.id != "float1"]
+    fl = [r for r in out.regions if r.id == "float1"][0]
+    # floating is layered on top: its z exceeds every base panel's z
+    assert fl.z > max(r.z for r in base)

--- a/tests/layout/test_tiling_render.py
+++ b/tests/layout/test_tiling_render.py
@@ -1,0 +1,26 @@
+from core.layout.models import PageSpec
+from core.layout.tiling import grid, apply_tiling
+from core.layout import qt_renderer
+
+
+def test_tiled_page_renders_with_background_gutters(qapp):
+    # 1x2 grid on a white page: the vertical gutter between the two panels must be background.
+    page = PageSpec(page_size_px=(200, 100), background="#FFFFFF")
+    apply_tiling(page, grid(1, 2), gutter=20, margin=10)
+    img = qt_renderer.render_page_to_image(page)
+    assert img.width() == 200 and img.height() == 100
+    # center column (x=100) lies in the 20px gutter between the two panels -> background (white)
+    gutter_px = img.pixelColor(100, 50)
+    assert gutter_px.red() > 240 and gutter_px.green() > 240 and gutter_px.blue() > 240
+    # a point inside the left panel (well left of the gutter) is within an (empty) image
+    # placeholder frame, i.e. NOT the page background — the placeholder fill is grey.
+    left_px = img.pixelColor(40, 50)
+    assert not (left_px.red() > 240 and left_px.green() > 240 and left_px.blue() > 240)
+
+
+def test_two_panels_present(qapp):
+    page = PageSpec(page_size_px=(200, 100), background="#FFFFFF")
+    apply_tiling(page, grid(1, 2), gutter=20, margin=10)
+    assert len(page.regions) == 2
+    for r in page.regions:
+        assert r.shape == "path"

--- a/tests/layout/test_writeback_move.py
+++ b/tests/layout/test_writeback_move.py
@@ -1,0 +1,34 @@
+from PySide6.QtWidgets import QGraphicsItem
+
+from core.layout.models import Region, PathSegment
+from core.layout import qt_renderer
+
+
+def _triangle():
+    return [
+        PathSegment(type="move", pts=[(10.0, 10.0)]),
+        PathSegment(type="line", pts=[(50.0, 10.0)]),
+        PathSegment(type="line", pts=[(50.0, 50.0)]),
+        PathSegment(type="close", pts=[]),
+    ]
+
+
+def test_writeback_translates_path_segments(qapp):
+    r = Region(id="p1", kind="image", shape="path", segments=_triangle(), bbox=(10, 10, 40, 40))
+    item = qt_renderer._RegionPathItem(qt_renderer.region_to_painter_path(r), r)
+    item.setFlag(QGraphicsItem.ItemSendsGeometryChanges, True)
+    item.setPos(5.0, -3.0)  # fires itemChange -> _writeback_move
+
+    assert r.segments[0].pts == [(15.0, 7.0)]
+    assert r.segments[1].pts == [(55.0, 7.0)]
+    assert r.segments[2].pts == [(55.0, 47.0)]
+    assert r.bbox == (15, 7, 40, 40)
+
+
+def test_writeback_rect_region_unchanged_behavior(qapp):
+    r = Region(id="t1", kind="text", shape="rect", bbox=(0, 0, 100, 40))
+    from PySide6.QtCore import QRectF
+    item = qt_renderer._RegionRectItem(QRectF(0, 0, 100, 40), r)
+    item.setFlag(QGraphicsItem.ItemSendsGeometryChanges, True)
+    item.setPos(7.0, 9.0)
+    assert r.bbox == (7, 9, 100, 40)  # translate-only, size unchanged


### PR DESCRIPTION
## Comic Layout — dynamic comic-style page layout

Adds arbitrary comic-style pages (non-rectangular / concave / curved panels, angled gutters, bleed & borderless frames, AI-first + manual authoring, and a comic text toolkit). The feature was decomposed into 5 sub-projects, each built spec → plan → subagent-driven TDD → per-task review → whole-sub-project Opus review. This is the single PR for the whole feature (per the one-PR-per-feature convention).

**Layout test suite: 166 → 344 passing** across the feature; pure geometry stays Qt-free, no new third-party dependencies.

### #1 — Geometry & render core
Path-based regions with typed segments (move/line/quad/cubic/close), image clip-to-shape, per-region stroke (incl. `stroke_px=0` borderless), and a `bleed` flag. Qt renderer (`core/layout/qt_renderer.py`) renders regions to a `QGraphicsScene`.

### #2 — Page-partition / tiling engine
Pure `core/layout/polygon.py` (`signed_area`, `clip_halfplane`, `inset_polygon`, `union_polygons`, `polygon_to_segments`) + `core/layout/tiling.py` (slice-tree `tile()`, concave cell-merge, inset gutters, presets: grid / three_tiers / splash_with_strip / diagonal_action / feature_L). Outputs `shape="path"` regions that render unchanged through #1.

### #3 — Comic text overlays
Declarative `Overlay`/`OverlayStyle` on `PageSpec.overlays` (Qt-free) + pure `core/layout/balloons.py` (speech, thought, caption, SFX geometry with tails/scallops) + a renderer overlay pass that measures wrapped text to size the body.

### #4 — AI designer extension
Pure `core/layout/svg_path.py` (`svg_to_segments`/`segments_to_svg`) + `designer.parse_response` now emits SVG-path regions, bleed/stroke, tiling-preset expansion, and region-relative or raw-pixel overlays; the designer prompt documents the tiled-panel id scheme. GUI applies designed overlays onto the page.

### #5 — Manual editor (region geometry · region ops · overlay editing)
- **#5a Region geometry:** `GeometryEditor` controller with vertex/curve-handle drag (handles regenerated after each scene rebuild), per-panel bleed/borderless/z toggles (`GeometryInspector`), path-segment write-back on translate, undo via `History`.
- **#5b Region operations:** pure `core/layout/region_ops.py` — split (two-click free-line knife via `clip_halfplane`), merge (`union_polygons` + area-conservation guard), delete; canvas tool modes + inspector controls; `LayoutTab` owns all mutation.
- **#5c Overlay editing + export:** `Overlay.rotation` (rendered about the anchor); pure `core/layout/overlay_ops.py` (stranded-overlay detection + reposition onto the nearest panel); `OverlayInspector` (place/delete/rotate/select) + `OverlayEditor` (body/tail drag handles, tail snaps to the nearest region); regions-only redesigns tidy stranded overlays. **Export fold-in:** Layout-tab PNG export + the export dialog now render through the Qt renderer (comic geometry + overlays + rotation), with DPI honored via a `render_page_to_image` scale parameter.

### Architecture notes
- Pure geometry modules (`geometry`, `polygon`, `tiling`, `balloons`, `svg_path`, `region_ops`, `overlay_ops`) are Qt-free and headless-testable; Qt lives only in `gui/layout/` and `core/layout/qt_renderer.py`.
- Inspector/controller split throughout: UI widgets emit intent signals; `LayoutTab` owns all model mutation.
- Edit handles survive the full-scene rebuild by regeneration from the model, not preservation.

### Known follow-ups (deferred, non-blocking)
- The interactive editor canvas doesn't show a live `bleed` preview (exports do render bleed/overlays via the Qt path).
- Minor UX polish: overlay "Edit on canvas" checkbox desyncs after a commit; rotation spinner records one undo snapshot per degree; overlay-inspector panel order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
