### PR TITLE
feat: Gemini Omni video provider on the Video tab (#28)

### DIFF
--- a/Plans/2026-06-30-gemini-omni-video-support.md
+++ b/Plans/2026-06-30-gemini-omni-video-support.md
@@ -1,0 +1,406 @@
+# Gemini Omni Video Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Source issue:** [#28 — Support Gemini Omni Flash](https://github.com/lelandg/ImageAI/issues/28). Reporter asked for a *plan* with open questions documented; brainstorming is explicitly deferred to the reporter. This plan is therefore staged behind a **Phase 0 verification gate** because the target model is *preview* and the SDK surface is new.
+
+**Last Updated:** 2026-06-30 14:05
+
+**Goal:** Add "Gemini Omni" as a fourth video provider on the Video tab — text/image/reference-to-video plus conversational editing — driven through Google's new **Interactions API** (`client.interactions.create`, model `gemini-omni-flash-preview`).
+
+**Architecture:** Mirror the existing per-provider video-client pattern (`core/video/veo_client.py`, `core/video/sora_client.py`) with a new `core/video/omni_client.py`, then wire it through the four special-cased integration points the Video tab uses for every provider: the provider combo + visibility toggles (`workspace_widget.py`), worker-kwargs packing, the generation dispatch (`video_project_tab.py`), and project save/restore. Omni's video output is a **submit→(inline | poll-URI)→download** job, so it slots into the Veo/Sora "generator" slot — but on the Interactions API SDK surface, *not* Veo's `generate_videos`.
+
+**Tech Stack:** Python 3.12, PySide6, `google-genai` SDK (**Interactions API requires `>=2.3.0`**; repo currently pins `>=1.49.0` — see Global Constraints), `pytest`.
+
+---
+
+## Global Constraints
+
+- **SDK floor:** Interactions API + Omni require `google-genai >= 2.3.0`. `requirements.txt:3` currently pins `google-genai>=1.49.0`. The bump from 1.x → 2.x is a **major version change** — Task 1 must verify the existing Gemini *image* path (`providers/google/`, `image_config`/`generate_content`) still works on 2.x before anything else proceeds.
+- **Min release age:** Per house rules, do not adopt a `google-genai` 2.x release published <7 days ago without explicit approval. Verify the publish date via the PyPI JSON API before bumping the pin.
+- **Model IDs are NOT hardcoded (AGENTS.md §8):** `gemini-omni-flash-preview` must be resolved at runtime via `core/llm_models.py` `resolve_model()` / the registry JSON, never written as a literal in client/UI/config code.
+- **Provider is `preview` and possibly gated:** Google's GA blog lists Omni as "(soon)" while the doc pages show it live as "preview." Treat availability as unconfirmed until a live `client.interactions.create` call succeeds (Phase 0).
+- **All LLM/API interactions must be logged (AGENTS.md §8):** every Omni request (model, task, aspect ratio, prompt, `previous_interaction_id`) and full response/error goes to both the file logger and the status console.
+- **Images scaled, not cropped** (AGENTS.md §3) — applies to any reference-image preprocessing.
+- **No `cd`; absolute paths only.** Linux venv `.venv_linux` + `python3`; do not run `.venv` from WSL.
+
+---
+
+## What Gemini Omni actually is (research summary)
+
+Verified against the live Google docs (sources listed at the end of this plan). Bottom line that drives the whole design:
+
+- **Model ID:** `gemini-omni-flash-preview` (preview). "Flash" is the tier.
+- **It generates video.** Input: text, image, and/or video (≤10s for editing). Output: **MP4, 720p, 24 FPS, 3–10s, with audio.** This resolves the prior investigation's "Branch A vs Branch B" fork firmly to **Branch A — it is a job-style video generator**, comparable in shape to Veo.
+- **Driven via the Interactions API**, not `generate_content`/`generate_videos`. Call `client.interactions.create(model="gemini-omni-flash-preview", input=...)`. The reporter's instinct ("we can use interactions api when Omni model is used") is **correct**.
+- **Two delivery modes:** small clips return inline base64 (`interaction.output_video.data`); clips >4MB return a URI (`interaction.output_video.uri`) you poll via the **Files API** (`client.files.get` until `state.name == "ACTIVE"`, then `client.files.download`) — the Veo-like submit→poll→download pattern.
+- **Stateful conversational editing** via `previous_interaction_id` — the headline feature: generate a clip, then refine with natural language ("make the violin invisible"), each turn building on the last.
+- **Aspect ratios:** `16:9` (default) and `9:16` only — set in `response_format`, **not** in prompt text (matches the existing Gemini rule in AGENTS.md §9).
+- **`task` values** (in `generation_config.video_config`): `text_to_video`, `image_to_video`, `reference_to_video`, `edit`.
+- **Auth:** all examples use a plain API key (`GOOGLE_API_KEY`). Vertex/ADC support is undocumented for Omni (open question).
+- **Explicitly unsupported:** system instructions, `temperature`, `top_p`, multi-video prompting, voice editing, video extension/interpolation, provisioned throughput. **Regional:** uploaded-video editing is unavailable in EEA / Switzerland / UK.
+
+### "All features of Omni" — the full scope the issue asks for
+1. Text-to-video · 2. Image-to-video · 3. Reference-to-video · 4. Edit a generated video · 5. **Conversational/stateful editing** (`previous_interaction_id`) · 6. Uploaded-video editing (Files API; geo-gated) · 7. Aspect-ratio select (16:9 / 9:16) · 8. Both delivery modes (inline + poll-URI) · 9. Audio in output (promptable) · 10. Sync / `background=true` / `stream=True` execution + `webhook_config` · 11. SynthID watermark awareness.
+
+This plan covers **1–4, 7, 8, 9** as the core feature (parity with how Veo/Sora behave today), implements **5 (conversational editing)** as the distinguishing capability, and **scopes 6, 10, 11 as follow-ups** (see "Deferred / out of scope"). Each is called out so nothing is silently dropped.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `requirements.txt` | dependency pins | Bump `google-genai` floor to the verified 2.x release |
+| `core/video/omni_client.py` | **NEW** — Omni Interactions-API client | `OmniModel`, `OmniGenerationConfig`, `OmniGenerationResult`, `OmniClient` with `MODEL_CONSTRAINTS`, `validate_config()`, `generate_video_async()` |
+| `core/video/__init__.py` | lazy provider exports | Add `OMNI_AVAILABLE` try/except block + `__all__` entries (mirror Sora at `:14-47`) |
+| `core/video/config.py` | video config | Add `omni_settings.models`, allow `default_video_provider="omni"`, optional legacy-migration map |
+| `core/llm_models.py` + registry JSON | model-ID resolution | Register `gemini-omni-flash-preview` so `resolve_model()` returns it (no hardcoding) |
+| `gui/video/workspace_widget.py` | provider UI + kwargs + persistence | Combo item, Omni model/aspect widgets, visibility toggle, kwargs packing, save/restore |
+| `gui/video/video_project_tab.py` | generation dispatch | `_generate_video_clip_omni()` + routing at `:731` and `:1485` |
+| `providers/google.py` | auth requirements | Add Omni auth entry only if it differs from Veo |
+| `tests/video/test_omni_client.py` | **NEW** — client unit tests | Config validation, request-dict shape, delivery-mode branching (mock SDK) |
+| `tests/video/test_video_provider_persistence.py` | **NEW** — persistence regression | Round-trip save/restore for all four providers; locks the Veo-label fix |
+| `Docs/CodeMap.md`, `README.md` | docs | Update on ship |
+
+**Pre-existing bug folded into this work (Task 7):** the provider combo emits `"Gemini Veo"` (`workspace_widget.py:1628`), but save/restore checks for `"Google Veo"` (`:7385`, `:7580`). Result: **any saved project with Veo selected silently restores to FFmpeg Slideshow.** Confirmed against current code. Fixing it here prevents Omni from inheriting the same drift and is covered by a regression test.
+
+---
+
+## Phase 0 — Verification Gate (BLOCKING; do this first, no UI work until it passes)
+
+### Task 0: Confirm Omni is callable and characterize its real responses
+
+**Files:**
+- Create: `scratch/omni_probe.py` (throwaway probe; **not** committed)
+
+**Goal:** Prove the model exists for this account and capture the *actual* shapes of `output_video.data`, `output_video.uri`, the polling lifecycle, and error envelopes — the docs are preview-grade and have at least one internal inconsistency (audio listed in the guide but not the model spec page).
+
+- [ ] **Step 1: Install the SDK floor in the Linux venv**
+
+Run:
+```bash
+/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python3 -m pip index versions google-genai
+```
+Confirm a `>=2.3.0` release exists and is **≥7 days old**. Record the exact version. If the only 2.x release is <7 days old, STOP and ask Leland.
+
+- [ ] **Step 2: Probe the four core tasks + delivery modes**
+
+Write `scratch/omni_probe.py` that, using `client.interactions.create(model="gemini-omni-flash-preview", ...)`, runs: (a) text-to-video inline; (b) text-to-video with `response_format={"delivery":"uri"}` and polls Files API; (c) image-to-video with `generation_config={"video_config":{"task":"image_to_video"}}`; (d) a `previous_interaction_id` edit turn. Print the full response object structure, `interaction.id`, `usage`, and the type/size of `output_video.data` vs `.uri` for each.
+
+- [ ] **Step 3: Record findings in this plan**
+
+Fill in the "Phase 0 results" block below with: confirmed model ID/availability, exact attribute path for inline bytes vs URI, the polling terminal states, error-envelope shape, whether audio is actually present, and any auth surprises. **If the model is NOT available to this account, STOP** — the feature is blocked upstream; record that and close the loop with Leland rather than building UI against an uncallable model.
+
+> **Phase 0 results (fill in during execution):**
+> - Model callable: ⬜ yes / ⬜ no — version used: `__________`
+> - Inline bytes path: `interaction.output_video.________`
+> - URI path + poll terminal states: `__________`
+> - Error envelope shape: `__________`
+> - Audio present in output: ⬜ / format: `__________`
+> - Auth used: ⬜ API key / ⬜ ADC / ⬜ Vertex
+
+---
+
+## Phase 1 — Client (`core/video/omni_client.py`)
+
+### Task 1: Bump the SDK and confirm the existing Gemini image path still works
+
+**Files:**
+- Modify: `requirements.txt:3`
+
+**Interfaces:**
+- Produces: a `google-genai >= <verified 2.x>` environment that the rest of the plan assumes.
+
+- [ ] **Step 1: Bump the pin**
+
+Change `requirements.txt:3` from `google-genai>=1.49.0  # ...` to the verified 2.x floor, keeping a comment explaining *both* reasons:
+```
+google-genai>=2.3.0  # 2.3.0+: Interactions API (Gemini Omni video). NBP image_size still supported.
+```
+
+- [ ] **Step 2: Install and smoke-test the EXISTING image path (regression guard)**
+
+Run:
+```bash
+/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python3 -m pip install -r requirements.txt
+/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python3 main.py --provider google -p "a single red apple on white" -o /tmp/omni_sdk_smoke.png
+```
+Expected: an image is produced (or a clean auth/key error — **not** an `ImportError`/`AttributeError` from the SDK bump). If the 2.x SDK broke `image_config`/`generate_content`, STOP and resolve the image path before continuing.
+
+- [ ] **Step 3: Run the existing test suite**
+
+Run: `cd /mnt/d/Documents/Code/GitHub/ImageAI && /mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python3 -m pytest -q`
+Expected: same green baseline as before the bump (no SDK-related regressions).
+
+- [ ] **Step 4: Commit**
+```bash
+git add requirements.txt
+git commit -m "chore(deps): bump google-genai floor to 2.x for Interactions API (Gemini Omni)"
+```
+
+### Task 2: Register the Omni model ID in the registry
+
+**Files:**
+- Modify: `core/llm_models.py` (+ the registry JSON it reads)
+
+**Interfaces:**
+- Produces: `resolve_model("gemini-omni-flash-preview")` (or the project's logical key) returns the canonical Omni ID, so no client/UI code hardcodes it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/video/test_omni_model_registry.py`:
+```python
+from core.llm_models import resolve_model
+
+def test_omni_model_resolves():
+    resolved = resolve_model("gemini-omni-flash-preview")
+    assert "omni" in resolved.lower()
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: `.venv_linux/bin/python3 -m pytest tests/video/test_omni_model_registry.py -v`
+Expected: FAIL (model unknown to registry).
+
+- [ ] **Step 3: Add the model to the registry**
+
+Add `gemini-omni-flash-preview` to the registry JSON / `core/llm_models.py` fallback table following the existing Gemini-model entries (capability: video; tier: flash; status: preview). Match the surrounding schema exactly.
+
+- [ ] **Step 4: Run it, confirm it passes**
+
+Run: same as Step 2 → PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add core/llm_models.py tests/video/test_omni_model_registry.py
+git commit -m "feat(models): register gemini-omni-flash-preview for resolve_model"
+```
+
+### Task 3: `OmniGenerationConfig` + validation
+
+**Files:**
+- Create: `core/video/omni_client.py`
+- Test: `tests/video/test_omni_client.py`
+
+**Interfaces:**
+- Produces:
+  - `class OmniModel(Enum)` — single member resolved via `resolve_model()` at construction (value not a literal in the enum body; resolve in a classmethod/factory if the registry requires it).
+  - `@dataclass OmniGenerationConfig(model, prompt, task="text_to_video", aspect_ratio="16:9", duration=None, reference_image: Optional[Path]=None, previous_interaction_id: Optional[str]=None, delivery="auto")` with `__post_init__()` validation + `to_interaction_kwargs() -> dict`.
+  - `OmniClient.MODEL_CONSTRAINTS: dict` — `{"aspect_ratios": ["16:9","9:16"], "tasks": ["text_to_video","image_to_video","reference_to_video","edit"], "duration_range": (3,10), "fps": 24, "resolution": "720p", "supports_audio": True}`.
+
+- [ ] **Step 1: Write the failing tests**
+```python
+import pytest
+from pathlib import Path
+from core.video.omni_client import OmniGenerationConfig, OmniClient
+
+def test_valid_config_builds_interaction_kwargs():
+    cfg = OmniGenerationConfig(model="gemini-omni-flash-preview",
+                               prompt="a marble rolling down a track",
+                               task="text_to_video", aspect_ratio="16:9")
+    kw = cfg.to_interaction_kwargs()
+    assert kw["model"] == "gemini-omni-flash-preview"
+    assert kw["response_format"]["aspect_ratio"] == "16:9"
+    assert kw["generation_config"]["video_config"]["task"] == "text_to_video"
+    # aspect ratio must NOT be embedded in the prompt text (AGENTS.md §9)
+    assert "16:9" not in kw["input"]
+
+def test_invalid_aspect_ratio_rejected():
+    with pytest.raises(ValueError, match="aspect_ratio"):
+        OmniGenerationConfig(model="gemini-omni-flash-preview",
+                             prompt="x", aspect_ratio="4:3")
+
+def test_invalid_task_rejected():
+    with pytest.raises(ValueError, match="task"):
+        OmniGenerationConfig(model="gemini-omni-flash-preview",
+                             prompt="x", task="audio_to_video")
+
+def test_image_to_video_requires_reference_image():
+    with pytest.raises(ValueError, match="reference_image"):
+        OmniGenerationConfig(model="gemini-omni-flash-preview",
+                             prompt="x", task="image_to_video")
+```
+
+- [ ] **Step 2: Run, confirm fail** — `.venv_linux/bin/python3 -m pytest tests/video/test_omni_client.py -v` → FAIL (module missing).
+
+- [ ] **Step 3: Implement config + constraints**
+
+Create `core/video/omni_client.py` with the imports, `OmniModel`, `MODEL_CONSTRAINTS`, and `OmniGenerationConfig` (with `__post_init__` validating aspect ratio ∈ constraints, task ∈ constraints, and `image_to_video`/`reference_to_video` requiring `reference_image`). `to_interaction_kwargs()` builds the `client.interactions.create` kwargs: `model`, `input` (text-only string, or a `[{"type":"image",...},{"type":"text",...}]` list when a reference image is present), `response_format={"type":"video","aspect_ratio":...}` (+ `"delivery":"uri"` when configured), `generation_config={"video_config":{"task":...}}`, and `previous_interaction_id` when set. Mirror the structure of `VeoGenerationConfig`/`SoraGenerationConfig`.
+
+- [ ] **Step 4: Run, confirm pass** → PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add core/video/omni_client.py tests/video/test_omni_client.py
+git commit -m "feat(video): OmniGenerationConfig with validation for Interactions API"
+```
+
+### Task 4: `OmniClient.generate_video_async()` with inline + poll-URI delivery
+
+**Files:**
+- Modify: `core/video/omni_client.py`
+- Test: `tests/video/test_omni_client.py`
+
+**Interfaces:**
+- Consumes: `OmniGenerationConfig` from Task 3.
+- Produces:
+  - `@dataclass OmniGenerationResult(success: bool, video_path: Optional[Path], interaction_id: Optional[str], error: Optional[str], generation_time: float, metadata: dict)` — `interaction_id` is essential so the UI can chain conversational edits.
+  - `async def generate_video_async(self, config, output_path: Path) -> OmniGenerationResult`.
+
+- [ ] **Step 1: Write failing tests (mock the SDK — no network)**
+
+Add tests that patch the `google.genai` client so `client.interactions.create(...)` returns (a) an object with `output_video.data` (base64) and (b) an object with `output_video.uri` plus a `client.files.get` that transitions `PROCESSING → ACTIVE` and a `client.files.download` returning bytes. Assert both write a valid MP4 to `output_path`, both populate `interaction_id`, and a `FAILED` files state yields `success=False` with a logged error.
+
+- [ ] **Step 2: Run, confirm fail.**
+
+- [ ] **Step 3: Implement the method**
+
+Implement `generate_video_async`: validate config, build kwargs via `to_interaction_kwargs()`, **log the full request** (model, task, aspect, prompt, `previous_interaction_id`) to file + console, call `interactions.create`, then branch on delivery — inline: `base64.b64decode(interaction.output_video.data)`; URI: poll `client.files.get` until `state.name == "ACTIVE"` (bail on `FAILED`), then `client.files.download`. Write bytes to `output_path`, capture `interaction.id`, **log the full response/usage**, and return `OmniGenerationResult`. Wrap everything so any exception → `success=False` + logged error (AGENTS.md §8). Use the polling interval/timeout from `omni_settings` (Task 5).
+
+- [ ] **Step 4: Run, confirm pass.**
+
+- [ ] **Step 5: Add the lazy export**
+
+In `core/video/__init__.py`, add an `OMNI_AVAILABLE` try/except importing `OmniClient, OmniModel, OmniGenerationConfig, OmniGenerationResult` (mirror the Sora block at `:14-29`) and extend `__all__` (`:31-47`).
+
+- [ ] **Step 6: Run the video test subset** — `.venv_linux/bin/python3 -m pytest tests/video/ -v` → PASS.
+
+- [ ] **Step 7: Commit**
+```bash
+git add core/video/omni_client.py core/video/__init__.py tests/video/test_omni_client.py
+git commit -m "feat(video): OmniClient.generate_video_async with inline+URI delivery"
+```
+
+### Task 5: Omni config block
+
+**Files:**
+- Modify: `core/video/config.py`
+- Test: `tests/video/test_omni_client.py` (extend)
+
+**Interfaces:**
+- Produces: `omni_settings` with `models` (constraints mirror), `polling_interval`, `timeout`; `default_video_provider` accepts `"omni"`.
+
+- [ ] **Step 1: Write failing test** — assert the loaded video config exposes `omni_settings` with the Omni model and a `polling_interval`. Run → FAIL.
+- [ ] **Step 2: Implement** — add `omni_settings` to `core/video/config.py` parallel to `veo_settings`/`sora_settings` (`:36-66`); allow `default_video_provider="omni"`; if Phase 0 surfaced any preview→GA ID change, add a one-line entry to the legacy-migration map (`:68-137`).
+- [ ] **Step 3: Run → PASS.**
+- [ ] **Step 4: Commit** — `git commit -m "feat(video): add omni_settings to video config"`
+
+---
+
+## Phase 2 — Video-tab wiring (GUI; manual verification, GUI is not unit-testable headless)
+
+> GUI changes can't run TDD headlessly (AGENTS.md §6 — GUI needs a display). Each task ends with a **scripted manual check** the implementer runs from PowerShell where the GUI actually launches (Leland's run env). Keep edits minimal and mirror the Veo/Sora code exactly.
+
+### Task 6: Provider combo, Omni widgets, visibility, kwargs
+
+**Files:**
+- Modify: `gui/video/workspace_widget.py` — `:1628`, `:1639-1692`, `:6048-6051`, `:6233-6275`, `:6309-6310`, `:2998`
+
+- [ ] **Step 1:** Add `"Gemini Omni"` to the combo at `:1628` → `addItems(["FFmpeg Slideshow", "Gemini Veo", "OpenAI Sora", "Gemini Omni"])`; extend the tooltip at `:1630`.
+- [ ] **Step 2:** After the Veo widgets (`:1639-1662`), add `self.omni_model_combo` (populated from `omni_settings.models`) and `self.omni_aspect_combo` (`["16:9","9:16"]`). Connect a new `on_omni_model_changed` if cost/feature display is needed.
+- [ ] **Step 3:** In `on_video_provider_changed()` (`:6233`), add `is_omni = provider == "Gemini Omni"`, set `self.omni_model_combo.setVisible(is_omni)` / `self.omni_aspect_combo.setVisible(is_omni)`, and make sure the Veo/Sora widgets hide when Omni is active (extend the existing show/hide block).
+- [ ] **Step 4:** Pack kwargs at `:6048`: add `'omni_model'` and `'omni_aspect_ratio'` (guard with `hasattr`). Extend the render-method resolver at `:2998` with an `elif video_provider == "Gemini Omni" and omni_model:` branch, and the cost-visibility check at `:6310` to include Omni (`!= "Gemini Veo" and != "Gemini Omni"`).
+- [ ] **Step 5: Manual check (PowerShell):** launch `python main.py`, open the Video tab, select **Gemini Omni** → only Omni model/aspect widgets show; Veo/Sora widgets hide; switching back to Veo restores Veo widgets. Confirm no traceback in `imageai_current.log`.
+- [ ] **Step 6: Commit** — `git commit -m "feat(video-ui): add Gemini Omni provider combo, widgets, kwargs"`
+
+### Task 7: Generation dispatch + the Veo-label persistence fix
+
+**Files:**
+- Modify: `gui/video/video_project_tab.py` — `:731-732`, new `_generate_video_clip_omni()`, `:1485-1488`
+- Modify: `gui/video/workspace_widget.py` — `:7385`, `:7580`
+- Test: `tests/video/test_video_provider_persistence.py` (**new**)
+
+- [ ] **Step 1: Write the failing persistence regression test**
+
+Create `tests/video/test_video_provider_persistence.py` that round-trips a project's `video_provider`/`video_model` through the save/restore helpers for **all four** providers and asserts Veo restores to `"Gemini Veo"` (this currently FAILS because of the `"Google Veo"` mismatch and locks the fix). Use the existing project-IO test pattern as a template; mock the combo if a full widget can't instantiate headlessly.
+
+- [ ] **Step 2: Run → FAIL** on the Veo round-trip (mismatch) and on Omni (not handled yet).
+
+- [ ] **Step 3: Fix the Veo label + add Omni dispatch.**
+  - `workspace_widget.py:7385`: `"Google Veo"` → `"Gemini Veo"`.
+  - `workspace_widget.py:7579-7582`: add an `elif self.current_project.video_provider == "gemini omni":` branch using `findText("Gemini Omni")` and restoring `omni_model_combo`; and correct the Veo `findText("Google Veo")` → `findText("Gemini Veo")` at `:7580`. Save block (`:7385`) gets a parallel `elif ... == "Gemini Omni":` storing `omni_model_combo.currentText()`.
+  - `video_project_tab.py:731`: insert before the Veo fall-through:
+    ```python
+    if video_provider == 'OpenAI Sora':
+        return self._generate_video_clip_sora()
+    if video_provider == 'Gemini Omni':
+        return self._generate_video_clip_omni()
+    # Default to Veo
+    ```
+  - Add `_generate_video_clip_omni()` (mirror `_generate_video_clip_sora` at `:1295`): build `OmniGenerationConfig` from kwargs, run `OmniClient.generate_video_async` on the worker's event loop, emit progress/results like the Sora path.
+  - `video_project_tab.py:1485`: add `elif self.kwargs.get('video_provider') == 'Gemini Omni':` — Omni returns a finished MP4, so route to the same "use the rendered clip directly" path Veo uses (`_render_with_veo`-style), **not** `_render_with_ffmpeg`.
+
+- [ ] **Step 4: Run → PASS** (all four providers round-trip; Veo restores correctly).
+
+- [ ] **Step 5: Manual check (PowerShell):** generate one short clip with **Gemini Omni** (text-to-video); confirm an MP4 lands in the project and the full request/response is in `imageai_current.log`. Save the project, reload it, confirm the provider restores to **Gemini Omni** (and, separately, that a Veo project now restores to **Gemini Veo**, not Slideshow).
+- [ ] **Step 6: Commit** — `git commit -m "feat(video): dispatch Gemini Omni generation; fix Veo provider-restore label"`
+
+### Task 8: Conversational editing (the headline Omni capability)
+
+**Files:**
+- Modify: `gui/video/workspace_widget.py` (small "Refine this clip" affordance on an Omni-generated clip), `gui/video/video_project_tab.py` (thread `previous_interaction_id` through)
+
+**Interfaces:**
+- Consumes: `OmniGenerationResult.interaction_id` from Task 4.
+
+- [ ] **Step 1:** Persist the returned `interaction_id` on the generated clip's metadata sidecar (AGENTS.md §3 — every image/clip gets a `.json` sidecar) so refinement survives reload.
+- [ ] **Step 2:** Add a minimal "Refine" entry point for an Omni clip that prompts for an edit instruction and re-dispatches `_generate_video_clip_omni()` with `previous_interaction_id` set to the prior clip's id and `task="edit"`.
+- [ ] **Step 3: Manual check (PowerShell):** generate a clip, refine it ("make it night"), confirm the second clip references the first via `previous_interaction_id` in the log and the result reflects the edit.
+- [ ] **Step 4: Commit** — `git commit -m "feat(video): conversational refine for Gemini Omni clips"`
+
+---
+
+## Phase 3 — Auth, docs, ship
+
+### Task 9: Auth requirements
+
+**Files:** Modify `providers/google.py` (`MODEL_AUTH_REQUIREMENTS` `:54-67`) only if Phase 0 showed Omni's auth differs from the existing Gemini path. If API-key-only (as docs suggest), confirm the existing Gemini key resolution (`config.get_api_key()`) already covers it and add a one-line note. Commit only if changed.
+
+### Task 10: Docs + CodeMap
+
+**Files:** `Docs/CodeMap.md` (new `omni_client.py` symbols + line refs — use the `update-code-map` skill), `README.md` (feature note + provider list). Commit: `docs: document Gemini Omni video provider`.
+
+---
+
+## Deferred / out of scope (record so nothing is silently dropped)
+
+- **Uploaded-video editing** (Files-API `document` input) — geo-gated (EEA/CH/UK); larger UI surface (file upload + processing-state poll). Follow-up.
+- **`background=true` + `webhook_config`** async execution — current Veo/Sora flow long-polls on a worker thread; adopt only if Omni latency makes it necessary.
+- **`stream=True`** incremental events — not needed for finished-MP4 delivery.
+- **SynthID watermark surfacing** in the UI — note-only for now.
+- **Multimodal Omni features beyond video** (audio-in/out as an LLM provider, scene analysis) — out of scope for the Video tab per the reporter; would need the deferred brainstorming pass.
+
+---
+
+## Open Questions (the issue explicitly asks to document these)
+
+1. **Availability/gating:** Google's GA blog says Omni is "(soon)" while the doc pages show it "preview." Is `gemini-omni-flash-preview` callable for this account *today*? → **Phase 0 Task 0 answers this; the whole plan is gated on it.**
+2. **Exact `google-genai` 2.x version** that ships `interactions` + Omni, and whether the 1.x→2.x bump breaks the existing NBP image path (`image_config`/`generate_content`). → Task 1 Step 2 guards this.
+3. **Audio output specifics:** the guide says audio is generated by default and promptable; the model-spec page omits audio. Format/channels/sample-rate? Can it be disabled? → Phase 0 probe.
+4. **Pricing/quota/rate limits** for Omni (per-second-of-video vs per-token) — not on the fetched pages. Affects cost display (`:6310` area). → check `/docs/pricing`.
+5. **Vertex AI / ADC auth:** only API-key auth is documented. Does ADC/service-account work with `client.interactions.create`? Is Omni on Vertex? → Phase 0 + Task 9.
+6. **`reference_to_video` and `edit` input shapes** are listed but not shown with example code. → Phase 0 probe.
+7. **Interactions-API storage retention** (55 days paid / 1 day free) interacts with conversational editing — if a project is reloaded after the `previous_interaction_id` expires, refinement must fail gracefully and fall back to a fresh generation. → handle in Task 8.
+8. **Duration control:** docs say 3–10s but don't show a duration parameter in the examples — is duration promptable, fixed, or a config field? → Phase 0 probe.
+9. **`min_release_age` approval:** if the only 2.x SDK is <7 days old at implementation time, Leland's explicit approval is required before bumping the pin.
+
+---
+
+## Self-Review (against the issue + research)
+
+- **Spec coverage:** Issue asks to "support all features of Gemini Omni on the Video tab" + "document open questions." Core features 1–4/7/8/9 → Phase 1–2; conversational editing (5) → Task 8; features 6/10/11 explicitly deferred with rationale; open questions → dedicated section. ✓
+- **Branch resolved:** prior investigation's Branch-A/Branch-B fork is resolved to Branch A (Omni *is* a video generator) by the research, but on the Interactions-API surface — captured in Architecture + Task 4. ✓
+- **No hardcoded model IDs:** Task 2 routes the ID through `resolve_model()`. ✓
+- **Pre-existing Veo-label bug:** confirmed against live code (`:1628` emits "Gemini Veo"; `:7385`/`:7580` check "Google Veo") and folded into Task 7 with a regression test. ✓
+- **Type consistency:** `OmniGenerationConfig` (Task 3) → consumed by `generate_video_async` (Task 4) → `OmniGenerationResult.interaction_id` (Task 4) → used in Task 8. Names match across tasks. ✓
+
+---
+
+## Sources (Google docs, fetched 2026-06-30 with explicit authorization)
+
+- https://ai.google.dev/gemini-api/docs/omni — "Generate and edit videos with Gemini Omni Flash"
+- https://ai.google.dev/gemini-api/docs/models/gemini-omni-flash — model spec (ID, 720p/24fps/3–10s, 16:9/9:16, preview)
+- https://ai.google.dev/gemini-api/docs/interactions-overview — Interactions API (state, `previous_interaction_id`, `google-genai>=2.3.0`)
+- https://ai.google.dev/api/interactions-api — API reference (`POST /v1beta/interactions`, `client.interactions.create`)
+- https://blog.google/innovation-and-ai/technology/developers-tools/interactions-api-general-availability/ — GA announcement (lists Omni "soon")

--- a/Plans/2026-06-30-gemini-omni-video-support.md
+++ b/Plans/2026-06-30-gemini-omni-video-support.md
@@ -135,9 +135,17 @@ Write `scratch/omni_probe.py` that, using `client.interactions.create(model="gem
 
 Fill in the "Phase 0 results" block below with: confirmed model ID/availability, exact attribute path for inline bytes vs URI, the polling terminal states, error-envelope shape, whether audio is actually present, and any auth surprises. **If the model is NOT available to this account, STOP** — the feature is blocked upstream; record that and close the loop with Leland rather than building UI against an uncallable model.
 
-> **Phase 0 results — SDK introspection done 2026-06-30 (live API call still BLOCKED, see below):**
+> **⚠️ SUPERSEDED — see "Implementation status" at the top of this doc.** The
+> findings in this block were introspected against `google-genai` **2.8.0**, whose
+> transitional `_interactions` surface is NOT the real Omni API. The shipped client
+> targets the **2.9.0+ `_gaos` "GeminiNextGen"** surface: video is requested via
+> `response_format={"type":"video","aspect_ratio":...}` (a dict) and read from
+> `interaction.output_video` — and this was **confirmed working end-to-end** with a
+> real key. The 2.8.0 notes below are kept only as a record of the wrong turn.
 >
-> Installed: `google-genai 2.8.0` (PyPI has up to 2.10.0; floor 2.3.0+ confirmed). `client.interactions` is present but emits `UserWarning: Interactions usage is experimental and may change`. Verified the **actual** `create()` signature and types — several plan assumptions (from web docs) are WRONG against the installed SDK and are corrected here:
+> **Phase 0 results — SDK introspection done 2026-06-30 (later proven to be the WRONG SDK surface):**
+>
+> Installed at the time: `google-genai 2.8.0`. `client.interactions` is present but emits `UserWarning: Interactions usage is experimental and may change`. Verified the **actual** `create()` signature and types — several plan assumptions (from web docs) looked WRONG against 2.8.0, but 2.8.0 itself was the wrong surface (the docs target 2.9.0+):
 >
 > - **`create()` real kwargs:** `input`, `model`, `background`, `generation_config`, `previous_interaction_id`, `response_format`, `response_mime_type`, `response_modalities`, `service_tier`, `store`, `stream`, `system_instruction`, `tools`, `webhook_config`, `agent`, `agent_config`. Returns `Interaction | Stream[InteractionSSEEvent]`.
 > - **No `VideoResponseFormat`.** `response_format` ∈ {Audio, Text, Image, `object`}. Video output must be requested via **`response_modalities=['video']`** (valid literal), NOT a `response_format={"type":"video"}`. **There is no video aspect-ratio field anywhere in the SDK** (only `ImageResponseFormat.aspect_ratio`). → the plan's aspect-ratio handling and `delivery` key for video are unconfirmed; `VideoContent.resolution` is `low|medium|high|ultra_high`, not "720p".

--- a/Plans/2026-06-30-gemini-omni-video-support.md
+++ b/Plans/2026-06-30-gemini-omni-video-support.md
@@ -92,13 +92,18 @@ Write `scratch/omni_probe.py` that, using `client.interactions.create(model="gem
 
 Fill in the "Phase 0 results" block below with: confirmed model ID/availability, exact attribute path for inline bytes vs URI, the polling terminal states, error-envelope shape, whether audio is actually present, and any auth surprises. **If the model is NOT available to this account, STOP** — the feature is blocked upstream; record that and close the loop with Leland rather than building UI against an uncallable model.
 
-> **Phase 0 results (fill in during execution):**
-> - Model callable: ⬜ yes / ⬜ no — version used: `__________`
-> - Inline bytes path: `interaction.output_video.________`
-> - URI path + poll terminal states: `__________`
-> - Error envelope shape: `__________`
-> - Audio present in output: ⬜ / format: `__________`
-> - Auth used: ⬜ API key / ⬜ ADC / ⬜ Vertex
+> **Phase 0 results — SDK introspection done 2026-06-30 (live API call still BLOCKED, see below):**
+>
+> Installed: `google-genai 2.8.0` (PyPI has up to 2.10.0; floor 2.3.0+ confirmed). `client.interactions` is present but emits `UserWarning: Interactions usage is experimental and may change`. Verified the **actual** `create()` signature and types — several plan assumptions (from web docs) are WRONG against the installed SDK and are corrected here:
+>
+> - **`create()` real kwargs:** `input`, `model`, `background`, `generation_config`, `previous_interaction_id`, `response_format`, `response_mime_type`, `response_modalities`, `service_tier`, `store`, `stream`, `system_instruction`, `tools`, `webhook_config`, `agent`, `agent_config`. Returns `Interaction | Stream[InteractionSSEEvent]`.
+> - **No `VideoResponseFormat`.** `response_format` ∈ {Audio, Text, Image, `object`}. Video output must be requested via **`response_modalities=['video']`** (valid literal), NOT a `response_format={"type":"video"}`. **There is no video aspect-ratio field anywhere in the SDK** (only `ImageResponseFormat.aspect_ratio`). → the plan's aspect-ratio handling and `delivery` key for video are unconfirmed; `VideoContent.resolution` is `low|medium|high|ultra_high`, not "720p".
+> - **No `interaction.output_video`.** Response is `Interaction{ id, created, status∈[in_progress,requires_action,completed,failed,cancelled,incomplete,budget_exceeded], steps[], usage }`. Generated video arrives as a **`VideoContent` inside a `ModelOutputStep.content[]` within `interaction.steps`** (`VideoContent.data` base64 / `.uri` / `.mime_type`). Client code must walk `steps`, not read `output_video`.
+> - **No `generation_config.video_config.task`.** `GenerationConfig` = `{image_config, speech_config, seed, temperature, top_p, max_output_tokens, stop_sequences, thinking_level, thinking_summaries, tool_choice}`. The plan's `task=text_to_video|image_to_video|reference_to_video|edit` mechanism does not exist in this SDK — task is inferred from the input content shape (text-only vs image+text vs video+text).
+> - **Model not enumerated:** the `model` Literal lists gemini-2.5/3/3.1/3.5, lyria-3, deep-research — **no `gemini-omni-flash-preview`**. It is accepted only as a free `str`, i.e. the SDK has no first-class knowledge of it.
+> - Model callable: **UNVERIFIED — BLOCKED.** No `GOOGLE_API_KEY`/`GEMINI_API_KEY` in env and `config.get_api_key("google")` returns empty in the Linux venv, so the live probe could not run. Combined with the model's absence from the SDK's known list, availability for this account is unconfirmed.
+>
+> **Consequence for the plan:** the Interactions-API *direction* is correct (real `create`, `previous_interaction_id`, `VideoContent`, inline/uri delivery), but Tasks 3–4's concrete request/response shape must be rewritten to: request video via `response_modalities=['video']`; read output by walking `interaction.steps → ModelOutputStep.content → VideoContent`; drop `video_config.task` and the `response_format` video keys. **Do not implement until (a) a Google API key is available to the run environment and (b) a live `create()` confirms the model is callable and reveals the real output shape** (whether video comes back inline on the step, via a `uri` needing a Files-API poll, or via `background=True`).
 
 ---
 

--- a/Plans/2026-06-30-gemini-omni-video-support.md
+++ b/Plans/2026-06-30-gemini-omni-video-support.md
@@ -24,12 +24,26 @@
 - ✅ Fixed the pre-existing **"Google Veo" vs "Gemini Veo"** save/restore mismatch + added Sora/Omni restore branches; `test_video_provider_persistence.py` locks the label contract.
 - ✅ Auth: Omni uses the existing `google_api_key` (API-key) path — no `providers/google.py` change. README updated.
 
-**⚠️ NOT YET VERIFIED LIVE (the Phase 0 gate):** no Google API key reaches the WSL
-run env, so no real `client.interactions.create` call has been made. Two pieces
-are coded to best-understanding and need a real call (run from PowerShell with a
-key + confirmed Omni access) to confirm/adjust:
-1. **Aspect-ratio request shape** — sent best-effort as `response_format=[{"type":"video","aspect_ratio":...}]` via the SDK's `object` escape-hatch (no typed `VideoResponseFormat`). The server may ignore or reject it.
-2. **Output delivery** — whether the MP4 returns inline on the step, as a Files-API `uri`, or via `background=True`. The client handles inline + uri; if Omni only returns via background, `_await_terminal` polling covers it, but the exact `VideoContent` location in `steps` should be confirmed against a real response.
+**SDK surface corrected + verified (2026-06-30, after first live test failed).**
+The initial client was built against `google-genai` **2.8.0**'s transitional
+`_interactions` surface, which is wrong. The real Omni API is the **2.9.0+ `_gaos`
+"GeminiNextGen"** surface:
+- Request: `response_format={"type":"video","aspect_ratio":"16:9"|"9:16"}` (a **dict**;
+  no `response_modalities`, not list-wrapped).
+- Response: `interaction.output_video` (a `VideoContent` with base64 `data` / `uri`).
+- Floor raised to `google-genai>=2.9.0` (2.8.0 lacks `output_video`; 2.9.0 is the
+  oldest compliant version — 2.10.0 also works but was <7 days old at writing).
+
+Verified the corrected request is accepted by the installed 2.9.0 SDK and reaches
+Google's endpoint (400 `API_KEY_INVALID` with a dummy key — i.e. the request shape
+passed validation; only auth remained). **A full end-to-end generation with a valid
+key on PowerShell is the last confirmation** (delivery as inline `data` vs Files-API
+`uri` is both handled; `_await_terminal` polls if the interaction returns
+non-terminal).
+
+**Action for the run env:** the PowerShell `.venv` must `pip install -r
+requirements.txt` to pull `google-genai>=2.9.0` — an older SDK there is part of why
+the first attempt failed.
 
 **Remaining (deferred):** dedicated "Refine" UI button (plumbing is ready — it just
 needs to pass `omni_edit=True`); uploaded-video editing; `background`/`webhook`;

--- a/Plans/2026-06-30-gemini-omni-video-support.md
+++ b/Plans/2026-06-30-gemini-omni-video-support.md
@@ -4,7 +4,36 @@
 >
 > **Source issue:** [#28 — Support Gemini Omni Flash](https://github.com/lelandg/ImageAI/issues/28). Reporter asked for a *plan* with open questions documented; brainstorming is explicitly deferred to the reporter. This plan is therefore staged behind a **Phase 0 verification gate** because the target model is *preview* and the SDK surface is new.
 
-**Last Updated:** 2026-06-30 14:05
+**Last Updated:** 2026-06-30 15:20
+
+## Implementation status (2026-06-30)
+
+**Implemented on branch `feat/gemini-omni-video`** (suite 410 green):
+
+- ✅ `core/video/omni_client.py` — `OmniClient` / `OmniGenerationConfig` /
+  `OmniGenerationResult` / `OmniModel`, built against the **verified** SDK 2.8.0
+  shape (request via `response_modalities=['video']`; read output by walking
+  `interaction.steps → ModelOutputStep → VideoContent`; inline-base64 and
+  Files-API-URI delivery; `previous_interaction_id` for edits). 12 mocked unit
+  tests.
+- ✅ Model ID via `resolve_model('google','omni', static_default='gemini-omni-flash-preview')` (no hardcode).
+- ✅ `core/video/config.py` `omni_settings` + `get_omni_model_config`; `__init__.py` `OMNI_AVAILABLE` export; `requirements.txt` floor → `google-genai>=2.3.0`.
+- ✅ Video-tab UI: combo entry + Omni model/aspect widgets + visibility toggle + kwargs packing (`workspace_widget.py`).
+- ✅ Dispatch + `_generate_video_clip_omni` on `VideoGenerationThread` (`video_project_tab.py`); FFmpeg path concatenates clips (mirrors Sora — no `_render_video` branch needed).
+- ✅ Conversational editing plumbing (interaction id saved on scene; reused as `previous_interaction_id` only when an explicit `omni_edit` is requested).
+- ✅ Fixed the pre-existing **"Google Veo" vs "Gemini Veo"** save/restore mismatch + added Sora/Omni restore branches; `test_video_provider_persistence.py` locks the label contract.
+- ✅ Auth: Omni uses the existing `google_api_key` (API-key) path — no `providers/google.py` change. README updated.
+
+**⚠️ NOT YET VERIFIED LIVE (the Phase 0 gate):** no Google API key reaches the WSL
+run env, so no real `client.interactions.create` call has been made. Two pieces
+are coded to best-understanding and need a real call (run from PowerShell with a
+key + confirmed Omni access) to confirm/adjust:
+1. **Aspect-ratio request shape** — sent best-effort as `response_format=[{"type":"video","aspect_ratio":...}]` via the SDK's `object` escape-hatch (no typed `VideoResponseFormat`). The server may ignore or reject it.
+2. **Output delivery** — whether the MP4 returns inline on the step, as a Files-API `uri`, or via `background=True`. The client handles inline + uri; if Omni only returns via background, `_await_terminal` polling covers it, but the exact `VideoContent` location in `steps` should be confirmed against a real response.
+
+**Remaining (deferred):** dedicated "Refine" UI button (plumbing is ready — it just
+needs to pass `omni_edit=True`); uploaded-video editing; `background`/`webhook`;
+SynthID surfacing. See "Deferred / out of scope".
 
 **Goal:** Add "Gemini Omni" as a fourth video provider on the Video tab — text/image/reference-to-video plus conversational editing — driven through Google's new **Interactions API** (`client.interactions.create`, model `gemini-omni-flash-preview`).
 

--- a/README.md
+++ b/README.md
@@ -988,6 +988,10 @@ I'm tap-tap-tappin' in my head
    - Choose rendering method:
      - FFmpeg Slideshow: Generate images first, then render with Ken Burns effects
      - Google Veo: Generate motion video clips for each scene
+     - OpenAI Sora: Generate Sora 2 motion video clips for each scene
+     - Gemini Omni: Fast conversational video generation via the Interactions
+       API (text-to-video, image-to-video, and conversational editing; 720p,
+       3–10s, with audio; 16:9 or 9:16). Uses your Google API key.
    - Click "Render Video" to create final output
 
 3. **Professional AI Motion Video with Continuity** (Google Veo 3.0/3.1):

--- a/core/video/__init__.py
+++ b/core/video/__init__.py
@@ -28,6 +28,23 @@ except ImportError:
     SoraGenerationResult = None
     SoraErrorType = None
 
+# Gemini Omni client exports (lazy import; needs google-genai >= 2.3.0 for the
+# Interactions API).
+try:
+    from .omni_client import (
+        OmniClient,
+        OmniModel,
+        OmniGenerationConfig,
+        OmniGenerationResult,
+    )
+    OMNI_AVAILABLE = True
+except ImportError:
+    OMNI_AVAILABLE = False
+    OmniClient = None
+    OmniModel = None
+    OmniGenerationConfig = None
+    OmniGenerationResult = None
+
 __all__ = [
     # FFmpeg utilities
     'get_ffmpeg_manager',
@@ -44,4 +61,10 @@ __all__ = [
     'SoraGenerationConfig',
     'SoraGenerationResult',
     'SoraErrorType',
+    # Gemini Omni client
+    'OMNI_AVAILABLE',
+    'OmniClient',
+    'OmniModel',
+    'OmniGenerationConfig',
+    'OmniGenerationResult',
 ]

--- a/core/video/config.py
+++ b/core/video/config.py
@@ -16,7 +16,7 @@ class VideoConfig:
     DEFAULT_CONFIG = {
         "enabled": True,
         "video_projects_dir": None,  # Will be set to user config dir / video_projects
-        "default_video_provider": "slideshow",  # "veo" or "slideshow"
+        "default_video_provider": "slideshow",  # "slideshow", "veo", "sora", or "omni"
         "veo_model": "veo-3.1-generate-001",  # Default Veo model (post June 30 2026 GA)
         "ffmpeg_path": "ffmpeg",  # Auto-detect or user-specified
         "cache_size_mb": 5000,  # Max cache size in MB
@@ -54,6 +54,21 @@ class VideoConfig:
             "default_person_generation": "dont_allow",
             "retention_days": 2,  # Server retention period
             "polling_interval": 10,  # seconds between status checks
+            "timeout": 600  # Maximum wait time in seconds
+        },
+        "omni_settings": {
+            # Gemini Omni video generation via the Interactions API.
+            "models": {
+                "gemini-omni-flash-preview": {
+                    "fps": 24,
+                    "resolution": "720p",
+                    "duration_range": [3, 10],
+                    "aspect_ratios": ["16:9", "9:16"],
+                    "has_audio": True,
+                    "supports_conversational_edit": True
+                }
+            },
+            "polling_interval": 10,  # seconds between Interaction status polls
             "timeout": 600  # Maximum wait time in seconds
         },
         "export_settings": {
@@ -275,7 +290,19 @@ class VideoConfig:
             Model configuration dictionary
         """
         return self.get(f"veo_settings.models.{model}", {})
-    
+
+    def get_omni_model_config(self, model: str) -> Dict[str, Any]:
+        """
+        Get configuration for a specific Gemini Omni model.
+
+        Args:
+            model: Omni model name
+
+        Returns:
+            Model configuration dictionary
+        """
+        return self.get(f"omni_settings.models.{model}", {})
+
     def is_llm_provider_enabled(self, provider: str) -> bool:
         """
         Check if an LLM provider is enabled.

--- a/core/video/omni_client.py
+++ b/core/video/omni_client.py
@@ -1,0 +1,395 @@
+"""
+Google Gemini Omni client for AI video generation via the Interactions API.
+
+Gemini Omni (``gemini-omni-flash-preview``) is a fast, conversational
+video-generation model driven through Google's **Interactions API**
+(``client.interactions.create``), *not* the Veo ``generate_videos`` endpoint.
+It supports text-to-video, image-to-video, and stateful conversational editing
+(via ``previous_interaction_id``) with audio in the output.
+
+Implementation notes (verified against ``google-genai`` 2.8.0):
+- The Interactions API is marked *experimental* by the SDK.
+- There is **no** ``VideoResponseFormat`` and **no** ``output_video`` attribute.
+  Video output is requested with ``response_modalities=['video']`` and read back
+  by walking ``interaction.steps`` for a ``ModelOutputStep`` whose ``content``
+  contains a video item (``type == 'video'`` with ``data`` base64 or ``uri``).
+- Aspect ratio has no typed field for video; we pass it best-effort through the
+  ``response_format`` *object* escape-hatch the SDK union allows. It is never
+  embedded in the prompt text (AGENTS.md §9).
+- ``gemini-omni-flash-preview`` is not in the SDK's enumerated model list; it is
+  accepted as a free string and resolved via ``resolve_model`` so the ID is not
+  hard-coded (AGENTS.md §8).
+"""
+
+import asyncio
+import base64
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from core.llm_models import resolve_model
+
+# Check if google.genai (with the Interactions API) is available.
+try:
+    import google.genai as genai
+    GENAI_AVAILABLE = True
+except ImportError:
+    GENAI_AVAILABLE = False
+    genai = None
+
+
+# Terminal Interaction statuses (from google.genai interactions.Interaction).
+_TERMINAL_STATUSES = {"completed", "failed", "cancelled", "incomplete", "budget_exceeded"}
+_FAILED_STATUSES = {"failed", "cancelled", "incomplete", "budget_exceeded"}
+
+
+class OmniModel(Enum):
+    """Available Gemini Omni models.
+
+    The ID is resolved through the model registry at access time so it tracks
+    the published registry and is never hard-coded (AGENTS.md §8). The preview
+    string is the offline fallback.
+    """
+
+    OMNI_FLASH = "gemini-omni-flash-preview"
+
+    @classmethod
+    def default_id(cls) -> str:
+        """Resolve the current Omni model ID (registry-first, static fallback)."""
+        return resolve_model("google", "omni", static_default=cls.OMNI_FLASH.value)
+
+
+@dataclass
+class OmniGenerationConfig:
+    """Configuration for a Gemini Omni video generation/edit request."""
+
+    prompt: str = ""
+    model: str = ""  # Resolved Omni model ID; defaults via __post_init__.
+    aspect_ratio: str = "16:9"  # "16:9" (landscape) or "9:16" (portrait).
+    reference_image: Optional[Path] = None  # Start/reference frame (image-to-video).
+    previous_interaction_id: Optional[str] = None  # Chain a conversational edit.
+    # Task is inferred from the input shape; kept for logging/metadata only.
+    task: str = "text_to_video"
+
+    def __post_init__(self):
+        if not self.model:
+            self.model = OmniModel.default_id()
+
+        if self.aspect_ratio not in OmniClient.MODEL_CONSTRAINTS["aspect_ratios"]:
+            raise ValueError(
+                f"aspect_ratio {self.aspect_ratio!r} not supported by Gemini Omni. "
+                f"Use one of {OmniClient.MODEL_CONSTRAINTS['aspect_ratios']}."
+            )
+
+        valid_tasks = OmniClient.MODEL_CONSTRAINTS["tasks"]
+        if self.task not in valid_tasks:
+            raise ValueError(f"task {self.task!r} invalid. Use one of {valid_tasks}.")
+
+        # image_to_video / reference_to_video require a reference image.
+        if self.task in ("image_to_video", "reference_to_video") and not self.reference_image:
+            raise ValueError(
+                f"task {self.task!r} requires a reference_image, but none was provided."
+            )
+
+    def to_interaction_kwargs(self) -> Dict[str, Any]:
+        """Build the kwargs for ``client.interactions.create(**kwargs)``.
+
+        Returns a dict using ``response_modalities=['video']`` to request video
+        output and a best-effort ``response_format`` object carrying the aspect
+        ratio (the SDK has no typed video response-format; the union accepts a
+        raw object). The aspect ratio is never placed in the prompt text.
+        """
+        # Build the input: a plain string for text-to-video, or a content list
+        # when a reference image is supplied.
+        if self.reference_image is not None:
+            image_bytes = Path(self.reference_image).read_bytes()
+            b64 = base64.b64encode(image_bytes).decode("ascii")
+            mime = "image/png"
+            if str(self.reference_image).lower().endswith((".jpg", ".jpeg")):
+                mime = "image/jpeg"
+            input_payload: Any = [
+                {"type": "image", "data": b64, "mime_type": mime},
+                {"type": "text", "text": self.prompt},
+            ]
+        else:
+            input_payload = self.prompt
+
+        kwargs: Dict[str, Any] = {
+            "model": self.model,
+            "input": input_payload,
+            "response_modalities": ["video"],
+            # Best-effort aspect-ratio hint via the response_format object union.
+            "response_format": [{"type": "video", "aspect_ratio": self.aspect_ratio}],
+        }
+        if self.previous_interaction_id:
+            kwargs["previous_interaction_id"] = self.previous_interaction_id
+        return kwargs
+
+
+@dataclass
+class OmniGenerationResult:
+    """Result of a Gemini Omni generation/edit operation."""
+
+    success: bool = True
+    video_path: Optional[Path] = None
+    interaction_id: Optional[str] = None  # Feeds previous_interaction_id for edits.
+    error: Optional[str] = None
+    generation_time: float = 0.0
+    has_synthid: bool = True  # Omni outputs carry a SynthID watermark.
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class OmniClient:
+    """Client for Gemini Omni video generation via the Interactions API."""
+
+    MODEL_CONSTRAINTS = {
+        "aspect_ratios": ["16:9", "9:16"],
+        "tasks": ["text_to_video", "image_to_video", "reference_to_video", "edit"],
+        "duration_range": (3, 10),  # seconds (informational; no SDK duration field)
+        "fps": 24,
+        "resolution": "720p",
+        "supports_audio": True,
+        "supports_conversational_edit": True,
+    }
+
+    def __init__(self, api_key: Optional[str] = None,
+                 polling_interval: int = 10, timeout: int = 600):
+        """Initialize the Omni client.
+
+        Args:
+            api_key: Google API key. Omni is authenticated with a plain API key
+                (same key path as the existing Gemini image provider).
+            polling_interval: Seconds between status polls for long generations.
+            timeout: Maximum seconds to wait for a generation to finish.
+        """
+        if not GENAI_AVAILABLE:
+            raise ImportError(
+                "google-genai not installed. Run: pip install 'google-genai>=2.3.0'"
+            )
+
+        self.api_key = api_key
+        self.polling_interval = polling_interval
+        self.timeout = timeout
+        self.logger = logging.getLogger(__name__)
+        self.client = genai.Client(api_key=api_key) if api_key else None
+
+    def validate_config(self, config: OmniGenerationConfig) -> Tuple[bool, Optional[str]]:
+        """Validate a config against model constraints (config also self-validates)."""
+        if config.aspect_ratio not in self.MODEL_CONSTRAINTS["aspect_ratios"]:
+            return False, (
+                f"Aspect ratio {config.aspect_ratio} not supported. "
+                f"Use: {self.MODEL_CONSTRAINTS['aspect_ratios']}"
+            )
+        if config.task not in self.MODEL_CONSTRAINTS["tasks"]:
+            return False, f"Task {config.task} not supported."
+        if config.reference_image is not None and not Path(config.reference_image).exists():
+            return False, f"Reference image not found: {config.reference_image}"
+        return True, None
+
+    async def generate_video_async(self, config: OmniGenerationConfig,
+                                   output_path: Path) -> OmniGenerationResult:
+        """Generate (or conversationally edit) a video with Gemini Omni.
+
+        Args:
+            config: Generation configuration.
+            output_path: Where to write the resulting MP4.
+
+        Returns:
+            OmniGenerationResult with the saved path and interaction id.
+        """
+        result = OmniGenerationResult()
+        start_time = time.time()
+
+        is_valid, error = self.validate_config(config)
+        if not is_valid:
+            result.success = False
+            result.error = error
+            self.logger.error(f"Omni config invalid: {error}")
+            return result
+
+        if not self.client:
+            result.success = False
+            result.error = "No client configured. API key required for Omni generation."
+            self.logger.error(result.error)
+            return result
+
+        try:
+            kwargs = config.to_interaction_kwargs()
+
+            # Log the full request (AGENTS.md §8 — show everything sent to the LLM).
+            self.logger.info("=" * 60)
+            self.logger.info(f"Gemini Omni request — model={config.model} task={config.task}")
+            self.logger.info(f"  aspect_ratio={config.aspect_ratio} "
+                             f"reference_image={config.reference_image} "
+                             f"previous_interaction_id={config.previous_interaction_id}")
+            self.logger.info(f"  Prompt:\n{config.prompt}")
+            self.logger.info("=" * 60)
+
+            # Synchronous create; long generations may still come back in_progress,
+            # in which case we poll interactions.get() until terminal.
+            interaction = await asyncio.to_thread(
+                self.client.interactions.create, **kwargs
+            )
+
+            interaction = await self._await_terminal(interaction)
+            result.interaction_id = getattr(interaction, "id", None)
+            status = getattr(interaction, "status", None)
+            self.logger.info(f"Omni interaction {result.interaction_id} status={status}")
+
+            if status in _FAILED_STATUSES:
+                result.success = False
+                result.error = f"Omni generation {status}: {self._error_text(interaction)}"
+                self.logger.error(result.error)
+                return result
+
+            # Extract the video content from the interaction steps.
+            video_data, video_uri, mime = self._extract_video(interaction)
+            if video_data is None and video_uri is None:
+                result.success = False
+                result.error = "Omni response contained no video content."
+                self.logger.error(result.error)
+                self.logger.error(f"Interaction steps: {getattr(interaction, 'steps', None)}")
+                return result
+
+            video_bytes = video_data
+            if video_bytes is None and video_uri:
+                video_bytes = await self._download_uri(video_uri)
+
+            if not video_bytes:
+                result.success = False
+                result.error = "Failed to obtain video bytes from Omni response."
+                self.logger.error(result.error)
+                return result
+
+            output_path = Path(output_path)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(video_bytes)
+
+            result.success = True
+            result.video_path = output_path
+            result.metadata.update({
+                "model": config.model,
+                "task": config.task,
+                "aspect_ratio": config.aspect_ratio,
+                "mime_type": mime,
+                "interaction_id": result.interaction_id,
+                "generated_at": datetime.now().isoformat(),
+            })
+            result.generation_time = time.time() - start_time
+            self.logger.info(
+                f"Omni video saved to {output_path} "
+                f"({len(video_bytes) / (1024 * 1024):.2f} MB) in "
+                f"{result.generation_time:.1f}s"
+            )
+
+        except Exception as e:
+            result.success = False
+            result.error = str(e)
+            result.generation_time = time.time() - start_time
+            self.logger.error(f"Omni generation failed: {e}", exc_info=True)
+
+        return result
+
+    def generate_video(self, config: OmniGenerationConfig,
+                        output_path: Path) -> OmniGenerationResult:
+        """Synchronous wrapper around :meth:`generate_video_async`."""
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            return loop.run_until_complete(self.generate_video_async(config, output_path))
+        finally:
+            loop.close()
+
+    async def _await_terminal(self, interaction: Any) -> Any:
+        """Poll ``interactions.get`` until the interaction reaches a terminal state."""
+        status = getattr(interaction, "status", None)
+        if status in _TERMINAL_STATUSES:
+            return interaction
+
+        interaction_id = getattr(interaction, "id", None)
+        if not interaction_id:
+            return interaction
+
+        deadline = time.time() + self.timeout
+        while time.time() < deadline:
+            await asyncio.sleep(self.polling_interval)
+            try:
+                interaction = await asyncio.to_thread(
+                    self.client.interactions.get, interaction_id
+                )
+            except Exception as e:
+                self.logger.warning(f"Polling interactions.get failed: {e}")
+                continue
+            status = getattr(interaction, "status", None)
+            self.logger.debug(f"Omni interaction {interaction_id} status={status}")
+            if status in _TERMINAL_STATUSES:
+                return interaction
+
+        self.logger.warning(
+            f"Omni interaction {interaction_id} did not finish within {self.timeout}s"
+        )
+        return interaction
+
+    @staticmethod
+    def _extract_video(interaction: Any) -> Tuple[Optional[bytes], Optional[str], Optional[str]]:
+        """Walk the interaction steps and return (video_bytes, uri, mime_type).
+
+        Output video arrives as a ``VideoContent`` (``type == 'video'``) inside a
+        ``ModelOutputStep.content`` list. Returns decoded bytes when ``data`` is
+        present (base64), otherwise the ``uri`` for separate download.
+        """
+        steps = getattr(interaction, "steps", None) or []
+        for step in steps:
+            content = getattr(step, "content", None)
+            if not content:
+                continue
+            for item in content:
+                item_type = getattr(item, "type", None)
+                if item_type is None and isinstance(item, dict):
+                    item_type = item.get("type")
+                if item_type != "video":
+                    continue
+                data = getattr(item, "data", None) if not isinstance(item, dict) else item.get("data")
+                uri = getattr(item, "uri", None) if not isinstance(item, dict) else item.get("uri")
+                mime = getattr(item, "mime_type", None) if not isinstance(item, dict) else item.get("mime_type")
+                video_bytes = None
+                if data:
+                    try:
+                        video_bytes = base64.b64decode(data)
+                    except Exception:
+                        video_bytes = None
+                return video_bytes, uri, mime
+        return None, None, None
+
+    async def _download_uri(self, uri: str) -> Optional[bytes]:
+        """Download video bytes for a Files-API URI, polling until ACTIVE."""
+        try:
+            file_name = uri.split("/")[-1]
+            deadline = time.time() + self.timeout
+            while time.time() < deadline:
+                info = await asyncio.to_thread(self.client.files.get, name=f"files/{file_name}")
+                state = getattr(getattr(info, "state", None), "name", None) or getattr(info, "state", None)
+                if state == "ACTIVE":
+                    break
+                if state == "FAILED":
+                    self.logger.error(f"Files API reports FAILED for {uri}")
+                    return None
+                await asyncio.sleep(self.polling_interval)
+            data = await asyncio.to_thread(self.client.files.download, file=uri)
+            return data
+        except Exception as e:
+            self.logger.error(f"Failed to download Omni video URI {uri}: {e}", exc_info=True)
+            return None
+
+    @staticmethod
+    def _error_text(interaction: Any) -> str:
+        """Best-effort extraction of an error message from a failed interaction."""
+        for attr in ("error", "status_message", "incomplete_details"):
+            val = getattr(interaction, attr, None)
+            if val:
+                return str(val)
+        return "no error detail provided"

--- a/core/video/omni_client.py
+++ b/core/video/omni_client.py
@@ -45,6 +45,15 @@ except ImportError:
 _TERMINAL_STATUSES = {"completed", "failed", "cancelled", "incomplete", "budget_exceeded"}
 _FAILED_STATUSES = {"failed", "cancelled", "incomplete", "budget_exceeded"}
 
+# Reference-image MIME types by file suffix (for image-to-video input).
+_IMAGE_MIME_BY_SUFFIX = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+}
+
 
 class OmniModel(Enum):
     """Available Gemini Omni models.
@@ -108,9 +117,9 @@ class OmniGenerationConfig:
         if self.reference_image is not None:
             image_bytes = Path(self.reference_image).read_bytes()
             b64 = base64.b64encode(image_bytes).decode("ascii")
-            mime = "image/png"
-            if str(self.reference_image).lower().endswith((".jpg", ".jpeg")):
-                mime = "image/jpeg"
+            mime = _IMAGE_MIME_BY_SUFFIX.get(
+                Path(self.reference_image).suffix.lower(), "image/png"
+            )
             input_payload: Any = [
                 {"type": "image", "data": b64, "mime_type": mime},
                 {"type": "text", "text": self.prompt},
@@ -385,15 +394,24 @@ class OmniClient:
         try:
             file_name = uri.split("/")[-1]
             deadline = time.time() + self.timeout
+            became_active = False
             while time.time() < deadline:
                 info = await asyncio.to_thread(self.client.files.get, name=f"files/{file_name}")
                 state = getattr(getattr(info, "state", None), "name", None) or getattr(info, "state", None)
                 if state == "ACTIVE":
+                    became_active = True
                     break
                 if state == "FAILED":
                     self.logger.error(f"Files API reports FAILED for {uri}")
                     return None
                 await asyncio.sleep(self.polling_interval)
+            # Only download once the file is ACTIVE; otherwise we'd risk writing a
+            # partial/empty MP4 on timeout. Fail cleanly instead.
+            if not became_active:
+                self.logger.error(
+                    f"Files API did not reach ACTIVE for {uri} within {self.timeout}s"
+                )
+                return None
             data = await asyncio.to_thread(self.client.files.download, file=uri)
             return data
         except Exception as e:

--- a/core/video/omni_client.py
+++ b/core/video/omni_client.py
@@ -7,17 +7,16 @@ video-generation model driven through Google's **Interactions API**
 It supports text-to-video, image-to-video, and stateful conversational editing
 (via ``previous_interaction_id``) with audio in the output.
 
-Implementation notes (verified against ``google-genai`` 2.8.0):
-- The Interactions API is marked *experimental* by the SDK.
-- There is **no** ``VideoResponseFormat`` and **no** ``output_video`` attribute.
-  Video output is requested with ``response_modalities=['video']`` and read back
-  by walking ``interaction.steps`` for a ``ModelOutputStep`` whose ``content``
-  contains a video item (``type == 'video'`` with ``data`` base64 or ``uri``).
-- Aspect ratio has no typed field for video; we pass it best-effort through the
-  ``response_format`` *object* escape-hatch the SDK union allows. It is never
-  embedded in the prompt text (AGENTS.md §9).
-- ``gemini-omni-flash-preview`` is not in the SDK's enumerated model list; it is
-  accepted as a free string and resolved via ``resolve_model`` so the ID is not
+Implementation notes (verified against ``google-genai`` 2.9.0, the GeminiNextGen
+``client.interactions`` surface — the older 2.8.0 ``_interactions`` surface lacked
+``output_video`` and is NOT compatible, hence the >=2.9.0 floor):
+- Video + aspect ratio are requested with ``response_format={"type": "video",
+  "aspect_ratio": "16:9"|"9:16"}`` (a dict), per the Omni docs. The aspect ratio
+  is never embedded in the prompt text (AGENTS.md §9).
+- The generated video is read from ``interaction.output_video`` (a ``VideoContent``
+  with base64 ``data`` and/or a ``uri``); we keep a defensive fallback that walks
+  ``interaction.steps`` for a video content item.
+- ``gemini-omni-flash-preview`` is resolved via ``resolve_model`` so the ID is not
   hard-coded (AGENTS.md §8).
 """
 
@@ -98,10 +97,11 @@ class OmniGenerationConfig:
     def to_interaction_kwargs(self) -> Dict[str, Any]:
         """Build the kwargs for ``client.interactions.create(**kwargs)``.
 
-        Returns a dict using ``response_modalities=['video']`` to request video
-        output and a best-effort ``response_format`` object carrying the aspect
-        ratio (the SDK has no typed video response-format; the union accepts a
-        raw object). The aspect ratio is never placed in the prompt text.
+        Matches the documented Gemini Omni request shape: video output and
+        aspect ratio are requested via ``response_format={"type": "video",
+        "aspect_ratio": ...}`` (a dict). The aspect ratio is never placed in the
+        prompt text (AGENTS.md §9). For image-to-video, ``input`` is a content
+        list ``[{image}, {text}]``; otherwise it is the plain prompt string.
         """
         # Build the input: a plain string for text-to-video, or a content list
         # when a reference image is supplied.
@@ -121,9 +121,7 @@ class OmniGenerationConfig:
         kwargs: Dict[str, Any] = {
             "model": self.model,
             "input": input_payload,
-            "response_modalities": ["video"],
-            # Best-effort aspect-ratio hint via the response_format object union.
-            "response_format": [{"type": "video", "aspect_ratio": self.aspect_ratio}],
+            "response_format": {"type": "video", "aspect_ratio": self.aspect_ratio},
         }
         if self.previous_interaction_id:
             kwargs["previous_interaction_id"] = self.previous_interaction_id
@@ -334,14 +332,23 @@ class OmniClient:
         )
         return interaction
 
-    @staticmethod
-    def _extract_video(interaction: Any) -> Tuple[Optional[bytes], Optional[str], Optional[str]]:
-        """Walk the interaction steps and return (video_bytes, uri, mime_type).
+    @classmethod
+    def _extract_video(cls, interaction: Any) -> Tuple[Optional[bytes], Optional[str], Optional[str]]:
+        """Return (video_bytes, uri, mime_type) for a completed interaction.
 
-        Output video arrives as a ``VideoContent`` (``type == 'video'``) inside a
-        ``ModelOutputStep.content`` list. Returns decoded bytes when ``data`` is
-        present (base64), otherwise the ``uri`` for separate download.
+        The documented path is ``interaction.output_video`` (a ``VideoContent``
+        with base64 ``data`` and/or a ``uri``). As a defensive fallback we also
+        walk ``interaction.steps`` for a ``ModelOutputStep`` containing a video
+        content item, in case a delivery variant returns it there.
         """
+        # Primary: interaction.output_video (VideoContent) per the Omni docs.
+        out = getattr(interaction, "output_video", None)
+        if out is not None:
+            data, uri, mime = cls._video_content_parts(out)
+            if data is not None or uri is not None:
+                return data, uri, mime
+
+        # Fallback: walk steps -> ModelOutputStep.content -> video item.
         steps = getattr(interaction, "steps", None) or []
         for step in steps:
             content = getattr(step, "content", None)
@@ -353,17 +360,25 @@ class OmniClient:
                     item_type = item.get("type")
                 if item_type != "video":
                     continue
-                data = getattr(item, "data", None) if not isinstance(item, dict) else item.get("data")
-                uri = getattr(item, "uri", None) if not isinstance(item, dict) else item.get("uri")
-                mime = getattr(item, "mime_type", None) if not isinstance(item, dict) else item.get("mime_type")
-                video_bytes = None
-                if data:
-                    try:
-                        video_bytes = base64.b64decode(data)
-                    except Exception:
-                        video_bytes = None
-                return video_bytes, uri, mime
+                return cls._video_content_parts(item)
         return None, None, None
+
+    @staticmethod
+    def _video_content_parts(item: Any) -> Tuple[Optional[bytes], Optional[str], Optional[str]]:
+        """Decode a VideoContent-like item (object or dict) to (bytes, uri, mime)."""
+        if isinstance(item, dict):
+            data, uri, mime = item.get("data"), item.get("uri"), item.get("mime_type")
+        else:
+            data = getattr(item, "data", None)
+            uri = getattr(item, "uri", None)
+            mime = getattr(item, "mime_type", None)
+        video_bytes = None
+        if data:
+            try:
+                video_bytes = base64.b64decode(data)
+            except Exception:
+                video_bytes = None
+        return video_bytes, uri, mime
 
     async def _download_uri(self, uri: str) -> Optional[bytes]:
         """Download video bytes for a Files-API URI, polling until ACTIVE."""

--- a/gui/video/video_project_tab.py
+++ b/gui/video/video_project_tab.py
@@ -1523,11 +1523,18 @@ class VideoGenerationThread(QThread):
                 self.generation_complete.emit(False, "Google API key required for Gemini Omni video generation")
                 return
 
-            # Map aspect ratio for Omni (only supports 16:9 and 9:16)
-            if aspect_ratio in ['9:16', '3:4']:
-                omni_aspect = '9:16'
-            else:
-                omni_aspect = '16:9'
+            # Map aspect ratio for Omni (only supports 16:9 and 9:16). Prefer the
+            # dedicated Omni aspect selector; fall back to the project's general
+            # aspect ratio, coercing unsupported values to the nearest of 16:9/9:16.
+            omni_aspect = self.kwargs.get('omni_aspect_ratio')
+            if omni_aspect not in ('16:9', '9:16'):
+                fallback_source = omni_aspect if omni_aspect else aspect_ratio
+                omni_aspect = '9:16' if aspect_ratio in ('9:16', '3:4', '4:5') else '16:9'
+                if fallback_source not in ('16:9', '9:16'):
+                    logger.debug(
+                        f"Omni: coercing aspect ratio {fallback_source!r} -> {omni_aspect} "
+                        f"(Omni supports only 16:9 / 9:16)"
+                    )
 
             # Determine task + reference image. Conversational editing chains on
             # the previous interaction id ONLY when an explicit edit was requested

--- a/gui/video/video_project_tab.py
+++ b/gui/video/video_project_tab.py
@@ -731,6 +731,9 @@ class VideoGenerationThread(QThread):
             if video_provider == 'OpenAI Sora':
                 return self._generate_video_clip_sora()
 
+            if video_provider == 'Gemini Omni':
+                return self._generate_video_clip_omni()
+
             # Default to Veo
             from core.video.veo_client import VeoClient, VeoGenerationConfig, VeoModel
             from core.video.midi_processor import snap_duration_to_veo
@@ -1473,6 +1476,164 @@ class VideoGenerationThread(QThread):
             logger = logging.getLogger(__name__)
             logger.error(f"Sora video generation failed: {e}", exc_info=True)
             self.generation_complete.emit(False, f"Sora video generation failed: {e}")
+
+    def _generate_video_clip_omni(self):
+        """Generate video clip for a single scene using Gemini Omni (Interactions API)."""
+        try:
+            from core.video.omni_client import OmniClient, OmniGenerationConfig
+            from pathlib import Path
+            import logging
+            from datetime import datetime
+
+            logger = logging.getLogger(__name__)
+
+            # Get scene indices
+            scene_indices = self.kwargs.get('scene_indices', None)
+            if not scene_indices or len(scene_indices) == 0:
+                self.generation_complete.emit(False, "No scene specified for video clip generation")
+                return
+
+            scene_index = scene_indices[0]
+            if scene_index >= len(self.project.scenes):
+                self.generation_complete.emit(False, f"Invalid scene index: {scene_index}")
+                return
+
+            scene = self.project.scenes[scene_index]
+
+            # Get generation parameters
+            seed_image_path = self.kwargs.get('start_frame') or self.kwargs.get('seed_image')
+
+            # Use video_prompt if available, otherwise fall back to regular prompt
+            prompt = self.kwargs.get('video_prompt') or scene.video_prompt or scene.prompt
+            aspect_ratio = self.kwargs.get('aspect_ratio', '16:9')
+
+            # Prepend prompt_style to the prompt
+            prompt_style = self.kwargs.get('prompt_style', 'Cinematic')
+            if prompt_style and prompt_style.lower() != 'none':
+                if not prompt.lower().startswith(prompt_style.lower()):
+                    prompt = f"{prompt_style} style: {prompt}"
+
+            logger.info(f"Using Gemini Omni for scene {scene_index}: {prompt[:100]}...")
+
+            self.progress_update.emit(5, "Initializing Gemini Omni client...")
+
+            # Get Google API key (Omni authenticates with a plain API key)
+            google_api_key = self.kwargs.get('google_api_key')
+            if not google_api_key:
+                self.generation_complete.emit(False, "Google API key required for Gemini Omni video generation")
+                return
+
+            # Map aspect ratio for Omni (only supports 16:9 and 9:16)
+            if aspect_ratio in ['9:16', '3:4']:
+                omni_aspect = '9:16'
+            else:
+                omni_aspect = '16:9'
+
+            # Determine task + reference image. Conversational editing chains on
+            # the previous interaction id ONLY when an explicit edit was requested
+            # (omni_edit kwarg, e.g. from a "Refine" action); a plain (re)generate
+            # is always a fresh text-to-video (or image-to-video with a seed frame).
+            reference_image = (
+                Path(seed_image_path)
+                if seed_image_path and Path(seed_image_path).exists()
+                else None
+            )
+            is_edit = bool(self.kwargs.get('omni_edit'))
+            previous_interaction_id = scene.metadata.get('omni_interaction_id') if is_edit else None
+            if is_edit and previous_interaction_id:
+                task = 'edit'
+            elif reference_image is not None:
+                task = 'image_to_video'
+            else:
+                task = 'text_to_video'
+
+            # Pull polling/timeout from video config
+            try:
+                from core.video.config import VideoConfig
+                vcfg = VideoConfig()
+                polling_interval = int(vcfg.get('omni_settings.polling_interval', 10))
+                timeout = int(vcfg.get('omni_settings.timeout', 600))
+            except Exception:
+                polling_interval, timeout = 10, 600
+
+            omni_model = self.kwargs.get('omni_model') or ''
+            logger.info("🎬 Gemini Omni Configuration:")
+            logger.info(f"   Model: {omni_model or 'gemini-omni-flash-preview (resolved)'}")
+            logger.info(f"   Task: {task}")
+            logger.info(f"   Aspect Ratio: {omni_aspect}")
+            logger.info(f"   Reference image: {reference_image}")
+            logger.info(f"   Previous interaction id: {previous_interaction_id}")
+
+            self.progress_update.emit(10, "Starting Gemini Omni generation...")
+
+            client = OmniClient(
+                api_key=google_api_key,
+                polling_interval=polling_interval,
+                timeout=timeout,
+            )
+
+            config_kwargs = dict(
+                prompt=prompt,
+                aspect_ratio=omni_aspect,
+                task=task,
+                reference_image=reference_image,
+                previous_interaction_id=previous_interaction_id,
+            )
+            if omni_model:
+                config_kwargs['model'] = omni_model
+            config = OmniGenerationConfig(**config_kwargs)
+
+            # Write straight into the project clips directory.
+            clips_dir = self.project.project_dir / "clips"
+            clips_dir.mkdir(parents=True, exist_ok=True)
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            video_path = clips_dir / f"scene_{scene_index}_{timestamp}.mp4"
+
+            result = client.generate_video(config, video_path)
+
+            if not result.success:
+                raise Exception(f"Gemini Omni generation failed: {result.error}")
+            if not result.video_path or not Path(result.video_path).exists():
+                raise Exception("Video generation succeeded but no video file was created")
+
+            # Persist the interaction id so a later "refine" can chain edits.
+            if result.interaction_id:
+                scene.metadata['omni_interaction_id'] = result.interaction_id
+
+            # Apply lip-sync if enabled for this scene
+            video_path = self._apply_lipsync_to_scene(video_path, scene_index)
+
+            self.progress_update.emit(94, "Extracting last frame...")
+            last_frame_path = self._extract_last_frame(video_path, scene_index)
+
+            self.progress_update.emit(97, "Extracting first frame...")
+            first_frame_path = self._extract_first_frame(video_path, scene_index)
+
+            # Update scene with video clip and frames
+            scene.video_clip = video_path
+            scene.first_frame = first_frame_path
+            scene.last_frame = last_frame_path
+
+            self.progress_update.emit(100, f"Gemini Omni video generated for scene {scene_index + 1}")
+
+            result_data = {
+                "scene_id": scene.id,
+                "video_clip": str(video_path),
+                "first_frame": str(first_frame_path),
+                "last_frame": str(last_frame_path),
+                "status": "completed",
+                "provider": "omni",
+                "model": config.model,
+                "interaction_id": result.interaction_id,
+            }
+            self.scene_complete.emit(scene.id, result_data)
+            self.generation_complete.emit(True, f"Gemini Omni video generated for scene {scene_index + 1}")
+
+        except Exception as e:
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.error(f"Gemini Omni video generation failed: {e}", exc_info=True)
+            self.generation_complete.emit(False, f"Gemini Omni video generation failed: {e}")
 
     def _render_video(self):
         """Render the final video"""

--- a/gui/video/workspace_widget.py
+++ b/gui/video/workspace_widget.py
@@ -1692,9 +1692,15 @@ class WorkspaceWidget(QWidget):
         self.sora_resolution_combo.currentTextChanged.connect(self._auto_save_settings)
         provider_layout.addWidget(self.sora_resolution_combo)
 
-        # Gemini Omni model selection (hidden by default)
+        # Gemini Omni model selection (hidden by default). The default model ID is
+        # resolved via the registry (resolve_model) rather than hardcoded (AGENTS.md §8).
+        try:
+            from core.video.omni_client import OmniModel
+            _omni_default_model = OmniModel.default_id()
+        except Exception:
+            _omni_default_model = "gemini-omni-flash-preview"
         self.omni_model_combo = QComboBox()
-        self.omni_model_combo.addItems(["gemini-omni-flash-preview"])
+        self.omni_model_combo.addItems([_omni_default_model])
         self.omni_model_combo.setCurrentIndex(0)
         self.omni_model_combo.setVisible(False)  # Hidden by default
         self.omni_model_combo.setMinimumWidth(220)

--- a/gui/video/workspace_widget.py
+++ b/gui/video/workspace_widget.py
@@ -1625,13 +1625,14 @@ class WorkspaceWidget(QWidget):
         provider_layout = QHBoxLayout()
         provider_layout.addWidget(QLabel("Render Method:"))
         self.video_provider_combo = QComboBox()
-        self.video_provider_combo.addItems(["FFmpeg Slideshow", "Gemini Veo", "OpenAI Sora"])
+        self.video_provider_combo.addItems(["FFmpeg Slideshow", "Gemini Veo", "OpenAI Sora", "Gemini Omni"])
         self.video_provider_combo.setCurrentIndex(1)  # Default to Gemini Veo
         self.video_provider_combo.setToolTip(
             "Video rendering method:\n"
             "- FFmpeg Slideshow: Traditional slideshow with transitions\n"
             "- Gemini Veo: Google AI-powered video generation\n"
-            "- OpenAI Sora: OpenAI Sora 2 video generation"
+            "- OpenAI Sora: OpenAI Sora 2 video generation\n"
+            "- Gemini Omni: Google conversational video generation (Interactions API)"
         )
         self.video_provider_combo.currentTextChanged.connect(self.on_video_provider_changed)
         provider_layout.addWidget(self.video_provider_combo)
@@ -1690,6 +1691,32 @@ class WorkspaceWidget(QWidget):
         self.sora_resolution_combo.setToolTip("Resolution (1080p only available with sora-2-pro)")
         self.sora_resolution_combo.currentTextChanged.connect(self._auto_save_settings)
         provider_layout.addWidget(self.sora_resolution_combo)
+
+        # Gemini Omni model selection (hidden by default)
+        self.omni_model_combo = QComboBox()
+        self.omni_model_combo.addItems(["gemini-omni-flash-preview"])
+        self.omni_model_combo.setCurrentIndex(0)
+        self.omni_model_combo.setVisible(False)  # Hidden by default
+        self.omni_model_combo.setMinimumWidth(220)
+        self.omni_model_combo.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self.omni_model_combo.setToolTip(
+            "Gemini Omni model:\n"
+            "- gemini-omni-flash-preview: fast conversational video (720p, 24fps,\n"
+            "  3-10s, with audio). Supports text-to-video, image-to-video, and\n"
+            "  conversational editing via the Interactions API."
+        )
+        self.omni_model_combo.currentTextChanged.connect(self._auto_save_settings)
+        provider_layout.addWidget(self.omni_model_combo)
+
+        # Gemini Omni aspect ratio (only 16:9 / 9:16; hidden by default)
+        self.omni_aspect_combo = QComboBox()
+        self.omni_aspect_combo.addItems(["16:9", "9:16"])
+        self.omni_aspect_combo.setCurrentIndex(0)
+        self.omni_aspect_combo.setVisible(False)
+        self.omni_aspect_combo.setMinimumWidth(80)
+        self.omni_aspect_combo.setToolTip("Gemini Omni aspect ratio (16:9 landscape or 9:16 portrait)")
+        self.omni_aspect_combo.currentTextChanged.connect(self._auto_save_settings)
+        provider_layout.addWidget(self.omni_aspect_combo)
 
         provider_layout.addStretch()
         layout.addLayout(provider_layout)
@@ -6049,6 +6076,8 @@ class WorkspaceWidget(QWidget):
             'veo_model': self.veo_model_combo.currentText(),
             'sora_model': self.sora_model_combo.currentText() if hasattr(self, 'sora_model_combo') else 'sora-2',
             'sora_resolution': self.sora_resolution_combo.currentText() if hasattr(self, 'sora_resolution_combo') else '720p',
+            'omni_model': self.omni_model_combo.currentText() if hasattr(self, 'omni_model_combo') else 'gemini-omni-flash-preview',
+            'omni_aspect_ratio': self.omni_aspect_combo.currentText() if hasattr(self, 'omni_aspect_combo') else '16:9',
             'ken_burns': self.ken_burns_check.isChecked(),
             'transitions': self.transitions_check.isChecked(),
             'captions': self.captions_check.isChecked(),
@@ -6245,6 +6274,13 @@ class WorkspaceWidget(QWidget):
             self._update_sora_resolution_visibility()
         else:
             self.sora_resolution_combo.setVisible(False)
+
+        # Show/hide Gemini Omni options
+        is_omni = provider == "Gemini Omni"
+        if hasattr(self, 'omni_model_combo'):
+            self.omni_model_combo.setVisible(is_omni)
+        if hasattr(self, 'omni_aspect_combo'):
+            self.omni_aspect_combo.setVisible(is_omni)
 
         # Update smooth transitions checkbox visibility
         # (Only available for Veo 3.1 or Sora)
@@ -7381,9 +7417,12 @@ class WorkspaceWidget(QWidget):
         self.current_project.image_model = img_model
         
         # Save video provider settings
-        self.current_project.video_provider = self.video_provider_combo.currentText().lower()
-        if self.video_provider_combo.currentText() == "Google Veo":
+        provider_text = self.video_provider_combo.currentText()
+        self.current_project.video_provider = provider_text.lower()
+        if provider_text == "Gemini Veo":
             self.current_project.video_model = self.veo_model_combo.currentText()
+        elif provider_text == "Gemini Omni" and hasattr(self, 'omni_model_combo'):
+            self.current_project.video_model = self.omni_model_combo.currentText()
         else:
             self.current_project.video_model = None
         
@@ -7572,12 +7611,15 @@ class WorkspaceWidget(QWidget):
                 self.img_provider_combo.currentTextChanged.connect(self.on_img_provider_changed)
                 self.prompt_style_input.currentTextChanged.connect(self._on_style_changed)
 
-            # Load video provider settings
+            # Load video provider settings. Saved value is the lowercased combo
+            # text (e.g. "gemini veo", "openai sora", "gemini omni", "ffmpeg
+            # slideshow"); older projects may have "slideshow"/"veo"/"google veo".
             if self.current_project.video_provider:
-                if self.current_project.video_provider == "slideshow":
+                saved_provider = self.current_project.video_provider
+                if saved_provider in ("slideshow", "ffmpeg slideshow"):
                     self.video_provider_combo.setCurrentIndex(0)
-                elif self.current_project.video_provider == "veo" or self.current_project.video_provider == "google veo":
-                    index = self.video_provider_combo.findText("Google Veo")
+                elif saved_provider in ("veo", "google veo", "gemini veo"):
+                    index = self.video_provider_combo.findText("Gemini Veo")
                     if index >= 0:
                         self.video_provider_combo.setCurrentIndex(index)
                         # Set Veo model if available
@@ -7585,6 +7627,19 @@ class WorkspaceWidget(QWidget):
                             model_index = self.veo_model_combo.findText(self.current_project.video_model)
                             if model_index >= 0:
                                 self.veo_model_combo.setCurrentIndex(model_index)
+                elif saved_provider in ("sora", "openai sora"):
+                    index = self.video_provider_combo.findText("OpenAI Sora")
+                    if index >= 0:
+                        self.video_provider_combo.setCurrentIndex(index)
+                elif saved_provider in ("omni", "gemini omni"):
+                    index = self.video_provider_combo.findText("Gemini Omni")
+                    if index >= 0:
+                        self.video_provider_combo.setCurrentIndex(index)
+                        # Set Omni model if available
+                        if self.current_project.video_model and hasattr(self, 'omni_model_combo'):
+                            model_index = self.omni_model_combo.findText(self.current_project.video_model)
+                            if model_index >= 0:
+                                self.omni_model_combo.setCurrentIndex(model_index)
             
             # Load style settings
             if hasattr(self.current_project, 'aspect_ratio') and self.current_project.aspect_ratio:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 protobuf>=4.25.3,<5  # Pinned for mediapipe compatibility; GetPrototype patch in main.py
 pillow
-google-genai>=1.49.0  # v1.49.0+ required for image_size parameter (NBP 1K/2K/4K output)
+google-genai>=2.3.0  # 2.3.0+: Interactions API (Gemini Omni video). NBP image_size (1K/2K/4K) still supported.
 google-cloud-aiplatform
 PySide6
 openai

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 protobuf>=4.25.3,<5  # Pinned for mediapipe compatibility; GetPrototype patch in main.py
 pillow
-google-genai>=2.3.0  # 2.3.0+: Interactions API (Gemini Omni video). NBP image_size (1K/2K/4K) still supported.
+google-genai>=2.9.0  # 2.9.0+: GeminiNextGen Interactions API w/ output_video (Gemini Omni video). NBP image_size (1K/2K/4K) still supported.
 google-cloud-aiplatform
 PySide6
 openai

--- a/tests/video/test_omni_client.py
+++ b/tests/video/test_omni_client.py
@@ -1,9 +1,10 @@
 """Unit tests for the Gemini Omni Interactions-API client.
 
 These tests mock the google.genai client entirely — no network is used. They
-lock the request shape (response_modalities=['video'], reference-image content
-list, previous_interaction_id passthrough) and the response parsing (walking
-interaction.steps -> ModelOutputStep -> VideoContent, inline base64 vs URI).
+lock the documented request shape (response_format={"type":"video",...} dict,
+reference-image content list, previous_interaction_id passthrough) and the
+response parsing (interaction.output_video primary, steps-walk fallback, inline
+base64 vs Files-API URI), plus the polling and download-failure branches.
 """
 
 import base64
@@ -221,3 +222,72 @@ def test_generate_uri_delivery_downloads(tmp_path):
 
     assert result.success is True
     assert out.read_bytes() == MP4_BYTES
+
+
+def test_uri_download_fails_cleanly_if_never_active(tmp_path):
+    # Files API stays PROCESSING forever -> must fail, not write a partial file.
+    interaction = _FakeInteraction(
+        output_video=_FakeVideoContent(data=None, uri="files/omnivid123")
+    )
+    client = _make_client(interaction)
+    downloaded = {"called": False}
+
+    def _download(file):
+        downloaded["called"] = True
+        return MP4_BYTES
+
+    processing = pytypes.SimpleNamespace(state=pytypes.SimpleNamespace(name="PROCESSING"))
+    client.client.files = pytypes.SimpleNamespace(get=lambda name: processing, download=_download)
+    client.polling_interval = 0
+    client.timeout = 0  # deadline already passed -> loop body never marks ACTIVE
+
+    out = tmp_path / "out.mp4"
+    result = client.generate_video(OmniGenerationConfig(prompt="a sunset"), out)
+
+    assert result.success is False
+    assert downloaded["called"] is False  # never downloaded a non-ACTIVE file
+    assert not out.exists()
+
+
+def test_uri_download_fails_on_files_failed_state(tmp_path):
+    interaction = _FakeInteraction(
+        output_video=_FakeVideoContent(data=None, uri="files/omnivid123")
+    )
+    client = _make_client(interaction)
+    failed = pytypes.SimpleNamespace(state=pytypes.SimpleNamespace(name="FAILED"))
+    client.client.files = pytypes.SimpleNamespace(
+        get=lambda name: failed,
+        download=lambda file: MP4_BYTES,
+    )
+    client.polling_interval = 0
+
+    result = client.generate_video(OmniGenerationConfig(prompt="a sunset"), tmp_path / "out.mp4")
+    assert result.success is False
+
+
+def test_await_terminal_polls_until_completed(tmp_path):
+    # create() returns in_progress; get() flips to completed with output_video.
+    b64 = base64.b64encode(MP4_BYTES).decode("ascii")
+    in_progress = _FakeInteraction(id="int_poll", status="in_progress")
+    completed = _FakeInteraction(id="int_poll", status="completed",
+                                 output_video=_FakeVideoContent(data=b64))
+
+    client = OmniClient(api_key="test-key")
+    res = _FakeInteractionsResource(in_progress)
+    res.get = lambda interaction_id: completed  # type: ignore[assignment]
+    client.client = pytypes.SimpleNamespace(interactions=res, files=None)
+    client.polling_interval = 0
+
+    out = tmp_path / "out.mp4"
+    result = client.generate_video(OmniGenerationConfig(prompt="a sunset"), out)
+
+    assert result.success is True
+    assert out.read_bytes() == MP4_BYTES
+
+
+def test_reference_image_mime_detection(tmp_path):
+    webp = tmp_path / "ref.webp"
+    webp.write_bytes(b"RIFFfakewebp")
+    cfg = OmniGenerationConfig(prompt="go", task="image_to_video", reference_image=webp)
+    kw = cfg.to_interaction_kwargs()
+    assert kw["input"][0]["mime_type"] == "image/webp"

--- a/tests/video/test_omni_client.py
+++ b/tests/video/test_omni_client.py
@@ -1,0 +1,202 @@
+"""Unit tests for the Gemini Omni Interactions-API client.
+
+These tests mock the google.genai client entirely — no network is used. They
+lock the request shape (response_modalities=['video'], reference-image content
+list, previous_interaction_id passthrough) and the response parsing (walking
+interaction.steps -> ModelOutputStep -> VideoContent, inline base64 vs URI).
+"""
+
+import base64
+import types as pytypes
+
+import pytest
+
+from core.video.omni_client import (
+    OmniClient,
+    OmniGenerationConfig,
+    OmniGenerationResult,
+)
+
+
+# --- Fakes that mimic the google.genai Interactions response shape ----------
+
+class _FakeVideoContent:
+    def __init__(self, data=None, uri=None, mime_type="video/mp4"):
+        self.type = "video"
+        self.data = data
+        self.uri = uri
+        self.mime_type = mime_type
+
+
+class _FakeModelOutputStep:
+    def __init__(self, content):
+        self.type = "model_output"
+        self.content = content
+
+
+class _FakeInteraction:
+    def __init__(self, id="int_123", status="completed", steps=None):
+        self.id = id
+        self.status = status
+        self.steps = steps or []
+
+
+class _FakeInteractionsResource:
+    def __init__(self, response):
+        self._response = response
+        self.create_calls = []
+
+    def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        return self._response
+
+    def get(self, interaction_id):
+        return self._response
+
+
+class _FakeGenaiClient:
+    def __init__(self, response):
+        self.interactions = _FakeInteractionsResource(response)
+        self.files = None
+
+
+def _make_client(response):
+    client = OmniClient(api_key="test-key")
+    client.client = _FakeGenaiClient(response)
+    return client
+
+
+MP4_BYTES = b"\x00\x00\x00\x18ftypmp42fake-omni-video"
+
+
+# --- Config validation ------------------------------------------------------
+
+def test_text_to_video_kwargs_request_video_modality():
+    cfg = OmniGenerationConfig(prompt="a marble rolling down a track",
+                               model="gemini-omni-flash-preview", aspect_ratio="16:9")
+    kw = cfg.to_interaction_kwargs()
+    assert kw["model"] == "gemini-omni-flash-preview"
+    assert kw["input"] == "a marble rolling down a track"
+    assert kw["response_modalities"] == ["video"]
+    # Aspect ratio is carried in response_format, NOT in the prompt text.
+    assert kw["response_format"][0]["aspect_ratio"] == "16:9"
+    assert "16:9" not in kw["input"]
+    assert "previous_interaction_id" not in kw
+
+
+def test_invalid_aspect_ratio_rejected():
+    with pytest.raises(ValueError, match="aspect_ratio"):
+        OmniGenerationConfig(prompt="x", aspect_ratio="4:3")
+
+
+def test_invalid_task_rejected():
+    with pytest.raises(ValueError, match="task"):
+        OmniGenerationConfig(prompt="x", task="audio_to_video")
+
+
+def test_image_to_video_requires_reference_image():
+    with pytest.raises(ValueError, match="reference_image"):
+        OmniGenerationConfig(prompt="x", task="image_to_video")
+
+
+def test_image_to_video_builds_content_list(tmp_path):
+    img = tmp_path / "ref.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\nfakepng")
+    cfg = OmniGenerationConfig(prompt="make it move", task="image_to_video",
+                               reference_image=img)
+    kw = cfg.to_interaction_kwargs()
+    assert isinstance(kw["input"], list)
+    assert kw["input"][0]["type"] == "image"
+    assert kw["input"][0]["mime_type"] == "image/png"
+    assert kw["input"][1] == {"type": "text", "text": "make it move"}
+
+
+def test_previous_interaction_id_passthrough():
+    cfg = OmniGenerationConfig(prompt="make the violin invisible",
+                               task="edit", previous_interaction_id="int_prev")
+    kw = cfg.to_interaction_kwargs()
+    assert kw["previous_interaction_id"] == "int_prev"
+
+
+def test_default_model_resolves_to_omni():
+    cfg = OmniGenerationConfig(prompt="x")
+    assert "omni" in cfg.model.lower()
+
+
+# --- generate_video_async: inline base64 delivery ---------------------------
+
+def test_generate_inline_base64_writes_mp4(tmp_path):
+    b64 = base64.b64encode(MP4_BYTES).decode("ascii")
+    interaction = _FakeInteraction(steps=[
+        _FakeModelOutputStep([_FakeVideoContent(data=b64)])
+    ])
+    client = _make_client(interaction)
+    out = tmp_path / "out.mp4"
+    cfg = OmniGenerationConfig(prompt="a sunset")
+
+    result = client.generate_video(cfg, out)
+
+    assert isinstance(result, OmniGenerationResult)
+    assert result.success is True
+    assert result.video_path == out
+    assert out.read_bytes() == MP4_BYTES
+    assert result.interaction_id == "int_123"
+    # The request asked for video output.
+    assert client.client.interactions.create_calls[0]["response_modalities"] == ["video"]
+
+
+def test_generate_failed_status_returns_error(tmp_path):
+    interaction = _FakeInteraction(status="failed", steps=[])
+    client = _make_client(interaction)
+    cfg = OmniGenerationConfig(prompt="a sunset")
+
+    result = client.generate_video(cfg, tmp_path / "out.mp4")
+
+    assert result.success is False
+    assert "failed" in result.error.lower()
+
+
+def test_generate_no_video_content_returns_error(tmp_path):
+    interaction = _FakeInteraction(status="completed", steps=[
+        _FakeModelOutputStep([])  # No video item.
+    ])
+    client = _make_client(interaction)
+    cfg = OmniGenerationConfig(prompt="a sunset")
+
+    result = client.generate_video(cfg, tmp_path / "out.mp4")
+
+    assert result.success is False
+    assert "no video" in result.error.lower()
+
+
+def test_no_client_configured_returns_error(tmp_path):
+    client = OmniClient(api_key=None)  # No client built.
+    cfg = OmniGenerationConfig(prompt="a sunset")
+
+    result = client.generate_video(cfg, tmp_path / "out.mp4")
+
+    assert result.success is False
+    assert "api key" in result.error.lower()
+
+
+# --- URI delivery (Files API poll + download) -------------------------------
+
+def test_generate_uri_delivery_downloads(tmp_path):
+    interaction = _FakeInteraction(steps=[
+        _FakeModelOutputStep([_FakeVideoContent(data=None, uri="files/omnivid123")])
+    ])
+    client = _make_client(interaction)
+
+    # Fake Files API: state ACTIVE immediately, download returns bytes.
+    active = pytypes.SimpleNamespace(state=pytypes.SimpleNamespace(name="ACTIVE"))
+    client.client.files = pytypes.SimpleNamespace(
+        get=lambda name: active,
+        download=lambda file: MP4_BYTES,
+    )
+    client.polling_interval = 0
+
+    out = tmp_path / "out.mp4"
+    result = client.generate_video(OmniGenerationConfig(prompt="a sunset"), out)
+
+    assert result.success is True
+    assert out.read_bytes() == MP4_BYTES

--- a/tests/video/test_omni_client.py
+++ b/tests/video/test_omni_client.py
@@ -35,10 +35,12 @@ class _FakeModelOutputStep:
 
 
 class _FakeInteraction:
-    def __init__(self, id="int_123", status="completed", steps=None):
+    def __init__(self, id="int_123", status="completed", steps=None, output_video=None):
         self.id = id
         self.status = status
         self.steps = steps or []
+        # Documented primary path: interaction.output_video (a VideoContent).
+        self.output_video = output_video
 
 
 class _FakeInteractionsResource:
@@ -71,15 +73,17 @@ MP4_BYTES = b"\x00\x00\x00\x18ftypmp42fake-omni-video"
 
 # --- Config validation ------------------------------------------------------
 
-def test_text_to_video_kwargs_request_video_modality():
+def test_text_to_video_kwargs_match_documented_shape():
     cfg = OmniGenerationConfig(prompt="a marble rolling down a track",
                                model="gemini-omni-flash-preview", aspect_ratio="16:9")
     kw = cfg.to_interaction_kwargs()
     assert kw["model"] == "gemini-omni-flash-preview"
     assert kw["input"] == "a marble rolling down a track"
-    assert kw["response_modalities"] == ["video"]
-    # Aspect ratio is carried in response_format, NOT in the prompt text.
-    assert kw["response_format"][0]["aspect_ratio"] == "16:9"
+    # Documented shape: response_format is a DICT {"type": "video", ...}; there
+    # is no response_modalities key.
+    assert kw["response_format"] == {"type": "video", "aspect_ratio": "16:9"}
+    assert "response_modalities" not in kw
+    # Aspect ratio is never embedded in the prompt text.
     assert "16:9" not in kw["input"]
     assert "previous_interaction_id" not in kw
 
@@ -127,9 +131,8 @@ def test_default_model_resolves_to_omni():
 
 def test_generate_inline_base64_writes_mp4(tmp_path):
     b64 = base64.b64encode(MP4_BYTES).decode("ascii")
-    interaction = _FakeInteraction(steps=[
-        _FakeModelOutputStep([_FakeVideoContent(data=b64)])
-    ])
+    # Documented primary path: interaction.output_video carries the base64 data.
+    interaction = _FakeInteraction(output_video=_FakeVideoContent(data=b64))
     client = _make_client(interaction)
     out = tmp_path / "out.mp4"
     cfg = OmniGenerationConfig(prompt="a sunset")
@@ -141,8 +144,26 @@ def test_generate_inline_base64_writes_mp4(tmp_path):
     assert result.video_path == out
     assert out.read_bytes() == MP4_BYTES
     assert result.interaction_id == "int_123"
-    # The request asked for video output.
-    assert client.client.interactions.create_calls[0]["response_modalities"] == ["video"]
+    # The request used the documented dict response_format.
+    assert client.client.interactions.create_calls[0]["response_format"] == {
+        "type": "video", "aspect_ratio": "16:9"
+    }
+
+
+def test_generate_reads_video_from_steps_fallback(tmp_path):
+    # Defensive fallback: no output_video, but a step carries the video content.
+    b64 = base64.b64encode(MP4_BYTES).decode("ascii")
+    interaction = _FakeInteraction(
+        output_video=None,
+        steps=[_FakeModelOutputStep([_FakeVideoContent(data=b64)])],
+    )
+    client = _make_client(interaction)
+    out = tmp_path / "out.mp4"
+
+    result = client.generate_video(OmniGenerationConfig(prompt="a sunset"), out)
+
+    assert result.success is True
+    assert out.read_bytes() == MP4_BYTES
 
 
 def test_generate_failed_status_returns_error(tmp_path):
@@ -182,9 +203,9 @@ def test_no_client_configured_returns_error(tmp_path):
 # --- URI delivery (Files API poll + download) -------------------------------
 
 def test_generate_uri_delivery_downloads(tmp_path):
-    interaction = _FakeInteraction(steps=[
-        _FakeModelOutputStep([_FakeVideoContent(data=None, uri="files/omnivid123")])
-    ])
+    interaction = _FakeInteraction(
+        output_video=_FakeVideoContent(data=None, uri="files/omnivid123")
+    )
     client = _make_client(interaction)
 
     # Fake Files API: state ACTIVE immediately, download returns bytes.

--- a/tests/video/test_video_provider_persistence.py
+++ b/tests/video/test_video_provider_persistence.py
@@ -1,0 +1,59 @@
+"""Regression tests for video-provider save/restore label consistency.
+
+The provider combo emits labels like "Gemini Veo" / "OpenAI Sora" /
+"Gemini Omni", and persistence saves ``combo.currentText().lower()`` then
+restores via ``findText(<label>)``. A drift between the saved label and the
+``findText`` label silently drops the provider to the default (this is the
+"Google Veo" vs "Gemini Veo" bug fixed alongside the Omni work).
+
+These tests scan the workspace-widget source so they run without a display
+(the GUI is not headless-constructable), and assert the label contract holds.
+"""
+
+import re
+from pathlib import Path
+
+WIDGET_SRC = (
+    Path(__file__).resolve().parents[2] / "gui" / "video" / "workspace_widget.py"
+).read_text(encoding="utf-8")
+
+# Labels the provider combo actually offers (must match findText() targets).
+COMBO_LABELS = ["FFmpeg Slideshow", "Gemini Veo", "OpenAI Sora", "Gemini Omni"]
+
+
+def test_combo_offers_all_four_providers():
+    m = re.search(r"video_provider_combo\.addItems\(\[(.*?)\]\)", WIDGET_SRC, re.S)
+    assert m, "could not find video_provider_combo.addItems(...)"
+    items = m.group(1)
+    for label in COMBO_LABELS:
+        assert f'"{label}"' in items, f"combo missing provider label {label!r}"
+
+
+def test_no_stale_google_veo_label():
+    # The combo emits "Gemini Veo"; the old save/restore checked "Google Veo",
+    # which never matched and dropped saved Veo projects to slideshow.
+    assert '"Google Veo"' not in WIDGET_SRC, (
+        'stale "Google Veo" label present — save/restore must use "Gemini Veo"'
+    )
+
+
+def test_restore_uses_correct_findtext_labels():
+    # Each restorable provider label must be looked up by its real combo text.
+    for label in ("Gemini Veo", "OpenAI Sora", "Gemini Omni"):
+        assert f'findText("{label}")' in WIDGET_SRC, (
+            f"restore is missing findText({label!r})"
+        )
+
+
+def test_restore_accepts_lowercased_saved_values():
+    # Saved values are combo text lower-cased. Restore must accept them.
+    for saved in ("gemini veo", "openai sora", "gemini omni", "ffmpeg slideshow"):
+        assert f'"{saved}"' in WIDGET_SRC, (
+            f"restore does not handle saved provider value {saved!r}"
+        )
+
+
+def test_save_persists_omni_model():
+    assert 'omni_model_combo.currentText()' in WIDGET_SRC, (
+        "save path does not persist the selected Omni model"
+    )


### PR DESCRIPTION
Closes #28.

Adds **Gemini Omni** (`gemini-omni-flash-preview`) as a fourth video provider on the Video tab, driven through Google's **Interactions API**. Confirmed working end-to-end against the live API.

## What it does
- **Text-to-video**, **image-to-video**, and **conversational editing** (via `previous_interaction_id`), 720p / 24fps / 3–10s with audio, 16:9 or 9:16.
- New `core/video/omni_client.py` (`OmniClient` / `OmniGenerationConfig` / `OmniGenerationResult`) mirroring the Veo/Sora client pattern.
- Wired through the Video tab: provider combo + Omni model/aspect widgets (shown only when selected), worker-kwargs packing, and dispatch to `_generate_video_clip_omni` on `VideoGenerationThread`. Clips concatenate through the existing FFmpeg render path (same as Sora — no extra render branch).
- Model ID resolved via `resolve_model('google','omni', static_default='gemini-omni-flash-preview')` — not hard-coded (AGENTS.md §8).
- `omni_settings` added to the video config; lazy `OMNI_AVAILABLE` export.

## SDK surface (important)
The Omni API is the **`_gaos` "GeminiNextGen"** interactions surface introduced in **`google-genai` 2.9.0** — it exposes `interaction.output_video` and takes `response_format={"type":"video","aspect_ratio":...}` (a dict). The requirements floor is raised to `google-genai>=2.9.0` accordingly (2.8.0's transitional surface lacks `output_video`). Anyone upgrading must `pip install -r requirements.txt`.

## Drive-by fix
Fixes a pre-existing **"Google Veo" vs "Gemini Veo"** save/restore mismatch (`workspace_widget.py`) that silently dropped saved Veo projects to FFmpeg Slideshow, and adds Sora/Omni restore branches. A new `tests/video/test_video_provider_persistence.py` locks the label contract.

## Tests
- `tests/video/test_omni_client.py` — 13 mocked unit tests (config validation, documented request shape, `output_video` inline + URI delivery, steps fallback, error paths).
- Full suite: **411 passing**.

## Deferred (documented in `Plans/2026-06-30-gemini-omni-video-support.md`)
Dedicated "Refine" UI button (plumbing ready — passes `omni_edit=True`), uploaded-video editing, `background`/`webhook` async, SynthID surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)