### PR TITLE
feat(layout): persist designer/style selections + orientation restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,5 +246,4 @@ Plans/CharacterAnimator_LayerExport_v3.md
 Notes/CharacterAnimator_BugFixes_20260112.md
 Notes/CharacterAnimator_BugFixes_Round2_20260112.md
 Notes/doc-report-*.md
-Layouts/Dynamic layout with circle.iaiproj.json
-Layouts/Dynamic layout with circle.pdf
+Layouts/

--- a/Discord/2026-06-30-gemini-omni-video.md
+++ b/Discord/2026-06-30-gemini-omni-video.md
@@ -1,0 +1,20 @@
+🎬 **New in ImageAI: Gemini Omni video generation**
+
+We just wired up Google's newest video model — **Gemini Omni** — into the Video tab. It's fast, conversational, and generates video *with audio* right out of the box.
+
+**What it does**
+- 🟢 **Text → video** — describe a scene, get a clip.
+- 🖼️ **Image → video** — feed it a starting frame and let it animate.
+- 💬 **Conversational editing** — keep refining the *same* clip across turns ("make it slower", "now at sunset") instead of starting over each time.
+- 🔊 **Audio in the output** — sound comes baked into the generated video.
+
+**The details that matter**
+- Pick your aspect ratio (16:9 or 9:16) — it's set on the request, never jammed into the prompt text, so no stray ratios showing up on screen.
+- Model ID is resolved at runtime from the registry, so it stays current without code changes.
+- Runs on Google's Interactions API (`google-genai` 2.9.0+).
+
+While in there we also squashed a Veo bug where video settings weren't sticking between sessions — those now save and restore properly.
+
+Full test suite is green (415 passing), and it's up as **PR #29**. Give Omni a spin in the Video tab and let us know what you make! 🚀
+
+🔗 Repo: <https://github.com/lelandg/ImageAI>

--- a/core/config.py
+++ b/core/config.py
@@ -303,6 +303,39 @@ class ConfigManager:
         layout_config["llm_provider"] = provider
         self.set_layout_config(layout_config)
 
+    def get_layout_llm_model(self) -> str:
+        """Get last-selected LLM model for the layout designer ('' if none)."""
+        layout_config = self.get_layout_config()
+        return layout_config.get("llm_model", "")
+
+    def set_layout_llm_model(self, model: str) -> None:
+        """Persist the layout designer's LLM model selection."""
+        layout_config = self.get_layout_config()
+        layout_config["llm_model"] = model
+        self.set_layout_config(layout_config)
+
+    def get_layout_content_kind(self) -> str:
+        """Get last-selected designer content kind ('' if none)."""
+        layout_config = self.get_layout_config()
+        return layout_config.get("content_kind", "")
+
+    def set_layout_content_kind(self, kind: str) -> None:
+        """Persist the layout designer's content-kind selection."""
+        layout_config = self.get_layout_config()
+        layout_config["content_kind"] = kind
+        self.set_layout_config(layout_config)
+
+    def get_layout_style_role(self) -> str:
+        """Get last-viewed style role in the Style panel ('' if none)."""
+        layout_config = self.get_layout_config()
+        return layout_config.get("style_role", "")
+
+    def set_layout_style_role(self, role: str) -> None:
+        """Persist the Style panel's last-viewed role."""
+        layout_config = self.get_layout_config()
+        layout_config["style_role"] = role
+        self.set_layout_config(layout_config)
+
     # Discord Rich Presence Configuration
 
     def get_discord_config(self) -> Dict[str, Any]:

--- a/core/layout/models.py
+++ b/core/layout/models.py
@@ -209,6 +209,9 @@ class DocumentSpec:
     schema_version: str = "2.0"
     history: List["Snapshot"] = field(default_factory=list)
     style: Optional["ProjectStyle"] = None
+    # Per-project render-position override: True = canvas above settings,
+    # False = beside, None = no stored choice (fall back to orientation).
+    render_on_top: Optional[bool] = None
 
 
 def migrate_legacy_blocks(blocks: List[Union[TextBlock, ImageBlock]]) -> List[Region]:

--- a/core/layout/schema.py
+++ b/core/layout/schema.py
@@ -223,6 +223,7 @@ def document_to_dict(doc: DocumentSpec) -> Dict:
         "metadata": dict(doc.metadata), "pages": [page_to_dict(p) for p in doc.pages],
         "history": [snapshot_to_dict(s) for s in doc.history],
         "style": project_style_to_dict(doc.style) if doc.style else None,
+        "render_on_top": doc.render_on_top,
     }
 
 
@@ -235,6 +236,7 @@ def document_from_dict(d: Dict) -> DocumentSpec:
         schema_version=d.get("schema_version", "2.0"),
         history=[snapshot_from_dict(s) for s in d.get("history", [])],
         style=project_style_from_dict(d["style"]) if d.get("style") else None,
+        render_on_top=d.get("render_on_top"),
     )
 
 

--- a/gui/layout/designer_panel.py
+++ b/gui/layout/designer_panel.py
@@ -52,12 +52,21 @@ class DesignerPanel(QWidget):
         row.addWidget(QLabel("Kind:"))
         self.kind_combo = QComboBox()
         self.kind_combo.addItems(CONTENT_KINDS)
+        saved_kind = self._cfg_get("get_layout_content_kind")
+        if saved_kind and saved_kind in CONTENT_KINDS:
+            self.kind_combo.setCurrentText(saved_kind)
+        self.kind_combo.currentTextChanged.connect(self._save_kind)
         row.addWidget(self.kind_combo)
         row.addWidget(QLabel("Provider:"))
         self.provider_combo = QComboBox()
         self.model_combo = QComboBox()
         self._populate_providers()
+        # _on_provider_changed (re)populates the model list AND reselects the saved
+        # model; _save_provider/_save_model only fire on real user changes (the
+        # init path sets indexes with signals blocked / via direct calls).
         self.provider_combo.currentTextChanged.connect(self._on_provider_changed)
+        self.provider_combo.currentTextChanged.connect(self._save_provider)
+        self.model_combo.currentTextChanged.connect(self._save_model)
         row.addWidget(self.provider_combo)
         row.addWidget(self.model_combo)
         lay.addLayout(row)
@@ -105,10 +114,40 @@ class DesignerPanel(QWidget):
     def _on_provider_changed(self, provider: str):
         from core.llm_models import get_provider_models
         _, pid = designer.resolve_provider_ids(provider)  # single source of truth
+        models = get_provider_models(pid) or []
         self.model_combo.blockSignals(True)
         self.model_combo.clear()
-        self.model_combo.addItems(get_provider_models(pid) or [])
+        self.model_combo.addItems(models)
+        # Reselect the saved model once its list is populated (mirrors the Image
+        # tab's provider→populate→restore ordering); fall back to the first model.
+        saved_model = self._cfg_get("get_layout_llm_model")
+        if saved_model and saved_model in models:
+            self.model_combo.setCurrentText(saved_model)
         self.model_combo.blockSignals(False)
+
+    # --- settings persistence ---
+    def _cfg_get(self, getter: str):
+        """Call an optional config getter, tolerating minimal test fakes."""
+        fn = getattr(self._config, getter, None) if self._config else None
+        return fn() if callable(fn) else None
+
+    def _cfg_set(self, setter: str, value):
+        fn = getattr(self._config, setter, None) if self._config else None
+        if callable(fn):
+            fn(value)
+            save = getattr(self._config, "save", None)
+            if callable(save):
+                save()
+
+    def _save_kind(self, kind: str):
+        self._cfg_set("set_layout_content_kind", kind)
+
+    def _save_provider(self, provider: str):
+        self._cfg_set("set_layout_llm_provider", provider)
+
+    def _save_model(self, model: str):
+        if model:  # ignore the transient empty state during list repopulation
+            self._cfg_set("set_layout_llm_model", model)
 
     def content_kind(self) -> str:
         return self.kind_combo.currentText()

--- a/gui/layout/layout_tab.py
+++ b/gui/layout/layout_tab.py
@@ -5,8 +5,9 @@ from typing import Optional
 
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QFileDialog, QLabel,
+    QSplitter, QScrollArea,
 )
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Signal, Qt
 
 from core.layout.models import DocumentSpec, PageSpec, PageSize, TextStyle
 from core.layout import project_io, qt_renderer
@@ -44,6 +45,10 @@ class LayoutTab(QWidget):
         self._locked = self._load_locked()
         self._knife_region_id = None
         self._merge_base_id = None
+        # Last page orientation the render-position toggle auto-synced to. Lets a
+        # manual override survive non-orientation edits (DPI/size) and only flip
+        # back to auto on a real portrait<->landscape change.
+        self._last_orientation: Optional[str] = None
         self._build()
         self._restore_session_or_new()
 
@@ -74,29 +79,53 @@ class LayoutTab(QWidget):
         self.lock_btn.toggled.connect(self._on_lock_toggled)
         self._update_lock_button()
         toolbar.addWidget(self.lock_btn)
+
+        # View toggle: stack the page render ABOVE the settings (vertical split)
+        # instead of beside them (horizontal). Auto-enabled for landscape pages
+        # on app/layout load and on orientation change; see
+        # _sync_split_to_orientation. A manual click overrides until the next
+        # orientation change.
+        self.orient_split_btn = QPushButton("⬓ Render Position")
+        self.orient_split_btn.setCheckable(True)
+        self.orient_split_btn.setToolTip(
+            "Show the page render above the settings (best for landscape pages).\n"
+            "Auto-enabled when the page is landscape; click to override.")
+        self.orient_split_btn.toggled.connect(self._on_orient_split_toggled)
+        toolbar.addWidget(self.orient_split_btn)
         root.addLayout(toolbar)
 
-        self.page_setup = PageSetupWidget(self.config)
-        self.page_setup.pageSizeChanged.connect(self._on_page_size_changed)
-        root.addWidget(self.page_setup)
-
-        self.designer = DesignerPanel(self.config)
-        self.designer.layoutProposed.connect(self._on_layout_proposed)
-        self.designer.design_btn.clicked.connect(self._on_design_clicked)
-        root.addWidget(self.designer)
-
-        self.style_panel = StylePanel()
-        self.style_panel.styleChanged.connect(self.apply_style)
-        root.addWidget(self.style_panel)
+        # Main area: big canvas on the left, scrollable control dock on the right,
+        # split by a draggable handle. Keeps the canvas usable instead of starving
+        # it inside one tall vertical column (the old layout).
+        split = QSplitter(Qt.Horizontal)
 
         self.canvas = CanvasWidget()
-        root.addWidget(self.canvas, 1)
+        split.addWidget(self.canvas)
 
         from gui.layout.geometry_editor import GeometryEditor
         self.geometry_editor = GeometryEditor(self.canvas, self)
 
         from gui.layout.overlay_editor import OverlayEditor
         self.overlay_editor = OverlayEditor(self.canvas, self)
+
+        # Right-hand control dock — all inspectors/panels stacked in a scroll area
+        # so they never compete with the canvas for height.
+        dock = QWidget()
+        dock_col = QVBoxLayout(dock)
+        dock_col.setContentsMargins(0, 0, 0, 0)
+
+        self.page_setup = PageSetupWidget(self.config)
+        self.page_setup.pageSizeChanged.connect(self._on_page_size_changed)
+        dock_col.addWidget(self.page_setup)
+
+        self.designer = DesignerPanel(self.config)
+        self.designer.layoutProposed.connect(self._on_layout_proposed)
+        self.designer.design_btn.clicked.connect(self._on_design_clicked)
+        dock_col.addWidget(self.designer)
+
+        self.style_panel = StylePanel(self.config)
+        self.style_panel.styleChanged.connect(self.apply_style)
+        dock_col.addWidget(self.style_panel)
 
         from gui.layout.overlay_inspector import OverlayInspector
         self.overlay_inspector = OverlayInspector()
@@ -105,7 +134,7 @@ class LayoutTab(QWidget):
         self.overlay_inspector.rotationChanged.connect(self._set_overlay_rotation)
         self.overlay_inspector.overlaySelected.connect(self._on_overlay_selected)
         self.overlay_inspector.editToggled.connect(self._on_overlay_edit_toggled)
-        root.addWidget(self.overlay_inspector)
+        dock_col.addWidget(self.overlay_inspector)
 
         self.inspector = ContentInspector(self.config)
         self.inspector.regionContentChanged.connect(self._on_region_content_changed)
@@ -113,7 +142,7 @@ class LayoutTab(QWidget):
         self.inspector.regionPromptChanged.connect(self._on_region_prompt_changed)
         self.inspector.regionPromptSuggestRequested.connect(self._on_region_prompt_suggest)
         self.inspector.regionSendToImageRequested.connect(self._on_region_send_to_image)
-        root.addWidget(self.inspector)
+        dock_col.addWidget(self.inspector)
 
         from gui.layout.geometry_inspector import GeometryInspector
         self.geometry_inspector = GeometryInspector()
@@ -124,7 +153,29 @@ class LayoutTab(QWidget):
         self.geometry_inspector.deleteRequested.connect(self._on_region_delete_requested)
         self.geometry_inspector.knifeToggled.connect(self._on_region_knife_toggled)
         self.geometry_inspector.mergeToggled.connect(self._on_region_merge_toggled)
-        root.addWidget(self.geometry_inspector)
+        dock_col.addWidget(self.geometry_inspector)
+        dock_col.addStretch(1)
+
+        dock_scroll = QScrollArea()
+        dock_scroll.setWidgetResizable(True)
+        # Scroll horizontally only if the dock is dragged narrower than its
+        # controls need, so nothing is ever clipped (vertical scroll handles
+        # height). 440px comfortably fits the widest row (the +Speech/+Thought/
+        # +Caption/+SFX buttons).
+        dock_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        dock_scroll.setWidget(dock)
+        dock_scroll.setMinimumWidth(440)
+        split.addWidget(dock_scroll)
+
+        # Canvas pane grows, dock pane stays compact; give the canvas the lion's
+        # share on first show. The dock opens at ~690px so its widest row (page
+        # setup) fits without a horizontal scrollbar; drag the handle narrower to
+        # reclaim space (it scrolls below ~670px).
+        split.setStretchFactor(0, 1)
+        split.setStretchFactor(1, 0)
+        split.setSizes([1000, 690])
+        self._main_split = split
+        root.addWidget(split, 1)
 
         self.canvas.regionSelected.connect(self._on_region_selected)
         self.canvas.knifeLine.connect(self._on_canvas_knife_line)
@@ -145,20 +196,82 @@ class LayoutTab(QWidget):
         if hasattr(self, "inspector"):
             self.inspector.set_region(None)
 
+    def _sync_page_setup_from_document(self):
+        """Reflect the loaded document's page size/orientation in the page-setup
+        controls (and, via PageSetupWidget.pageSizeChanged → _on_page_size_changed,
+        the render-on-top toggle). Every path that adopts a document calls this so
+        the controls and view never drift from what was loaded.
+
+        A loaded document may carry a per-project render-position override
+        (``render_on_top``); it wins over the orientation-derived default. Capture
+        it before set_page_size (whose orientation auto-sync would overwrite it via
+        _on_orient_split_toggled), then re-apply it on top."""
+        page = (self.document.pages[0]
+                if self.document and self.document.pages else None)
+        stored = self.document.render_on_top if self.document else None
+        # Treat the load as a fresh orientation baseline so set_page_size's
+        # auto-sync always reflects the loaded page, then the stored override wins.
+        self._last_orientation = None
+        if page is not None and page.page_size and hasattr(self, "page_setup"):
+            self.page_setup.set_page_size(page.page_size)
+        btn = getattr(self, "orient_split_btn", None)
+        if stored is not None and btn is not None and btn.isChecked() != stored:
+            btn.setChecked(bool(stored))  # toggled → _apply_split_orientation
+
     def new_document(self):
         ps = self.page_setup.page_size() if hasattr(self, "page_setup") else PageSize(8.5, 11, "in")
         pw, ph = ps.to_pixels()
         page = PageSpec(page_size_px=(pw, ph), page_size=ps, background="#FFFFFF")
         self._adopt_document(DocumentSpec(title="Untitled", pages=[page]))
+        self._last_orientation = ps.orientation
         self._refresh()
 
     def _on_page_size_changed(self, ps: PageSize):
+        # Keep the render-on-top view in step with the page orientation (landscape
+        # → render above settings) regardless of whether a document exists yet.
+        self._sync_split_to_orientation(ps.orientation)
         if not self.document or not self.document.pages:
             return
         page = self.document.pages[0]
         page.page_size = ps
         page.page_size_px = ps.to_pixels()
         self._refresh()
+
+    # --- split orientation (render beside vs. above the settings) ---
+    def _on_orient_split_toggled(self, on_top: bool):
+        self._apply_split_orientation(on_top)
+        # Remember the effective choice on the document so it persists with the
+        # project. Both manual clicks and orientation-driven auto-syncs land here.
+        if self.document is not None:
+            self.document.render_on_top = bool(on_top)
+
+    def _apply_split_orientation(self, on_top: bool):
+        """Horizontal = canvas left / settings right (portrait default);
+        Vertical = canvas on top / settings below (landscape / 'render on top')."""
+        split = getattr(self, "_main_split", None)
+        if split is None:
+            return
+        if on_top:
+            split.setOrientation(Qt.Vertical)
+            split.setSizes([700, 500])
+        else:
+            split.setOrientation(Qt.Horizontal)
+            split.setSizes([1000, 690])
+
+    def _sync_split_to_orientation(self, orientation: str):
+        """Drive the render-on-top toggle from the page orientation. Only acts when
+        the orientation actually flips, so a manual toggle (and the per-project
+        stored override) survives unrelated changes like DPI/size edits."""
+        btn = getattr(self, "orient_split_btn", None)
+        if btn is None:
+            return
+        prev = self._last_orientation
+        self._last_orientation = orientation
+        if orientation == prev:
+            return  # same orientation → leave the current (possibly manual) choice
+        want_on_top = (orientation == "landscape")
+        if btn.isChecked() != want_on_top:
+            btn.setChecked(want_on_top)  # toggled → _apply_split_orientation
 
     def _refresh(self):
         if getattr(self, "_suspend_refresh", False):
@@ -236,10 +349,7 @@ class LayoutTab(QWidget):
         if path and path.exists():
             try:
                 self._adopt_document(project_io.load_project(str(path)))
-                page = (self.document.pages[0]
-                        if self.document and self.document.pages else None)
-                if page is not None and page.page_size and hasattr(self, "page_setup"):
-                    self.page_setup.set_page_size(page.page_size)
+                self._sync_page_setup_from_document()
                 self._refresh()
                 logger.info("Layout: restored last session from %s", path)
                 return
@@ -643,6 +753,7 @@ class LayoutTab(QWidget):
 
     def open_project_from(self, path: str):
         self._adopt_document(project_io.load_project(path))
+        self._sync_page_setup_from_document()
         self._refresh()
 
     def export_pdf_to(self, path: str):
@@ -728,6 +839,7 @@ class LayoutTab(QWidget):
 
     def import_template_from(self, path: str):
         self._adopt_document(template_io.import_template(path))
+        self._sync_page_setup_from_document()
         self._refresh()
 
     # --- bundles (.iaibundle: project + images + fonts, self-contained) ---
@@ -769,10 +881,7 @@ class LayoutTab(QWidget):
     def import_bundle_from(self, path: str):
         dest = self._bundle_extract_dir(path)
         self._adopt_document(bundle_io.import_bundle(path, str(dest)))
-        page = (self.document.pages[0]
-                if self.document and self.document.pages else None)
-        if page is not None and page.page_size and hasattr(self, "page_setup"):
-            self.page_setup.set_page_size(page.page_size)
+        self._sync_page_setup_from_document()
         self._refresh()
 
     def _export_bundle_dialog(self):

--- a/gui/layout/overlay_inspector.py
+++ b/gui/layout/overlay_inspector.py
@@ -33,6 +33,9 @@ class OverlayInspector(QWidget):
         root.addWidget(QLabel("Overlays"))
 
         self.overlay_list = QListWidget()
+        # Cap the height so the list doesn't balloon and starve the panels below
+        # it inside the control dock; it scrolls internally when overlays overflow.
+        self.overlay_list.setMaximumHeight(140)
         self.overlay_list.itemSelectionChanged.connect(self._on_row_changed)
         root.addWidget(self.overlay_list)
 

--- a/gui/layout/page_setup_widget.py
+++ b/gui/layout/page_setup_widget.py
@@ -41,12 +41,17 @@ class PageSetupWidget(QWidget):
         self.dpi_spin.valueChanged.connect(self._on_dpi_changed)
         lay.addWidget(self.dpi_spin)
 
+        # Checkable so the active orientation stays visibly highlighted and can be
+        # synced to a loaded document (set_page_size) instead of silently drifting.
         self.portrait_btn = QPushButton("Portrait")
+        self.portrait_btn.setCheckable(True)
         self.portrait_btn.clicked.connect(self._on_portrait)
         self.landscape_btn = QPushButton("Landscape")
+        self.landscape_btn.setCheckable(True)
         self.landscape_btn.clicked.connect(self._on_landscape)
         lay.addWidget(self.portrait_btn)
         lay.addWidget(self.landscape_btn)
+        self._sync_orientation_buttons()
 
     def _reload_presets(self):
         self.size_combo.blockSignals(True)
@@ -88,6 +93,7 @@ class PageSetupWidget(QWidget):
         self.size_combo.setCurrentIndex(0)
         for w in widgets:
             w.blockSignals(False)
+        self._sync_orientation_buttons()
         self._emit_current()
 
     def add_custom_from_text(self, text: str) -> bool:
@@ -118,11 +124,21 @@ class PageSetupWidget(QWidget):
 
     def _on_portrait(self):
         self._orientation = "portrait"
+        self._sync_orientation_buttons()
         self._emit_current()
 
     def _on_landscape(self):
         self._orientation = "landscape"
+        self._sync_orientation_buttons()
         self._emit_current()
+
+    def _sync_orientation_buttons(self):
+        """Reflect ``self._orientation`` in the (mutually exclusive) buttons."""
+        for btn, name in ((self.portrait_btn, "portrait"),
+                          (self.landscape_btn, "landscape")):
+            btn.blockSignals(True)
+            btn.setChecked(self._orientation == name)
+            btn.blockSignals(False)
 
     def _emit_current(self):
         self.pageSizeChanged.emit(self.page_size())

--- a/gui/layout/style_panel.py
+++ b/gui/layout/style_panel.py
@@ -10,8 +10,9 @@ from core.layout.models import ProjectStyle, TextStyle
 class StylePanel(QWidget):
     styleChanged = Signal(object)  # ProjectStyle
 
-    def __init__(self, parent=None):
+    def __init__(self, config=None, parent=None):
         super().__init__(parent)
+        self._config = config
         self._style = ProjectStyle()
         self._build()
 
@@ -36,6 +37,11 @@ class StylePanel(QWidget):
         self.role_combo.blockSignals(True)
         self.role_combo.clear()
         self.role_combo.addItems(sorted(style.font_roles.keys()))
+        # Restore the last-viewed role if it still exists in this style; else the
+        # combo keeps its default (first) selection.
+        saved = self._cfg_get("get_layout_style_role")
+        if saved and saved in style.font_roles:
+            self.role_combo.setCurrentText(saved)
         self.role_combo.blockSignals(False)
         if self.role_combo.count():
             self._load_role(self.role_combo.currentText())
@@ -58,6 +64,20 @@ class StylePanel(QWidget):
     def _on_role_selected(self, role: str):
         if role:
             self._load_role(role)
+            self._cfg_set("set_layout_style_role", role)
+
+    # --- settings persistence (tolerant of minimal test config fakes) ---
+    def _cfg_get(self, getter: str):
+        fn = getattr(self._config, getter, None) if self._config else None
+        return fn() if callable(fn) else None
+
+    def _cfg_set(self, setter: str, value):
+        fn = getattr(self._config, setter, None) if self._config else None
+        if callable(fn):
+            fn(value)
+            save = getattr(self._config, "save", None)
+            if callable(save):
+                save()
 
     def _on_field_changed(self):
         role = self.role_combo.currentText()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+# Limit discovery to the real automated suite. Several root-level test_*.py files
+# are manual demo scripts (e.g. test_scaling.py calls app.exec(), which blocks the
+# Qt event loop forever in headless runs), so a bare `pytest` that collected them
+# would hang. Run a demo explicitly by path if you ever need it.
+testpaths = tests

--- a/tests/layout/test_designer_panel.py
+++ b/tests/layout/test_designer_panel.py
@@ -11,6 +11,22 @@ class FakeConfig:
     def get_layout_llm_provider(self): return "google"
 
 
+class StatefulFakeConfig:
+    """Records layout settings so save/restore round-trips can be asserted."""
+    def __init__(self, **seed):
+        self.layout = dict(seed)
+        self.saved = 0
+    def get_layout_config(self): return dict(self.layout)
+    def set_layout_config(self, c): self.layout = dict(c)
+    def save(self): self.saved += 1
+    def get_layout_llm_provider(self): return self.layout.get("llm_provider", "google")
+    def set_layout_llm_provider(self, p): self.layout["llm_provider"] = p
+    def get_layout_llm_model(self): return self.layout.get("llm_model", "")
+    def set_layout_llm_model(self, m): self.layout["llm_model"] = m
+    def get_layout_content_kind(self): return self.layout.get("content_kind", "")
+    def set_layout_content_kind(self, k): self.layout["content_kind"] = k
+
+
 def test_worker_emits_proposed_with_injected_completion(qapp):
     msgs = designer.build_messages("comic", (200, 200), "one panel")
     fake = lambda m: '{"layout": {"regions": [{"id":"a","kind":"image","bbox":[0,0,100,100]}]}}'
@@ -71,3 +87,46 @@ def test_failure_auto_expands_console(qapp):
 
     p.start_design("a page", (300, 300), completion_fn=boom)
     assert p.console_toggle.isChecked() and not p.console.isHidden()  # errors never hidden
+
+
+def test_content_kind_restored_from_config(qapp):
+    p = DesignerPanel(StatefulFakeConfig(content_kind="magazine"))
+    assert p.kind_combo.currentText() == "magazine"
+
+
+def test_content_kind_change_persists(qapp):
+    cfg = StatefulFakeConfig()
+    p = DesignerPanel(cfg)
+    p.kind_combo.setCurrentText("newspaper")
+    assert cfg.get_layout_content_kind() == "newspaper"
+
+
+def test_provider_change_persists(qapp):
+    cfg = StatefulFakeConfig()
+    p = DesignerPanel(cfg)
+    if p.provider_combo.count() < 2:
+        return  # only one provider available in this environment
+    p.provider_combo.setCurrentIndex(
+        (p.provider_combo.currentIndex() + 1) % p.provider_combo.count())
+    assert cfg.get_layout_llm_provider() == p.provider_combo.currentText()
+
+
+def test_model_restored_from_config(qapp):
+    # Discover a real model from a fresh panel, seed it, then rebuild and assert
+    # it is reselected after the provider repopulates the model list.
+    probe = DesignerPanel(StatefulFakeConfig())
+    if probe.model_combo.count() < 2:
+        return  # no alternate model to distinguish a restore from the default
+    target = probe.model_combo.itemText(1)
+    cfg = StatefulFakeConfig(llm_model=target)
+    p = DesignerPanel(cfg)
+    assert p.model_combo.currentText() == target
+
+
+def test_model_change_persists(qapp):
+    cfg = StatefulFakeConfig()
+    p = DesignerPanel(cfg)
+    if p.model_combo.count() < 2:
+        return
+    p.model_combo.setCurrentIndex(1)
+    assert cfg.get_layout_llm_model() == p.model_combo.currentText()

--- a/tests/layout/test_layout_tab_orientation.py
+++ b/tests/layout/test_layout_tab_orientation.py
@@ -1,0 +1,95 @@
+# tests/layout/test_layout_tab_orientation.py
+from PySide6.QtCore import Qt
+
+from core.layout.models import PageSize
+from gui.layout.layout_tab import LayoutTab
+
+
+class FakeConfig:
+    def get_layout_config(self): return {}
+    def set_layout_config(self, c): pass
+    def save(self): pass
+    def get_layout_llm_provider(self): return "google"
+
+
+def test_default_is_portrait_side_by_side(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    assert not tab.orient_split_btn.isChecked()
+    assert tab._main_split.orientation() == Qt.Horizontal
+
+
+def test_landscape_page_activates_render_on_top(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    tab.page_setup.set_page_size(PageSize(11, 8.5, "in", "landscape", 300))
+    assert tab.orient_split_btn.isChecked()
+    assert tab._main_split.orientation() == Qt.Vertical
+
+
+def test_portrait_reverts_to_side_by_side(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    tab.page_setup.set_page_size(PageSize(11, 8.5, "in", "landscape", 300))
+    tab.page_setup.set_page_size(PageSize(8.5, 11, "in", "portrait", 300))
+    assert not tab.orient_split_btn.isChecked()
+    assert tab._main_split.orientation() == Qt.Horizontal
+
+
+def test_manual_toggle_flips_orientation(qapp):
+    tab = LayoutTab(config=FakeConfig())
+    tab.orient_split_btn.setChecked(True)
+    assert tab._main_split.orientation() == Qt.Vertical
+    tab.orient_split_btn.setChecked(False)
+    assert tab._main_split.orientation() == Qt.Horizontal
+
+
+def test_manual_override_persists_per_project(qapp, tmp_path):
+    # Manually force render-on-top on a PORTRAIT page (against the auto rule),
+    # save, reopen — the stored per-project choice wins over orientation.
+    from core.layout import project_io
+
+    tab = LayoutTab(config=FakeConfig())  # portrait default, beside
+    tab.orient_split_btn.setChecked(True)  # manual override → on top
+    assert tab.document.render_on_top is True
+    p = tmp_path / "portrait_ontop.iaiproj.json"
+    project_io.save_project(tab.document, str(p))
+
+    tab2 = LayoutTab(config=FakeConfig())
+    tab2.open_project_from(str(p))
+    assert not tab2.page_setup.landscape_btn.isChecked()  # still portrait
+    assert tab2.orient_split_btn.isChecked()  # but stored override wins
+    assert tab2._main_split.orientation() == Qt.Vertical
+
+
+def test_manual_override_survives_same_orientation_edit(qapp):
+    # A manual choice must survive a non-orientation change (e.g. DPI/size edit).
+    tab = LayoutTab(config=FakeConfig())  # portrait, beside
+    tab.orient_split_btn.setChecked(True)  # manual → on top
+    tab.page_setup.set_page_size(PageSize(8.5, 11, "in", "portrait", 150))  # DPI edit
+    assert tab.orient_split_btn.isChecked()  # survived
+
+
+def test_orientation_flip_overrides_manual_choice(qapp):
+    # A real portrait<->landscape flip re-applies the auto rule, overriding manual.
+    tab = LayoutTab(config=FakeConfig())  # portrait, beside
+    tab.orient_split_btn.setChecked(True)  # manual → on top (portrait)
+    tab.page_setup.set_page_size(PageSize(11, 8.5, "in", "landscape", 300))
+    assert tab.orient_split_btn.isChecked()  # landscape → on top
+    tab.page_setup.set_page_size(PageSize(8.5, 11, "in", "portrait", 300))
+    assert not tab.orient_split_btn.isChecked()  # flip reverted to beside
+
+
+def test_opening_landscape_project_activates_render_on_top(qapp, tmp_path):
+    # Build + save a landscape project, then open it and confirm the page-setup
+    # orientation buttons and the render-on-top toggle both reflect it.
+    from core.layout import project_io
+
+    tab = LayoutTab(config=FakeConfig())
+    tab.page_setup.set_page_size(PageSize(11, 8.5, "in", "landscape", 300))
+    p = tmp_path / "land.iaiproj.json"
+    project_io.save_project(tab.document, str(p))
+
+    tab2 = LayoutTab(config=FakeConfig())  # opens portrait by default
+    assert not tab2.orient_split_btn.isChecked()
+    tab2.open_project_from(str(p))
+    assert tab2.page_setup.landscape_btn.isChecked()
+    assert tab2.orient_split_btn.isChecked()
+    assert tab2._main_split.orientation() == Qt.Vertical

--- a/tests/layout/test_page_setup_widget.py
+++ b/tests/layout/test_page_setup_widget.py
@@ -42,3 +42,27 @@ def test_emits_page_size_changed(qapp):
     w.pageSizeChanged.connect(lambda ps: received.append(ps))
     w.set_page_size(PageSize(4, 6, "in", "portrait", 300))
     assert received and received[-1].to_pixels() == (1200, 1800)
+
+
+def test_orientation_buttons_default_portrait(qapp):
+    w = PageSetupWidget(FakeConfig())
+    assert w.portrait_btn.isChecked()
+    assert not w.landscape_btn.isChecked()
+
+
+def test_orientation_buttons_sync_on_load(qapp):
+    w = PageSetupWidget(FakeConfig())
+    w.set_page_size(PageSize(11, 8.5, "in", "landscape", 300))
+    assert w.landscape_btn.isChecked()
+    assert not w.portrait_btn.isChecked()
+    w.set_page_size(PageSize(8.5, 11, "in", "portrait", 300))
+    assert w.portrait_btn.isChecked()
+    assert not w.landscape_btn.isChecked()
+
+
+def test_orientation_buttons_sync_on_click(qapp):
+    w = PageSetupWidget(FakeConfig())
+    w._on_landscape()
+    assert w.landscape_btn.isChecked() and not w.portrait_btn.isChecked()
+    w._on_portrait()
+    assert w.portrait_btn.isChecked() and not w.landscape_btn.isChecked()

--- a/tests/layout/test_project_io.py
+++ b/tests/layout/test_project_io.py
@@ -16,6 +16,22 @@ def test_save_load_roundtrip(tmp_path):
     assert loaded.pages[0].regions[0].text == "Hi"
 
 
+def test_render_on_top_roundtrip(tmp_path):
+    doc = DocumentSpec(title="Proj", pages=[PageSpec(page_size_px=(500, 500))],
+                       render_on_top=True)
+    p = tmp_path / "x.iaiproj.json"
+    project_io.save_project(doc, str(p))
+    assert project_io.load_project(str(p)).render_on_top is True
+
+
+def test_render_on_top_defaults_none_for_legacy(tmp_path):
+    # Projects saved before this field existed load with no stored override.
+    legacy = {"title": "Old", "pages": [{"page_size_px": [400, 400]}]}
+    p = tmp_path / "old.iaiproj.json"
+    p.write_text(json.dumps(legacy), encoding="utf-8")
+    assert project_io.load_project(str(p)).render_on_top is None
+
+
 def test_load_legacy_layout_json(tmp_path):
     legacy = {"title": "Legacy", "pages": [{
         "page_size_px": [400, 400],

--- a/tests/layout/test_style_panel.py
+++ b/tests/layout/test_style_panel.py
@@ -37,3 +37,39 @@ def test_editing_size(qapp):
     p._on_field_changed()
     assert p.style().font_roles["body"].size_px == 40
     assert got and got[-1].font_roles["body"].size_px == 40
+
+
+class StatefulFakeConfig:
+    def __init__(self, **seed):
+        self.layout = dict(seed)
+    def get_layout_config(self): return dict(self.layout)
+    def set_layout_config(self, c): self.layout = dict(c)
+    def save(self): pass
+    def get_layout_style_role(self): return self.layout.get("style_role", "")
+    def set_layout_style_role(self, r): self.layout["style_role"] = r
+
+
+def test_set_style_defaults_to_first_role_without_config(qapp):
+    p = StylePanel()
+    p.set_style(_style())
+    assert p.role_combo.currentText() == p.role_combo.itemText(0)
+
+
+def test_saved_role_restored_when_present(qapp):
+    p = StylePanel(StatefulFakeConfig(style_role="title"))  # "body" sorts first
+    p.set_style(_style())
+    assert p.role_combo.currentText() == "title"
+
+
+def test_saved_role_ignored_when_absent_from_style(qapp):
+    p = StylePanel(StatefulFakeConfig(style_role="nonexistent-role"))
+    p.set_style(_style())
+    assert p.role_combo.currentText() == p.role_combo.itemText(0)
+
+
+def test_role_change_persists(qapp):
+    cfg = StatefulFakeConfig()
+    p = StylePanel(cfg)
+    p.set_style(_style())
+    p.role_combo.setCurrentText("title")
+    assert cfg.get_layout_style_role() == "title"


### PR DESCRIPTION
## Summary

Restores last-used **Layout-tab** state across sessions and fixes a long-standing bare-`pytest` collection hang.

- **Selection persistence** — layout LLM model, designer content-kind, and Style-panel role now persist via `ConfigManager` (`get/set_layout_llm_model`, `_content_kind`, `_style_role`).
- **Orientation / dropdown restore** — orientation buttons, dropdowns, and page-setup sync restore on load using populate-then-restore with `blockSignals` (not a timer). Render-above toggle auto-activates in landscape; all load paths sync page setup.
- **`pytest.ini`** (`testpaths=tests`) — stops bare `pytest` from hanging on root demo scripts during collection.
- **`.gitignore`** — ignores the local `Layouts/` output dir.

Also includes a community-facing **Discord post** draft for the (already-merged) Gemini Omni video provider — committed as its own commit, not sent anywhere.

## Testing

`tests/layout` suite green — **388 passed**, including new `test_layout_tab_orientation.py`.

## Notes

Branched off `main` after PR #29 (Gemini Omni) merged. Small unrelated `gui/video/*` tweaks were intentionally **kept out** of this PR and held for the upcoming CLI-video work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)