### PR TITLE
feat(video): Gemini Omni Flash docs parity (multi-ref, edit-video, task, delivery=uri) + CLI refine flags

### DIFF
--- a/.claude/skills/imageai-cli/SKILL.md
+++ b/.claude/skills/imageai-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: imageai-cli
-description: Use when generating, editing, batching, or scripting images with the ImageAI CLI (`python main.py ...`) from inside the ImageAI repo, across any provider — Google Gemini / Nano Banana, OpenAI (gpt-image-2/1.5/1, DALL·E), Stability AI, or local Stable Diffusion. Covers model selection, sizing/aspect, references & masks, streaming, Batch API, lyrics-to-prompts, gcloud auth, and key management. Trigger whenever the user wants to make or edit an image (or set up/test a provider key) from the command line in this working directory.
+description: Use when generating, editing, batching, or scripting images or videos with the ImageAI CLI (`python main.py ...`) from inside the ImageAI repo, across any provider — Google Gemini / Nano Banana, OpenAI (gpt-image-2/1.5/1, DALL·E), Stability AI, or local Stable Diffusion. Covers model selection, sizing/aspect, references & masks, streaming, Batch API, lyrics-to-prompts, gcloud auth, key management, and video generation (Gemini Omni + Veo: refs, conversational refine, edit-your-own-video). Trigger whenever the user wants to make or edit an image or video (or set up/test a provider key) from the command line in this working directory.
 ---
 
 # imageai-cli

--- a/.claude/skills/imageai-cli/SKILL.md
+++ b/.claude/skills/imageai-cli/SKILL.md
@@ -218,6 +218,46 @@ python main.py --lyrics-to-prompts song.txt \
 `--lyrics-model` accepts any LiteLLM id (`gpt-4o`, `gemini/gemini-2.0-flash-exp`,
 `claude-sonnet-4-6`, …). Feed the resulting prompts back into image generation.
 
+## Video generation (`--video`)
+
+Two providers: `--video-provider omni` (Gemini Omni, conversational, audio
+baked in) and `veo` (default). Reuses `-p/--prompt` and `-o/--out`.
+
+```bash
+# Omni text-to-video (16:9 default; audio auto-generated)
+python main.py --video --video-provider omni -p "a marble run, smooth shot" -o marble.mp4
+
+# Subject references (up to 3 images; Omni infers reference_to_video)
+python main.py --video --video-provider omni -p "the cat bats the yarn ball" \
+    --ref-image cat.png --ref-image yarn.png -o cat.mp4
+
+# Conversationally refine the previous clip (id = operation_id in the sidecar)
+python main.py --video --video-provider omni --refine-from int_abc123 \
+    -p "make the violin invisible" -o v2.mp4
+
+# Edit your own footage (uploads via the Files API first)
+python main.py --video --video-provider omni --edit-video input.mp4 \
+    -p "make the mirror ripple like liquid" -o edited.mp4
+
+# Large/720p clips: ask for URI delivery
+python main.py --video --video-provider omni --delivery uri -p "city timelapse" -o city.mp4
+```
+
+### Omni prompt superpowers (in the prompt text, not flags)
+
+- **Image roles**: `<FIRST_FRAME>` (start frame) vs `<IMAGE_REF_N>` (subject refs,
+  N=0,1,2); declare with `[# Sources <FIRST_FRAME>@Image1]`.
+- **Timing**: natural language ("after 3 seconds, ...") or timecodes
+  (`[0-3s] a woman enters`, "every 2s cut to a new angle").
+- **Audio direction**: describe music/sound design in the prompt — Omni
+  soundtracks every clip by default.
+- **On-screen text**: Omni renders readable/animated text ("a neon sign that
+  reads OPEN").
+- Aspect ratio goes in `--aspect` (16:9 or 9:16), **never** in the prompt.
+
+Omni does **not** support: video extension (`--extend` is Veo-only), video
+references > 3s, negative-prompt configs, temperature/system instructions.
+
 ## Keys, testing & auth
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Gemini Omni video generation parity with Veo 3.1**: Multiple reference images (via `reference_to_video` API field and new `--ref-image` flags up to 3), uploaded-video editing (Files API integration), explicit `video_config.task` field, and `delivery=uri` output mode in CLI and programmatic API.
 - **CLI video enhancements**:
-  - `--refine-from VIDEO_ID` — conversational "refine" mode for Omni videos (stream follow-ups to an existing generation).
-  - `--edit-video INPUT_VIDEO` — upload and edit an existing video file (Omni + Veo).
-  - `--delivery {inline|uri}` — output mode selection (inline base64 or signed GCS URI).
+  - `--refine-from INTERACTION_ID` — conversational "refine" mode for Omni videos (stream follow-ups to an existing generation).
+  - `--edit-video INPUT_VIDEO` — upload and edit an existing video file (Omni only).
+  - `--delivery {inline|uri}` — output mode selection (inline base64 or a Files API URI (polled until ACTIVE, then downloaded)).
   - `--ref-image` repeatable up to 3 times for Omni multi-reference support.
 
 ## [0.39.0] - 2026-06-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.0] - 2026-07-01
+
+### Added
+- **Gemini Omni video generation parity with Veo 3.1**: Multiple reference images (via `reference_to_video` API field and new `--ref-image` flags up to 3), uploaded-video editing (Files API integration), explicit `video_config.task` field, and `delivery=uri` output mode in CLI and programmatic API.
+- **CLI video enhancements**:
+  - `--refine-from VIDEO_ID` — conversational "refine" mode for Omni videos (stream follow-ups to an existing generation).
+  - `--edit-video INPUT_VIDEO` — upload and edit an existing video file (Omni + Veo).
+  - `--delivery {inline|uri}` — output mode selection (inline base64 or signed GCS URI).
+  - `--ref-image` repeatable up to 3 times for Omni multi-reference support.
+
 ## [0.39.0] - 2026-06-14
 
 ### Added

--- a/Docs/ImageAI-CLI-Guide.md
+++ b/Docs/ImageAI-CLI-Guide.md
@@ -1,0 +1,622 @@
+# ImageAI CLI Guide
+
+Everything the ImageAI command line can do — from a one-liner image to scripted,
+agent-driven image **and** video generation. All of it runs through a single
+entry point: `python main.py`.
+
+This guide is written to be useful to both humans and **autonomous agents**: it
+documents every flag, the machine-readable output contracts, exit codes, and a
+large section of agent-oriented use cases and recipes at the end.
+
+> **Environment note.** Leland runs the app from PowerShell with `.venv`
+> (`python`); agents/WSL use `.venv_linux` (`python3`). Commands below use
+> `python main.py`; substitute `python3` in WSL.
+
+---
+
+## Table of contents
+
+- [Quick start](#quick-start)
+- [How the entry point decides CLI vs GUI](#how-the-entry-point-decides-cli-vs-gui)
+- [Image generation](#image-generation)
+  - [Providers at a glance](#providers-at-a-glance)
+  - [Google Gemini (Nano Banana)](#google-gemini-nano-banana)
+  - [OpenAI](#openai)
+  - [Stability AI](#stability-ai-hosted)
+  - [Local Stable Diffusion](#local-stable-diffusion-offline)
+  - [gpt-image-2 deep dive](#gpt-image-2-deep-dive)
+  - [References, composition & masks](#references-composition--masks)
+  - [Batch API](#batch-api-openai)
+- [Video generation](#video-generation)
+- [Lyrics → prompts pipeline](#lyrics--prompts-pipeline)
+- [Publication layout engine](#publication-layout-engine)
+- [Keys, auth & testing](#keys-auth--testing)
+- [Machine-readable output & exit codes](#machine-readable-output--exit-codes)
+- [Full flag reference](#full-flag-reference)
+- [Anti-footguns](#anti-footguns)
+- [Use cases for autonomous & other agents](#use-cases-for-autonomous--other-agents)
+
+---
+
+## Quick start
+
+```bash
+# Simplest possible image (default provider google, default model Nano Banana)
+python main.py -p "a red fox in snow"
+
+# Pick provider + model + explicit output
+python main.py --provider openai -m gpt-image-2 -p "a red fox in snow" -o fox.png
+
+# A single video clip (default video provider: Veo)
+python main.py --video -p "a red fox running through snow" -o fox.mp4
+
+# Verify a provider's API key works
+python main.py --provider openai -t
+```
+
+`-o/--out` is optional for images — without it, files auto-save with a sanitized,
+prompt-derived name in the platform images directory. **Every generated image
+gets a `.json` metadata sidecar** (prompt + generation details); every generated
+video gets one too.
+
+---
+
+## How the entry point decides CLI vs GUI
+
+`python main.py` launches the **GUI by default**. It stays in the **CLI** when
+you pass any action flag:
+
+| Trigger | Mode |
+|---------|------|
+| `-p/--prompt` | CLI image generation |
+| `--video` | CLI video generation |
+| `-t/--test` | CLI key test |
+| `-s/--set-key` | CLI key storage |
+| `--lyrics-to-prompts` | CLI lyrics pipeline |
+| `--layout-design` / `--layout-fill` / `--layout-export` | CLI layout engine |
+| `--gui` | Force the GUI even alongside other flags |
+| *(none of the above)* | GUI |
+
+This matters for automation: an agent can always stay headless by supplying an
+action flag, and never accidentally block on a window.
+
+---
+
+## Image generation
+
+### Providers at a glance
+
+| Provider | `--provider` | Auth | Best for |
+|----------|--------------|------|----------|
+| Google Gemini | `google` *(default)* | API key **or** `gcloud` ADC | Nano Banana family; fast, high quality, up to 4K (NBP) |
+| OpenAI | `openai` | API key | `gpt-image-2` "thinking" model, DALL·E 3 |
+| Stability AI | `stability` | API key (hosted) | SDXL / SD hosted endpoints |
+| Local SD | `local_sd` | none (local GPU/CPU) | offline generation, no per-image cost |
+
+Default provider **`google`**, default model **`gemini-2.5-flash-image`**.
+
+```bash
+# Provider + model + N images in one call
+python main.py --provider openai -m gpt-image-2 -n 4 -p "logo ideas" -o logo.png
+```
+
+### Google Gemini (Nano Banana)
+
+| Model | Alias | Max output |
+|-------|-------|-----------|
+| `gemini-3-pro-image-preview` | Nano Banana Pro | 4K |
+| `gemini-3.1-flash-image-preview` | Nano Banana 2 | 2K |
+| `gemini-2.5-flash-image` *(default)* | Nano Banana | 1024px |
+
+```bash
+# Default Nano Banana
+python main.py -p "watercolor harbor at dawn" -o harbor.png
+
+# Nano Banana Pro, 16:9 (the provider maps --size to an aspect ratio)
+python main.py -m gemini-3-pro-image-preview --size 1920x1080 \
+    -p "cinematic desert highway" -o road.png
+
+# gcloud Application Default Credentials instead of an API key
+python main.py --auth-mode gcloud -p "aurora over pines" -o aurora.png
+```
+
+- **Aspect ratio, not pixels in the prompt.** Set sizing via `--size`; Gemini
+  converts to an aspect ratio internally. Never bake `"(1024x768)"` into the
+  prompt — Gemini renders it as literal text in the image.
+- **Supported aspect ratios:** `1:1, 3:2, 2:3, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9`.
+- **Scaling:** Nano Banana caps at 1024px (app scales max-edge to 1024 then
+  upscales); NB2 → 2K native; NBP → 4K native.
+- Operations: **generate**, **edit**, **compose** (add `--reference` for the
+  latter two).
+
+### OpenAI
+
+| Model | Notes |
+|-------|-------|
+| `gpt-image-2` | "Thinking" model — `--quality` drives reasoning. Best quality. |
+| `gpt-image-1.5` | Latest non-thinking; supports `--output-format`, alpha PNG. |
+| `gpt-image-1` | Prior gen. |
+| `gpt-image-1-mini` | Fast / cheap. |
+| `dall-e-3` | `--quality standard|hd`, fixed size presets. |
+| `dall-e-2` | Legacy. |
+
+```bash
+# gpt-image-2 with explicit reasoning level
+python main.py --provider openai -m gpt-image-2 --quality high \
+    -p "complex composition with legible text" -o gen.png
+
+# DALL·E 3 in HD
+python main.py --provider openai -m dall-e-3 --quality hd \
+    -p "isometric city" -o city.png
+```
+
+### Stability AI (hosted)
+
+| Model | Label |
+|-------|-------|
+| `stable-diffusion-xl-1024-v1-0` *(default)* | SDXL 1.0 |
+| `stable-diffusion-xl-beta-v2-2-2` | SDXL Beta |
+| `stable-diffusion-512-v2-1` | SD 2.1 |
+| `stable-diffusion-v1-6` | SD 1.6 |
+
+```bash
+python main.py --provider stability -m stable-diffusion-xl-1024-v1-0 \
+    -p "fantasy castle, concept art" -o castle.png
+```
+
+### Local Stable Diffusion (offline)
+
+| Model | Label |
+|-------|-------|
+| `stabilityai/stable-diffusion-xl-base-1.0` | SDXL Base 1.0 |
+| `segmind/SSD-1B` | SSD-1B (Fast SDXL) |
+| `stabilityai/stable-diffusion-2-1` *(default)* | SD 2.1 |
+| `runwayml/stable-diffusion-v1-5` | SD 1.5 |
+| `CompVis/stable-diffusion-v1-4` | SD 1.4 |
+
+```bash
+python main.py --provider local_sd -m segmind/SSD-1B \
+    -p "studio portrait, soft light" -o portrait.png
+```
+
+- No API key. **First run downloads multi-GB weights from Hugging Face.**
+- Uses CUDA / Apple MPS when available, else CPU (slow).
+- Needs local-SD extras (`torch`, `diffusers`). If missing, install them
+  deliberately — don't let an automated run silently pull system deps.
+
+### gpt-image-2 deep dive
+
+`gpt-image-2` (released 2026-04-21) has the largest CLI surface.
+
+```bash
+# Custom size (edges multiples of 16, max 3840, aspect <=3:1, pixels 655K-8.3M)
+python main.py --provider openai -m gpt-image-2 \
+    --custom-size 2048x1152 -p "ultrawide wallpaper" -o gen.png
+
+# Streaming partials -> writes gen.p0.png, gen.p1.png, ... then gen.png
+python main.py --provider openai -m gpt-image-2 \
+    --stream-partials --quality high \
+    -p "intricate technical diagram" -o gen.png
+
+# JPEG output with compression
+python main.py --provider openai -m gpt-image-2 \
+    --output-format jpeg --output-compression 85 \
+    -p "photorealistic landscape" -o landscape.jpg
+
+# Permissive moderation
+python main.py --provider openai -m gpt-image-2 --moderation low \
+    -p "..." -o gen.png
+```
+
+**Cost estimator (1024×1024):**
+
+| Quality | Per image | At n=10 |
+|---------|-----------|---------|
+| low | ~$0.006 | ~$0.06 |
+| medium | ~$0.053 | ~$0.53 |
+| high | ~$0.211 | ~$2.11 |
+| Batch | 50% off all of the above | |
+
+**Snapshot pinning** for reproducible reruns:
+
+```python
+from core.constants import GPT_IMAGE_2_SNAPSHOT  # "gpt-image-2-2026-04-21"
+```
+
+Pass the snapshot ID as `-m` for bit-for-bit reruns across model releases.
+
+### References, composition & masks
+
+```bash
+# Multi-reference compose (up to 10 images) -> /v1/images/edits
+python main.py --provider openai -m gpt-image-2 \
+    --reference ref/a.png --reference ref/b.png \
+    -p "combine these styles" -o composed.png
+
+# Mask inpainting (transparent pixels in the mask = the edit zone)
+python main.py --provider openai -m gpt-image-2 \
+    --reference base.png --mask mask.png \
+    -p "replace the sky with stormy clouds" -o edited.png
+```
+
+`--reference` is repeatable (≤10) and routes to the edits endpoint; `--mask`
+takes a PNG whose transparent pixels mark where the model may paint. Google
+Gemini also supports references for edit/compose.
+
+### Batch API (OpenAI)
+
+```bash
+# Submit (50% discount, up to 24h turnaround) -> prints a job ID
+python main.py --provider openai -m gpt-image-2 --batch -p "your prompt" -o gen.png
+# -> Submitted batch job: batch_abc123...
+
+python main.py --provider openai --batch-status batch_abc123
+python main.py --provider openai --batch-fetch  batch_abc123
+```
+
+Jobs are tracked in `~/.imageai/batch_jobs.json` (and the GUI's **Batch Jobs** tab).
+
+---
+
+## Video generation
+
+Single-clip video generation, designed to be **agent-friendly** (predictable,
+scriptable, machine-readable). Enable it with `--video`; it reuses `-p/--prompt`
+and `-o/--out`.
+
+```bash
+# Text -> video (Veo is the default video provider)
+python main.py --video -p "a fox running through snow" -o fox.mp4
+
+# Gemini Omni, portrait, with audio baked into the output
+python main.py --video --video-provider omni --aspect 9:16 \
+    -p "neon city at night" -o city.mp4
+
+# Reference images (up to 3 for both providers; 2+ on Omni = subject references)
+python main.py --video -p "she walks toward camera" -o walk.mp4 \
+    --ref-image style.png --ref-image character.png
+
+# Extend an existing clip (Veo only) — continues from the given video
+python main.py --video --extend fox.mp4 -p "the fox leaps over a log" -o fox2.mp4
+
+# Veo frame-to-frame interpolation (end frame)
+python main.py --video -p "sunrise timelapse" -o sunrise.mp4 \
+    --ref-image start.png --last-frame end.png
+
+# Machine-readable result for agents (exactly one JSON object on stdout)
+python main.py --video -p "a fox in snow" -o fox.mp4 --json
+
+# Conversationally refine the previous clip (Omni only; id = operation_id in the sidecar)
+python main.py --video --video-provider omni --refine-from int_abc123 \
+    -p "make the violin invisible" -o v2.mp4
+
+# Edit your own footage (Omni only; uploads via the Files API first)
+python main.py --video --video-provider omni --edit-video input.mp4 \
+    -p "make the mirror ripple like liquid" -o edited.mp4
+
+# Large/720p clips: ask for URI delivery (Omni only)
+python main.py --video --video-provider omni --delivery uri -p "city timelapse" -o city.mp4
+```
+
+### Omni prompt superpowers (in the prompt text, not flags)
+
+- **Image roles**: `<FIRST_FRAME>` (start frame) vs `<IMAGE_REF_N>` (subject refs,
+  N=0,1,2); declare with `[# Sources <FIRST_FRAME>@Image1]`.
+- **Timing**: natural language ("after 3 seconds, ...") or timecodes
+  (`[0-3s] a woman enters`, "every 2s cut to a new angle").
+- **Audio direction**: describe music/sound design in the prompt — Omni
+  soundtracks every clip by default.
+- **On-screen text**: Omni renders readable/animated text ("a neon sign that
+  reads OPEN").
+- Aspect ratio goes in `--aspect` (16:9 or 9:16), **never** in the prompt.
+
+Omni does **not** support: video extension (`--extend` is Veo-only), video
+references > 3s, negative-prompt configs, temperature/system instructions.
+
+### Providers & capabilities
+
+| Capability | Gemini Omni (`omni`) | Veo (`veo`, default) |
+|------------|----------------------|----------------------|
+| Text → video | ✅ | ✅ |
+| Image/reference → video | ✅ (up to 3 refs) | ✅ (≤3 refs) |
+| Frame-to-frame interpolation (`--last-frame`) | ❌ | ✅ |
+| Extend an existing clip (`--extend`) | ❌ | ✅ (extends run at 720p) |
+| Conversational refine (`--refine-from`) | ✅ Omni only | ❌ |
+| Edit uploaded video (`--edit-video`) | ✅ Omni only | ❌ |
+| URI delivery (`--delivery uri`) | ✅ Omni only | ❌ |
+| Audio in output | ✅ | ✅ (Veo 3) |
+| Aspect ratios | `16:9`, `9:16` | `16:9`, `9:16`, `1:1` |
+| Auth | Google **API key only** | Google API key **or** `--auth-mode gcloud` |
+
+- **Clip length is model-fixed (~8 s).** There is no `--duration` knob by design.
+- Both providers authenticate with the **Google** key (same resolution order as
+  images). For Veo + ADC: `--auth-mode gcloud` with `GOOGLE_CLOUD_PROJECT` set.
+- `--extend`/`--last-frame` require `--video-provider veo` — pairing them with
+  `omni` is a clear validation error (exit code 2).
+- `--refine-from`/`--edit-video`/`--delivery` require `--video-provider omni` —
+  Veo rejects them with a validation error (exit code 2).
+
+### Output & reporting contract
+
+- Writes the `.mp4` to `-o` (or a prompt-derived name if omitted), plus a
+  `<output>.json` **sidecar** (prompt, provider, resolved model, aspect,
+  status, operation/interaction id, timestamps).
+- **Human/progress text always goes to stderr.**
+- With `--json`, **stdout carries exactly one JSON object and nothing else**, so
+  a parser never trips on log lines:
+
+```json
+{
+  "status": "completed",
+  "output_path": "fox.mp4",
+  "provider": "veo",
+  "model": "veo-3.1-generate-001",
+  "aspect_ratio": "16:9",
+  "operation_id": "operations/abc123",
+  "error": null
+}
+```
+
+---
+
+## Lyrics → prompts pipeline
+
+Turns a lyrics file into a set of image prompts using an **LLM** (not an image
+model). Feed the results back into image generation.
+
+```bash
+python main.py --lyrics-to-prompts song.txt \
+    --lyrics-model gpt-4o \
+    --lyrics-style cinematic \
+    --lyrics-temperature 0.7 \
+    --lyrics-output prompts.json
+```
+
+`--lyrics-model` accepts any LiteLLM id (`gpt-4o`,
+`gemini/gemini-2.0-flash-exp`, `claude-sonnet-4-6`, …).
+
+---
+
+## Publication layout engine
+
+The CLI also drives ImageAI's publication layout engine (design a page from a
+description, fill regions, export to PDF/PNG):
+
+```bash
+# Design a layout project (.json) from a text description
+python main.py --layout-design "3-panel comic, action scene" -o comic.json \
+    --content-kind comic --page-size "US Comic" --orientation portrait --dpi 300
+
+# Fill a layout's regions with generated images
+python main.py --layout-fill comic.json
+
+# Export to PDF or PNG (extension decides the format)
+python main.py --layout-export comic.json -o comic.pdf
+```
+
+Text-LLM provider/model for `--layout-design` are overridable with
+`--layout-llm-provider` / `--layout-llm-model` (default: the configured layout
+provider).
+
+---
+
+## Keys, auth & testing
+
+```bash
+# Store a key for the selected provider (interactive)
+python main.py --provider openai -s
+
+# Provide a key inline or from a file for a one-off run
+python main.py --provider stability -k "$STABILITY_KEY" -p "..." -o out.png
+python main.py --provider openai -K /path/to/key.txt -p "..." -o out.png
+
+# Verify the configured key works
+python main.py --provider openai -t
+
+# Setup instructions
+python main.py --help-api-key
+```
+
+Key resolution order: **CLI flag (`-k`/`-K`) > stored config > environment**.
+`--auth-mode gcloud` is Google-only (images + Veo) and bypasses API keys via ADC
+(`gcloud auth application-default login` first).
+
+Environment variables recognized: `GOOGLE_API_KEY` / `GEMINI_API_KEY`,
+`OPENAI_API_KEY`, `STABILITY_KEY` / `STABILITY_API_KEY`, and
+`GOOGLE_CLOUD_PROJECT` (for Veo + gcloud).
+
+---
+
+## Machine-readable output & exit codes
+
+This is the part that makes the CLI safe to drive from another program.
+
+**Video `--json`:** exactly one JSON object on **stdout**; all diagnostics on
+**stderr**. Parse `stdout` directly.
+
+**Video exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Generation failed (provider returned a failure) |
+| `2` | User / validation error (bad flags, missing key, unsupported combo) |
+| `3` | Unexpected exception |
+
+**Sidecars everywhere.** Images and videos both write a `<output>.json` next to
+the artifact — a durable record an agent can read later even without `--json`.
+
+**Logging goes to stderr.** Console diagnostics (warnings/errors) are routed to
+stderr specifically so `stdout` stays clean for `--json` consumers.
+
+```bash
+# Robust agent pattern: capture JSON, branch on exit code
+if out=$(python main.py --video -p "$PROMPT" -o clip.mp4 --json 2>err.log); then
+    path=$(printf '%s' "$out" | jq -r .output_path)
+    echo "clip at $path"
+else
+    echo "failed (exit $?):"; cat err.log
+fi
+```
+
+---
+
+## Full flag reference
+
+### Image / shared
+
+| Flag | Values | Notes |
+|------|--------|-------|
+| `--provider` | `google` \| `openai` \| `stability` \| `local_sd` | Default `google`. |
+| `-m`, `--model` | provider model id | See per-provider tables. |
+| `-p`, `--prompt` | text | Triggers CLI image generation. |
+| `-o`, `--out` | path | Optional for images; auto-named if omitted. |
+| `-n`, `--num-images` | int | Default 1; gpt-image-2 up to 10. |
+| `--size` | `WxH` or preset | Mutex with `--custom-size`. Google maps to aspect. |
+| `--custom-size` | `WxH` | **gpt-image-2 only.** Edges ×16, max 3840, aspect ≤3:1, pixels 655K–8.3M. |
+| `--quality` | `auto\|low\|medium\|high\|standard\|hd` | gpt-image-2: `auto/low/medium/high`; dall-e-3: `standard/hd`. |
+| `--output-format` | `png` \| `jpeg` \| `webp` | gpt-image-2 / gpt-image-1.5. |
+| `--output-compression` | `0..100` | jpeg/webp only. |
+| `--moderation` | `auto` \| `low` | gpt-image-2 only; `low` = permissive. |
+| `--reference` | path (repeatable ≤10) | Routes to `/v1/images/edits`. |
+| `--mask` | PNG path | Alpha mask inpainting; transparent = edit zone. |
+| `--stream-partials` | flag | gpt-image-2 only; writes `out.pN.png`. |
+| `--batch` / `--batch-status` / `--batch-fetch` | flag / JOB_ID | OpenAI Batch API. |
+
+### Video
+
+| Flag | Values | Notes |
+|------|--------|-------|
+| `--video` | flag | Enable video mode (uses `-p`/`-o`). |
+| `--video-provider` | `omni` \| `veo` | Default `veo`. |
+| `--video-model` | model id | Optional; else the provider's resolved default. |
+| `--aspect` | e.g. `16:9`, `9:16` | Validated per provider. |
+| `--ref-image` | path (repeatable) | Reference image (repeatable; omni: up to 3, veo: up to 3). |
+| `--last-frame` | path | End frame for Veo frame-to-frame interpolation (veo only). |
+| `--extend` | path | Extend this existing video (veo only); implies extend mode. |
+| `--delivery` | `inline` \| `uri` | Omni only: video delivery ('uri' recommended for large/720p clips). |
+| `--refine-from` | INTERACTION_ID | Omni only: conversationally refine a previous generation (interaction id = `operation_id` in the JSON sidecar). |
+| `--edit-video` | path | Omni only: upload this video and edit it with the prompt. |
+| `--json` | flag | One JSON result object on stdout. |
+
+### Lyrics / layout / keys / auth
+
+| Flag | Values | Notes |
+|------|--------|-------|
+| `--lyrics-to-prompts` | LYRICS_FILE | Plus `--lyrics-model` / `--lyrics-temperature` / `--lyrics-style` / `--lyrics-output`. |
+| `--layout-design` / `--layout-fill` / `--layout-export` | text / project.json / project.json | Layout engine; `--content-kind`, `--page-size`, `--orientation`, `--dpi`, `--layout-llm-provider`, `--layout-llm-model`. |
+| `--auth-mode` | `api-key` \| `gcloud` | `gcloud` is Google-only (images + Veo). |
+| `-k` / `-K` / `-s` / `-t` | — | Key inline / from file / store / test. |
+| `--help-api-key` | flag | Print API-key setup instructions. |
+| `--gui` | flag | Force the GUI. |
+
+---
+
+## Anti-footguns
+
+- **Provider/model must match.** `dall-e-3` needs `--provider openai`; `gemini-*`
+  needs `--provider google` (or default). Video: `--extend`/`--last-frame` need
+  `--video-provider veo`.
+- **Google sizing:** never put pixel dimensions in the prompt text; use `--size`.
+- **gpt-image-2 custom-size:** the #1 mistake is non-multiple-of-16 edges —
+  pre-flight validation rejects it.
+- **gpt-image-2 reasoning is just `--quality`** (`auto/low/medium/high`); there is
+  no separate reasoning knob. It also has **no** transparent background, no
+  `style`, no variations endpoint — use `gpt-image-1.5`/`gpt-image-1` for alpha PNG.
+- **Don't cross quality vocabularies:** `standard/hd` = DALL·E; `auto/low/medium/high` = gpt-image-2.
+- **gpt-image-2 requires OpenAI Org Verification.** If `-t` reports a verification
+  message, complete it in the OpenAI dashboard.
+- **Video clip length is fixed (~8 s).** Chain `--extend` for longer results
+  (Veo; extensions render at 720p).
+- **local_sd first run** downloads multi-GB weights and may need GPU extras.
+- **In `--json` mode, read stdout only.** Logs and progress are on stderr by design.
+
+---
+
+## Use cases for autonomous & other agents
+
+The CLI is deliberately headless-friendly: action flags avoid the GUI, `--json`
+gives a clean stdout contract, exit codes are meaningful, and every artifact has
+a `.json` sidecar. Ideas, from simple to ambitious:
+
+### 1. Deterministic single-shot generation
+Give an agent a prompt → get a file path back. Use `--json` for video, or read
+the image sidecar for metadata.
+```bash
+python main.py --video -p "$PROMPT" -o out.mp4 --json | jq -r .output_path
+```
+
+### 2. Prompt A/B fan-out and self-selection
+Generate `n` variants, then have a vision/LLM step pick the best.
+```bash
+python main.py --provider openai -m gpt-image-2 -n 6 -p "$PROMPT" -o variant.png
+# agent then scores variant*.png and keeps the winner
+```
+
+### 3. Cost-aware tiering
+An agent can pick quality per budget: draft at `--quality low` (~$0.006), then
+re-render only the chosen concept at `--quality high`. Or route bulk jobs through
+`--batch` for a 50% discount when latency is acceptable.
+
+### 4. Lyrics/story → storyboard → clips pipeline
+Chain the built-in stages: `--lyrics-to-prompts` produces prompts, feed each into
+image generation, then animate keyframes with `--video --ref-image`.
+```bash
+python main.py --lyrics-to-prompts song.txt --lyrics-output prompts.json
+# for each prompt: generate a keyframe image, then:
+python main.py --video --ref-image key.png -p "$LINE" -o scene.mp4 --json
+```
+
+### 5. Reference-consistent character/brand sets
+Keep a character or brand style consistent across many images/clips by always
+passing the same `--reference`/`--ref-image` set (Veo takes up to 3).
+
+### 6. Iterative video refinement via extend
+Build a longer sequence by chaining Veo `--extend`, each step continuing the last
+clip — an agent can loop until a target length or a "scene change" cue.
+```bash
+python main.py --video -p "establishing shot" -o s1.mp4 --json
+python main.py --video --extend s1.mp4 -p "camera pushes in" -o s2.mp4 --json
+```
+
+### 7. Masked, localized edits
+For "change only X" tasks, an agent generates a mask (transparent = edit zone)
+and calls `--reference base.png --mask mask.png`. Great for automated retouching
+or object replacement.
+
+### 8. Layout-driven publication assembly
+Design → fill → export entirely headlessly for comics, one-pagers, or reports:
+```bash
+python main.py --layout-design "$BRIEF" -o page.json --content-kind magazine
+python main.py --layout-fill page.json
+python main.py --layout-export page.json -o page.pdf
+```
+
+### 9. Long-running batch orchestration
+Submit many prompts with `--batch`, persist the returned job IDs, and poll
+`--batch-status` / `--batch-fetch` on a schedule. Jobs survive process restarts
+via `~/.imageai/batch_jobs.json`, so an agent can resume after a crash.
+
+### 10. Provider fallback / resilience
+On failure (non-zero exit or `status:"failed"` in JSON), an agent can retry on a
+different provider — e.g. Veo → Omni for video, or gpt-image-2 → Nano Banana Pro
+for images — without human intervention.
+
+### 11. Fully offline / air-gapped generation
+Use `--provider local_sd` where no API egress is allowed. No keys, no network
+after weights are cached — suitable for sandboxed agents.
+
+### 12. Reproducible evaluation harnesses
+Pin `gpt-image-2` to its snapshot ID for bit-for-bit reruns, generate a fixed
+prompt suite, and diff outputs across model/prompt changes as a regression test.
+
+### Agent integration checklist
+
+- Prefer `--json` for video and parse **stdout only**; treat **stderr** as logs.
+- Branch on **exit codes** (`0/1/2/3`), not on stdout text.
+- Read the `.json` **sidecar** for durable metadata (prompt, model, ids).
+- Pass keys via env vars or `-K <file>` — never inline secrets in a logged command.
+- For headless CI/agents, always supply an action flag so the GUI never launches.
+- Respect **model↔provider** pairing and per-provider aspect/size rules to avoid
+  validation errors (exit `2`).
+```

--- a/Plans/2026-07-01-omni-docs-parity.md
+++ b/Plans/2026-07-01-omni-docs-parity.md
@@ -1,0 +1,976 @@
+# Gemini Omni Flash Docs Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring ImageAI's Gemini Omni video integration to full parity with the official docs (https://ai.google.dev/gemini-api/docs/omni): multiple reference images, uploaded-video editing, explicit `video_config.task`, `delivery="uri"`, CLI conversational refinement, and prompt-feature documentation.
+
+**Architecture:** All API-shape changes land in `core/video/omni_client.py` (`OmniGenerationConfig` builds the `interactions.create` kwargs; `OmniClient` handles upload/poll/download). The CLI layer (`cli/parser.py`, `cli/commands/video.py`) maps new flags onto the config. Existing GUI callers keep working unchanged via back-compat (`reference_image` folds into the new `reference_images` list).
+
+**Tech Stack:** Python 3.12 (`.venv_linux`), `google-genai>=2.9.0` Interactions API, pytest (all tests mock the SDK — no network).
+
+## Global Constraints
+
+- Python interpreter for all test runs: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python` (never `.venv` from WSL).
+- Never `cd`; use absolute paths (`git -C /mnt/d/Documents/Code/GitHub/ImageAI ...`).
+- Aspect ratio and task are NEVER embedded in prompt text (AGENTS.md §9).
+- Model IDs are resolved via `resolve_model()` — never hardcode new ones (AGENTS.md §8).
+- Log every request detail sent to the LLM (AGENTS.md §8).
+- Conventional Commits; suite must be green before every commit.
+- Existing tests in `tests/video/` must keep passing — the documented request shape asserted there (dict `response_format`, content-list input) is load-bearing.
+- Full suite gate: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests -q` (440+ tests; must be green).
+
+## Documented API shapes being implemented (from the official docs, verbatim patterns)
+
+```python
+# Multi-reference (reference_to_video): several image items, then text
+input=[
+    {"type": "image", "data": cat_b64, "mime_type": "image/png"},
+    {"type": "image", "data": yarn_b64, "mime_type": "image/png"},
+    {"type": "text", "text": "A cat playfully batting at a ball of yarn."},
+]
+
+# Edit an uploaded video: Files API upload -> document item by URI
+video_file = client.files.upload(file="Video.mp4")   # poll PROCESSING -> ACTIVE
+input=[
+    {"type": "document", "uri": video_file.uri},
+    {"type": "text", "text": "make the mirror ripple like liquid"},
+]
+
+# Explicit task
+generation_config={"video_config": {"task": "image_to_video"}}
+
+# URI delivery
+response_format={"type": "video", "delivery": "uri"}
+```
+
+---
+
+### Task 1: Multiple reference images (`reference_images`) with task inference
+
+**Files:**
+- Modify: `core/video/omni_client.py` (dataclass `OmniGenerationConfig`, ~lines 74–137; `OmniClient.MODEL_CONSTRAINTS` ~line 156; `OmniClient.validate_config` ~line 187)
+- Test: `tests/video/test_omni_client.py`
+
+**Interfaces:**
+- Consumes: existing `OmniGenerationConfig` fields.
+- Produces: `OmniGenerationConfig.reference_images: List[Path]` (canonical), `reference_image: Optional[Path]` kept as back-compat input that folds into the list; task auto-inferred when `task=""` (new default): `previous_interaction_id → "edit"`, `≥2 refs → "reference_to_video"`, `1 ref → "image_to_video"`, else `"text_to_video"`. `MODEL_CONSTRAINTS["max_reference_images"] == 3`.
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/video/test_omni_client.py`:
+
+```python
+# --- Multi-reference images (reference_to_video) -----------------------------
+
+def _write_png(tmp_path, name):
+    p = tmp_path / name
+    p.write_bytes(b"\x89PNG\r\n\x1a\nfakepng-" + name.encode())
+    return p
+
+
+def test_multiple_reference_images_build_content_list(tmp_path):
+    cat = _write_png(tmp_path, "cat.png")
+    yarn = _write_png(tmp_path, "yarn.png")
+    cfg = OmniGenerationConfig(prompt="A cat playfully batting at a ball of yarn.",
+                               reference_images=[cat, yarn])
+    kw = cfg.to_interaction_kwargs()
+    # Documented shape: N image items followed by exactly one text item.
+    assert [item["type"] for item in kw["input"]] == ["image", "image", "text"]
+    assert kw["input"][2]["text"] == "A cat playfully batting at a ball of yarn."
+    # Two subject references => reference_to_video (inferred).
+    assert cfg.task == "reference_to_video"
+
+
+def test_single_reference_image_infers_image_to_video(tmp_path):
+    ref = _write_png(tmp_path, "ref.png")
+    cfg = OmniGenerationConfig(prompt="make it move", reference_images=[ref])
+    assert cfg.task == "image_to_video"
+
+
+def test_legacy_reference_image_folds_into_list(tmp_path):
+    ref = _write_png(tmp_path, "ref.png")
+    cfg = OmniGenerationConfig(prompt="go", task="image_to_video", reference_image=ref)
+    assert cfg.reference_images == [ref]
+    kw = cfg.to_interaction_kwargs()
+    assert [item["type"] for item in kw["input"]] == ["image", "text"]
+
+
+def test_too_many_reference_images_rejected(tmp_path):
+    refs = [_write_png(tmp_path, f"r{i}.png") for i in range(4)]
+    with pytest.raises(ValueError, match="reference image"):
+        OmniGenerationConfig(prompt="x", reference_images=refs)
+
+
+def test_previous_interaction_id_infers_edit_task():
+    cfg = OmniGenerationConfig(prompt="make the violin invisible",
+                               previous_interaction_id="int_prev")
+    assert cfg.task == "edit"
+
+
+def test_validate_config_checks_all_reference_images_exist(tmp_path):
+    ok = _write_png(tmp_path, "ok.png")
+    missing = tmp_path / "missing.png"
+    cfg = OmniGenerationConfig(prompt="x", reference_images=[ok])
+    cfg.reference_images.append(missing)  # bypass __post_init__ to hit validate_config
+    client = OmniClient(api_key="test-key")
+    is_valid, error = client.validate_config(cfg)
+    assert is_valid is False
+    assert "missing.png" in error
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests/video/test_omni_client.py -v -k "reference_images or infers or too_many or folds"`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'reference_images'` (and similar).
+
+- [ ] **Step 3: Implement** — in `core/video/omni_client.py`:
+
+Add `List` to the typing import:
+
+```python
+from typing import Any, Dict, List, Optional, Tuple
+```
+
+Replace the `OmniGenerationConfig` dataclass fields and `__post_init__` (keep `to_interaction_kwargs` mostly, shown fully in this step so the file is consistent):
+
+```python
+@dataclass
+class OmniGenerationConfig:
+    """Configuration for a Gemini Omni video generation/edit request."""
+
+    prompt: str = ""
+    model: str = ""  # Resolved Omni model ID; defaults via __post_init__.
+    aspect_ratio: str = "16:9"  # "16:9" (landscape) or "9:16" (portrait).
+    reference_image: Optional[Path] = None  # Back-compat single ref; folds into reference_images.
+    reference_images: List[Path] = field(default_factory=list)  # Subject/first-frame refs.
+    previous_interaction_id: Optional[str] = None  # Chain a conversational edit.
+    # Task sent as generation_config.video_config.task; inferred when left "".
+    task: str = ""
+
+    def __post_init__(self):
+        if not self.model:
+            self.model = OmniModel.default_id()
+
+        if self.reference_image is not None and not self.reference_images:
+            self.reference_images = [Path(self.reference_image)]
+        self.reference_images = [Path(p) for p in self.reference_images]
+
+        max_refs = OmniClient.MODEL_CONSTRAINTS["max_reference_images"]
+        if len(self.reference_images) > max_refs:
+            raise ValueError(
+                f"Gemini Omni supports at most {max_refs} reference image(s); "
+                f"got {len(self.reference_images)}."
+            )
+
+        if not self.task:
+            self.task = self._infer_task()
+
+        if self.aspect_ratio not in OmniClient.MODEL_CONSTRAINTS["aspect_ratios"]:
+            raise ValueError(
+                f"aspect_ratio {self.aspect_ratio!r} not supported by Gemini Omni. "
+                f"Use one of {OmniClient.MODEL_CONSTRAINTS['aspect_ratios']}."
+            )
+
+        valid_tasks = OmniClient.MODEL_CONSTRAINTS["tasks"]
+        if self.task not in valid_tasks:
+            raise ValueError(f"task {self.task!r} invalid. Use one of {valid_tasks}.")
+
+        # image_to_video / reference_to_video require a reference image.
+        if self.task in ("image_to_video", "reference_to_video") and not self.reference_images:
+            raise ValueError(
+                f"task {self.task!r} requires a reference_image, but none was provided."
+            )
+
+    def _infer_task(self) -> str:
+        """Infer the video_config task from the input shape (docs task enum)."""
+        if self.previous_interaction_id:
+            return "edit"
+        if len(self.reference_images) >= 2:
+            return "reference_to_video"
+        if self.reference_images:
+            return "image_to_video"
+        return "text_to_video"
+
+    def to_interaction_kwargs(self) -> Dict[str, Any]:
+        """Build the kwargs for ``client.interactions.create(**kwargs)``.
+
+        Matches the documented Gemini Omni request shape: video output and
+        aspect ratio are requested via ``response_format={"type": "video",
+        "aspect_ratio": ...}`` (a dict). The aspect ratio is never placed in the
+        prompt text (AGENTS.md §9). With reference images, ``input`` is a content
+        list ``[{image}, ..., {text}]``; otherwise it is the plain prompt string.
+        """
+        content: List[Dict[str, Any]] = []
+        for ref in self.reference_images:
+            image_bytes = Path(ref).read_bytes()
+            b64 = base64.b64encode(image_bytes).decode("ascii")
+            mime = _IMAGE_MIME_BY_SUFFIX.get(Path(ref).suffix.lower(), "image/png")
+            content.append({"type": "image", "data": b64, "mime_type": mime})
+
+        if content:
+            content.append({"type": "text", "text": self.prompt})
+            input_payload: Any = content
+        else:
+            input_payload = self.prompt
+
+        kwargs: Dict[str, Any] = {
+            "model": self.model,
+            "input": input_payload,
+            "response_format": {"type": "video", "aspect_ratio": self.aspect_ratio},
+        }
+        if self.previous_interaction_id:
+            kwargs["previous_interaction_id"] = self.previous_interaction_id
+        return kwargs
+```
+
+Add to `OmniClient.MODEL_CONSTRAINTS` (after `"tasks"`):
+
+```python
+        "max_reference_images": 3,  # Docs show multi-subject refs (<IMAGE_REF_N>, N=0..2).
+```
+
+Update `validate_config`'s reference-image check to cover the list:
+
+```python
+        for ref in (config.reference_images or []):
+            if not Path(ref).exists():
+                return False, f"Reference image not found: {ref}"
+```
+
+(replace the old single `config.reference_image` check).
+
+- [ ] **Step 4: Run the Omni test file — all tests pass (old + new)**
+
+Run: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests/video/test_omni_client.py -v`
+Expected: PASS (all, including pre-existing `test_image_to_video_builds_content_list`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /mnt/d/Documents/Code/GitHub/ImageAI add core/video/omni_client.py tests/video/test_omni_client.py
+git -C /mnt/d/Documents/Code/GitHub/ImageAI commit -m "feat(video): support multiple Omni reference images (reference_to_video)"
+```
+
+---
+
+### Task 2: Explicit `generation_config.video_config.task`
+
+**Files:**
+- Modify: `core/video/omni_client.py` (`to_interaction_kwargs`)
+- Test: `tests/video/test_omni_client.py`
+
+**Interfaces:**
+- Consumes: `OmniGenerationConfig.task` (Task 1 inference).
+- Produces: every `interactions.create` call includes `generation_config={"video_config": {"task": <task>}}`.
+
+- [ ] **Step 1: Write the failing tests** — append:
+
+```python
+# --- Explicit generation_config.video_config.task ----------------------------
+
+def test_task_sent_in_generation_config_text_to_video():
+    cfg = OmniGenerationConfig(prompt="a sunset")
+    kw = cfg.to_interaction_kwargs()
+    assert kw["generation_config"] == {"video_config": {"task": "text_to_video"}}
+
+
+def test_task_sent_in_generation_config_reference_to_video(tmp_path):
+    refs = [_write_png(tmp_path, f"s{i}.png") for i in range(2)]
+    cfg = OmniGenerationConfig(prompt="together in a park", reference_images=refs)
+    kw = cfg.to_interaction_kwargs()
+    # Disambiguates subject references from a first-frame image (identical
+    # input shapes otherwise).
+    assert kw["generation_config"]["video_config"]["task"] == "reference_to_video"
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests/video/test_omni_client.py -v -k generation_config`
+Expected: FAIL with `KeyError: 'generation_config'`.
+
+- [ ] **Step 3: Implement** — in `to_interaction_kwargs`, add to the `kwargs` dict right after `"response_format"`:
+
+```python
+            "generation_config": {"video_config": {"task": self.task}},
+```
+
+- [ ] **Step 4: Run the Omni test file**
+
+Run: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests/video/test_omni_client.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /mnt/d/Documents/Code/GitHub/ImageAI add core/video/omni_client.py tests/video/test_omni_client.py
+git -C /mnt/d/Documents/Code/GitHub/ImageAI commit -m "feat(video): send explicit video_config.task in Omni requests"
+```
+
+---
+
+### Task 3: `delivery="uri"` request option
+
+**Files:**
+- Modify: `core/video/omni_client.py` (`OmniGenerationConfig` field + validation + `to_interaction_kwargs`; `MODEL_CONSTRAINTS`)
+- Test: `tests/video/test_omni_client.py`
+
+**Interfaces:**
+- Consumes: existing URI-download path (`_download_uri`) — already handles a returned URI.
+- Produces: `OmniGenerationConfig.delivery: Optional[str]` (`None`/`"inline"`/`"uri"`); when `"uri"`, `response_format` gains `"delivery": "uri"`. `MODEL_CONSTRAINTS["deliveries"] == ["inline", "uri"]`.
+
+- [ ] **Step 1: Write the failing tests** — append:
+
+```python
+# --- delivery="uri" -----------------------------------------------------------
+
+def test_delivery_uri_in_response_format():
+    cfg = OmniGenerationConfig(prompt="a sunset", delivery="uri")
+    kw = cfg.to_interaction_kwargs()
+    assert kw["response_format"] == {
+        "type": "video", "aspect_ratio": "16:9", "delivery": "uri"
+    }
+
+
+def test_delivery_default_omits_key():
+    cfg = OmniGenerationConfig(prompt="a sunset")
+    assert "delivery" not in cfg.to_interaction_kwargs()["response_format"]
+
+
+def test_delivery_inline_omits_key():
+    cfg = OmniGenerationConfig(prompt="a sunset", delivery="inline")
+    assert "delivery" not in cfg.to_interaction_kwargs()["response_format"]
+
+
+def test_invalid_delivery_rejected():
+    with pytest.raises(ValueError, match="delivery"):
+        OmniGenerationConfig(prompt="x", delivery="carrier-pigeon")
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests/video/test_omni_client.py -v -k delivery`
+Expected: FAIL — unexpected keyword argument `delivery`.
+
+- [ ] **Step 3: Implement**
+
+Add the field to `OmniGenerationConfig` (after `previous_interaction_id`):
+
+```python
+    delivery: Optional[str] = None  # None/"inline" (base64) or "uri" (Files API; big clips).
+```
+
+Add validation at the end of `__post_init__`:
+
+```python
+        if self.delivery not in (None, "inline", "uri"):
+            raise ValueError(
+                f"delivery {self.delivery!r} invalid. Use 'inline' or 'uri'."
+            )
+```
+
+In `to_interaction_kwargs`, build `response_format` as a variable:
+
+```python
+        response_format: Dict[str, Any] = {
+            "type": "video", "aspect_ratio": self.aspect_ratio
+        }
+        if self.delivery == "uri":
+            # Docs recommend URI delivery for clips over ~4MB / higher res.
+            response_format["delivery"] = "uri"
+```
+
+and use it in `kwargs` (`"response_format": response_format,`).
+
+Add to `MODEL_CONSTRAINTS` after `"max_reference_images"`:
+
+```python
+        "deliveries": ["inline", "uri"],
+```
+
+- [ ] **Step 4: Run the Omni test file**
+
+Run: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests/video/test_omni_client.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /mnt/d/Documents/Code/GitHub/ImageAI add core/video/omni_client.py tests/video/test_omni_client.py
+git -C /mnt/d/Documents/Code/GitHub/ImageAI commit -m "feat(video): support Omni delivery=uri response format"
+```
+
+---
+
+### Task 4: Edit uploaded videos (Files API `document` input)
+
+**Files:**
+- Modify: `core/video/omni_client.py` (`OmniGenerationConfig` field/validation, `to_interaction_kwargs(video_uri=...)`, `OmniClient.generate_video_async`, new `OmniClient._upload_video`, `validate_config`)
+- Test: `tests/video/test_omni_client.py`
+
+**Interfaces:**
+- Consumes: Task 1's content-list builder.
+- Produces: `OmniGenerationConfig.input_video: Optional[Path]`; `to_interaction_kwargs(video_uri: Optional[str] = None)` (document item first, then images, then text); `OmniClient._upload_video(path: Path) -> str` (async; uploads, polls `PROCESSING`→`ACTIVE`, returns `file.uri`, raises `RuntimeError` on `FAILED`/timeout). `input_video` implies task `"edit"`.
+
+- [ ] **Step 1: Write the failing tests** — append:
+
+```python
+# --- Edit uploaded videos (Files API document input) --------------------------
+
+def test_input_video_infers_edit_task(tmp_path):
+    vid = tmp_path / "clip.mp4"
+    vid.write_bytes(MP4_BYTES)
+    cfg = OmniGenerationConfig(prompt="make the mirror ripple", input_video=vid)
+    assert cfg.task == "edit"
+
+
+def test_document_uri_first_in_content_list(tmp_path):
+    vid = tmp_path / "clip.mp4"
+    vid.write_bytes(MP4_BYTES)
+    cfg = OmniGenerationConfig(prompt="make the mirror ripple", input_video=vid)
+    kw = cfg.to_interaction_kwargs(video_uri="https://files.example/files/abc123")
+    assert kw["input"][0] == {"type": "document",
+                              "uri": "https://files.example/files/abc123"}
+    assert kw["input"][-1] == {"type": "text", "text": "make the mirror ripple"}
+    assert kw["generation_config"]["video_config"]["task"] == "edit"
+
+
+def test_generate_uploads_input_video_then_creates(tmp_path):
+    vid = tmp_path / "clip.mp4"
+    vid.write_bytes(MP4_BYTES)
+    b64 = base64.b64encode(MP4_BYTES).decode("ascii")
+    interaction = _FakeInteraction(output_video=_FakeVideoContent(data=b64))
+    client = _make_client(interaction)
+
+    uploaded = pytypes.SimpleNamespace(
+        name="files/upload1", uri="https://files.example/files/upload1",
+        state=pytypes.SimpleNamespace(name="ACTIVE"),
+    )
+    upload_calls = []
+
+    def _upload(file):
+        upload_calls.append(file)
+        return uploaded
+
+    client.client.files = pytypes.SimpleNamespace(
+        upload=_upload, get=lambda name: uploaded, download=lambda file: MP4_BYTES,
+    )
+    client.polling_interval = 0
+
+    out = tmp_path / "out.mp4"
+    cfg = OmniGenerationConfig(prompt="ripple the mirror", input_video=vid)
+    result = client.generate_video(cfg, out)
+
+    assert result.success is True
+    assert upload_calls == [str(vid)]
+    sent = client.client.interactions.create_calls[0]
+    assert sent["input"][0] == {"type": "document",
+                                "uri": "https://files.example/files/upload1"}
+
+
+def test_generate_fails_cleanly_if_upload_fails(tmp_path):
+    vid = tmp_path / "clip.mp4"
+    vid.write_bytes(MP4_BYTES)
+    interaction = _FakeInteraction()
+    client = _make_client(interaction)
+    failed = pytypes.SimpleNamespace(
+        name="files/upload1", uri=None, state=pytypes.SimpleNamespace(name="FAILED"),
+    )
+    client.client.files = pytypes.SimpleNamespace(
+        upload=lambda file: failed, get=lambda name: failed,
+        download=lambda file: MP4_BYTES,
+    )
+    client.polling_interval = 0
+
+    cfg = OmniGenerationConfig(prompt="ripple", input_video=vid)
+    result = client.generate_video(cfg, tmp_path / "out.mp4")
+
+    assert result.success is False
+    assert "upload" in result.error.lower() or "failed" in result.error.lower()
+    assert client.client.interactions.create_calls == []  # never created
+
+
+def test_validate_config_checks_input_video_exists(tmp_path):
+    cfg = OmniGenerationConfig(prompt="x")
+    cfg.input_video = tmp_path / "missing.mp4"  # bypass __post_init__
+    client = OmniClient(api_key="test-key")
+    is_valid, error = client.validate_config(cfg)
+    assert is_valid is False
+    assert "missing.mp4" in error
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests/video/test_omni_client.py -v -k "input_video or document_uri or upload"`
+Expected: FAIL — unexpected keyword argument `input_video`.
+
+- [ ] **Step 3: Implement**
+
+Field (after `reference_images`):
+
+```python
+    input_video: Optional[Path] = None  # Existing video to edit (uploaded via Files API).
+```
+
+`_infer_task` gains the video branch (before the `previous_interaction_id` check order doesn't matter — both mean edit):
+
+```python
+        if self.input_video is not None or self.previous_interaction_id:
+            return "edit"
+```
+
+Validation in `__post_init__` (after the task checks):
+
+```python
+        if self.task == "edit" and not (self.previous_interaction_id or self.input_video):
+            raise ValueError(
+                "task 'edit' requires previous_interaction_id or input_video."
+            )
+```
+
+`to_interaction_kwargs` signature and content list:
+
+```python
+    def to_interaction_kwargs(self, video_uri: Optional[str] = None) -> Dict[str, Any]:
+```
+
+and at the top of the content build (before the reference-image loop):
+
+```python
+        content: List[Dict[str, Any]] = []
+        if video_uri:
+            # Uploaded video to edit — documented as a "document" item by URI.
+            content.append({"type": "document", "uri": video_uri})
+```
+
+New helper on `OmniClient` (place after `_await_terminal`); module-level state reader next to `_IMAGE_MIME_BY_SUFFIX`:
+
+```python
+def _file_state(f: Any) -> Optional[str]:
+    """Files-API state as a string ('PROCESSING'/'ACTIVE'/'FAILED')."""
+    state = getattr(f, "state", None)
+    return getattr(state, "name", None) or (str(state) if state else None)
+```
+
+```python
+    async def _upload_video(self, path: Path) -> str:
+        """Upload a video via the Files API and wait until it is ACTIVE.
+
+        Returns the file URI to reference as a ``document`` input item.
+        Raises RuntimeError if processing fails or times out.
+        """
+        self.logger.info(f"Uploading video for Omni edit: {path}")
+        video_file = await asyncio.to_thread(self.client.files.upload, file=str(path))
+        deadline = time.time() + self.timeout
+        while _file_state(video_file) == "PROCESSING" and time.time() < deadline:
+            await asyncio.sleep(self.polling_interval)
+            video_file = await asyncio.to_thread(
+                self.client.files.get, name=video_file.name
+            )
+        state = _file_state(video_file)
+        if state != "ACTIVE":
+            raise RuntimeError(
+                f"Files API upload of {path} did not become ACTIVE (state={state})."
+            )
+        self.logger.info(f"Omni edit video uploaded: {video_file.uri}")
+        return video_file.uri
+```
+
+In `generate_video_async`, replace `kwargs = config.to_interaction_kwargs()` with:
+
+```python
+            video_uri = None
+            if config.input_video is not None:
+                video_uri = await self._upload_video(Path(config.input_video))
+            kwargs = config.to_interaction_kwargs(video_uri=video_uri)
+```
+
+(the surrounding `try` already converts the `RuntimeError` into a failed result; log line for the request should also mention `input_video={config.input_video}`).
+
+`validate_config` addition:
+
+```python
+        if config.input_video is not None and not Path(config.input_video).exists():
+            return False, f"Input video not found: {config.input_video}"
+```
+
+- [ ] **Step 4: Run the Omni test file**
+
+Run: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests/video/test_omni_client.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /mnt/d/Documents/Code/GitHub/ImageAI add core/video/omni_client.py tests/video/test_omni_client.py
+git -C /mnt/d/Documents/Code/GitHub/ImageAI commit -m "feat(video): edit uploaded videos with Omni via Files API document input"
+```
+
+---
+
+### Task 5: CLI — multi-ref cap and `--delivery` for Omni
+
+**Files:**
+- Modify: `cli/parser.py` (video group, ~line 230–271), `cli/commands/video.py` (`OMNI_MAX_REFS`, `build_omni_config`, `build_veo_config`)
+- Test: `tests/video/test_cli_video_config.py`, `tests/video/test_cli_video_parser.py`
+
+**Interfaces:**
+- Consumes: Task 1's `reference_images`, Task 3's `delivery`.
+- Produces: `--ref-image` accepted up to 3 for Omni; new arg `--delivery {inline,uri}` (dest `delivery`, Omni-only — Veo rejects it).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/video/test_cli_video_config.py` (this file uses a `_ns(**kw)` / namespace helper — match its existing style; check the top of the file and reuse its args factory):
+
+```python
+def test_omni_accepts_three_refs(tmp_path):
+    refs = []
+    for i in range(3):
+        p = tmp_path / f"r{i}.png"
+        p.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+        refs.append(str(p))
+    cfg = build_omni_config(_ns(prompt="together", ref_image=refs))
+    assert len(cfg.reference_images) == 3
+    assert cfg.task == "reference_to_video"
+
+
+def test_omni_rejects_four_refs(tmp_path):
+    refs = [str(tmp_path / f"r{i}.png") for i in range(4)]
+    with pytest.raises(VideoCliError, match="3"):
+        build_omni_config(_ns(prompt="x", ref_image=refs))
+
+
+def test_omni_delivery_uri_passthrough():
+    cfg = build_omni_config(_ns(prompt="a sunset", delivery="uri"))
+    assert cfg.delivery == "uri"
+
+
+def test_veo_rejects_delivery():
+    with pytest.raises(VideoCliError, match="omni"):
+        build_veo_config(_ns(prompt="x", delivery="uri"))
+```
+
+(Adjust the old `test_omni_rejects_two_refs` — it asserted the 1-ref cap that this task removes: replace it with the 3-ref cap tests above, i.e. delete `test_omni_rejects_two_refs`.)
+
+Append to `tests/video/test_cli_video_parser.py` inside/alongside `test_video_flags_parse` style:
+
+```python
+def test_delivery_flag_parses():
+    from cli.parser import build_parser
+    args = build_parser().parse_args(
+        ["--video", "-p", "x", "--video-provider", "omni", "--delivery", "uri"]
+    )
+    assert args.delivery == "uri"
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests/video/test_cli_video_config.py /mnt/d/Documents/Code/GitHub/ImageAI/tests/video/test_cli_video_parser.py -v`
+Expected: new tests FAIL (old 1-ref cap message / unknown `--delivery`).
+
+- [ ] **Step 3: Implement**
+
+`cli/parser.py` — update the `--ref-image` help and add `--delivery` after `--extend`:
+
+```python
+    video_group.add_argument(
+        "--ref-image",
+        action="append",
+        metavar="PATH",
+        help="Reference image (repeatable; omni: up to 3, veo: up to 3)",
+    )
+```
+
+```python
+    video_group.add_argument(
+        "--delivery",
+        choices=["inline", "uri"],
+        help="Omni only: video delivery ('uri' recommended for large/720p clips)",
+    )
+```
+
+`cli/commands/video.py`:
+
+```python
+OMNI_MAX_REFS = 3
+```
+
+`build_omni_config` — replace the single-ref mapping:
+
+```python
+    kwargs = dict(
+        prompt=getattr(args, "prompt", None) or "",
+        aspect_ratio=getattr(args, "aspect", None) or "16:9",
+    )
+    if getattr(args, "video_model", None):
+        kwargs["model"] = args.video_model
+    if refs:
+        kwargs["reference_images"] = refs
+    if getattr(args, "delivery", None):
+        kwargs["delivery"] = args.delivery
+```
+
+(the explicit `task=` mapping is dropped — `OmniGenerationConfig` now infers it).
+
+`build_veo_config` — add the guard at the top (with the existing ones — mirror how `build_omni_config` rejects `--extend`):
+
+```python
+    if getattr(args, "delivery", None):
+        raise VideoCliError("--delivery is only supported with --video-provider omni.")
+```
+
+- [ ] **Step 4: Run the CLI video tests**
+
+Run: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests/video -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /mnt/d/Documents/Code/GitHub/ImageAI add cli/parser.py cli/commands/video.py tests/video/test_cli_video_config.py tests/video/test_cli_video_parser.py
+git -C /mnt/d/Documents/Code/GitHub/ImageAI commit -m "feat(cli): omni multi-ref images (up to 3) and --delivery flag"
+```
+
+---
+
+### Task 6: CLI — `--refine-from` and `--edit-video` (Omni conversational edit)
+
+**Files:**
+- Modify: `cli/parser.py` (video group), `cli/commands/video.py` (`build_omni_config`, `build_veo_config`)
+- Test: `tests/video/test_cli_video_config.py`, `tests/video/test_cli_video_parser.py`
+
+**Interfaces:**
+- Consumes: Task 1/4 config fields (`previous_interaction_id`, `input_video`).
+- Produces: `--refine-from INTERACTION_ID` (dest `refine_from`) → `previous_interaction_id`; `--edit-video PATH` (dest `edit_video`) → `input_video`. Both Omni-only. The interaction id needed by `--refine-from` is already emitted as `operation_id` in the CLI's JSON output/sidecar.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/video/test_cli_video_config.py`:
+
+```python
+def test_omni_refine_from_maps_to_previous_interaction():
+    cfg = build_omni_config(_ns(prompt="make the violin invisible",
+                                refine_from="int_abc123"))
+    assert cfg.previous_interaction_id == "int_abc123"
+    assert cfg.task == "edit"
+
+
+def test_omni_edit_video_maps_to_input_video(tmp_path):
+    vid = tmp_path / "clip.mp4"
+    vid.write_bytes(b"\x00\x00\x00\x18ftypmp42fake")
+    cfg = build_omni_config(_ns(prompt="ripple the mirror", edit_video=str(vid)))
+    assert cfg.input_video == vid
+    assert cfg.task == "edit"
+
+
+def test_omni_edit_video_missing_file_errors(tmp_path):
+    with pytest.raises(VideoCliError, match="not found"):
+        build_omni_config(_ns(prompt="x", edit_video=str(tmp_path / "nope.mp4")))
+
+
+def test_veo_rejects_refine_from():
+    with pytest.raises(VideoCliError, match="omni"):
+        build_veo_config(_ns(prompt="x", refine_from="int_abc"))
+
+
+def test_veo_rejects_edit_video():
+    with pytest.raises(VideoCliError, match="omni"):
+        build_veo_config(_ns(prompt="x", edit_video="clip.mp4"))
+```
+
+Append to `tests/video/test_cli_video_parser.py`:
+
+```python
+def test_refine_and_edit_video_flags_parse():
+    from cli.parser import build_parser
+    args = build_parser().parse_args(
+        ["--video", "-p", "x", "--video-provider", "omni",
+         "--refine-from", "int_1", "--edit-video", "clip.mp4"]
+    )
+    assert args.refine_from == "int_1"
+    assert args.edit_video == "clip.mp4"
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests/video -v -k "refine or edit_video"`
+Expected: FAIL (unknown args / missing mapping).
+
+- [ ] **Step 3: Implement**
+
+`cli/parser.py` — add after `--delivery`:
+
+```python
+    video_group.add_argument(
+        "--refine-from",
+        metavar="INTERACTION_ID",
+        help="Omni only: conversationally refine a previous generation "
+             "(interaction id = 'operation_id' in the JSON sidecar)",
+    )
+    video_group.add_argument(
+        "--edit-video",
+        metavar="PATH",
+        help="Omni only: upload this video and edit it with the prompt",
+    )
+```
+
+`cli/commands/video.py` — in `build_omni_config` after the `delivery` mapping:
+
+```python
+    if getattr(args, "refine_from", None):
+        kwargs["previous_interaction_id"] = args.refine_from
+    if getattr(args, "edit_video", None):
+        vid = Path(args.edit_video).expanduser()
+        if not vid.exists():
+            raise VideoCliError(f"--edit-video video not found: {vid}")
+        kwargs["input_video"] = vid
+```
+
+`build_veo_config` — guards next to the `--delivery` one:
+
+```python
+    if getattr(args, "refine_from", None):
+        raise VideoCliError("--refine-from is only supported with --video-provider omni.")
+    if getattr(args, "edit_video", None):
+        raise VideoCliError("--edit-video is only supported with --video-provider omni.")
+```
+
+- [ ] **Step 4: Run the video test directory**
+
+Run: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests/video -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /mnt/d/Documents/Code/GitHub/ImageAI add cli/parser.py cli/commands/video.py tests/video/test_cli_video_config.py tests/video/test_cli_video_parser.py
+git -C /mnt/d/Documents/Code/GitHub/ImageAI commit -m "feat(cli): omni --refine-from and --edit-video conversational editing"
+```
+
+---
+
+### Task 7: Documentation — prompt-level Omni features + new flags
+
+**Files:**
+- Modify: `.claude/skills/imageai-cli/SKILL.md` (add a Video section — it currently covers images only)
+- Modify: `Docs/ImageAI-CLI-Guide.md` (video section ~lines 260–310 and flag table ~line 459; update ref cap, add new flags, add prompt-features subsection)
+
+**Interfaces:**
+- Consumes: flags from Tasks 5–6.
+- Produces: docs only; no code.
+
+- [ ] **Step 1: Add a "Video generation" section to `.claude/skills/imageai-cli/SKILL.md`** (before any closing/keys section, matching the file's tone):
+
+```markdown
+## Video generation (`--video`)
+
+Two providers: `--video-provider omni` (Gemini Omni, conversational, audio
+baked in) and `veo` (default). Reuses `-p/--prompt` and `-o/--out`.
+
+```bash
+# Omni text-to-video (16:9 default; audio auto-generated)
+python main.py --video --video-provider omni -p "a marble run, smooth shot" -o marble.mp4
+
+# Subject references (up to 3 images; Omni infers reference_to_video)
+python main.py --video --video-provider omni -p "the cat bats the yarn ball" \
+    --ref-image cat.png --ref-image yarn.png -o cat.mp4
+
+# Conversationally refine the previous clip (id = operation_id in the sidecar)
+python main.py --video --video-provider omni --refine-from int_abc123 \
+    -p "make the violin invisible" -o v2.mp4
+
+# Edit your own footage (uploads via the Files API first)
+python main.py --video --video-provider omni --edit-video input.mp4 \
+    -p "make the mirror ripple like liquid" -o edited.mp4
+
+# Large/720p clips: ask for URI delivery
+python main.py --video --video-provider omni --delivery uri -p "city timelapse" -o city.mp4
+```
+
+### Omni prompt superpowers (in the prompt text, not flags)
+
+- **Image roles**: `<FIRST_FRAME>` (start frame) vs `<IMAGE_REF_N>` (subject refs,
+  N=0,1,2); declare with `[# Sources <FIRST_FRAME>@Image1]`.
+- **Timing**: natural language ("after 3 seconds, ...") or timecodes
+  (`[0-3s] a woman enters`, "every 2s cut to a new angle").
+- **Audio direction**: describe music/sound design in the prompt — Omni
+  soundtracks every clip by default.
+- **On-screen text**: Omni renders readable/animated text ("a neon sign that
+  reads OPEN").
+- Aspect ratio goes in `--aspect` (16:9 or 9:16), **never** in the prompt.
+
+Omni does **not** support: video extension (`--extend` is Veo-only), video
+references > 3s, negative-prompt configs, temperature/system instructions.
+```
+
+- [ ] **Step 2: Update `Docs/ImageAI-CLI-Guide.md`**
+
+- In the video examples (~line 275): change `# Reference images (Veo up to 3; Omni 1)` to `# Reference images (up to 3 for both providers; 2+ on Omni = subject references)`.
+- Add the four new example commands (refine, edit-video, delivery) mirroring the SKILL.md block above.
+- In the capability table (~line 292): update the Omni column — reference images `up to 3`, add rows `Conversational refine (--refine-from)` = Omni only, `Edit uploaded video (--edit-video)` = Omni only, `URI delivery (--delivery uri)` = Omni only.
+- In the flag table (~line 459): add `--refine-from`, `--edit-video`, `--delivery` rows with the same one-line help as the parser.
+- Add the same "Omni prompt superpowers" subsection (role tags, timecodes, audio, text rendering, limitations).
+
+- [ ] **Step 3: Verify docs render and no code changed**
+
+Run: `git -C /mnt/d/Documents/Code/GitHub/ImageAI diff --stat`
+Expected: only `.claude/skills/imageai-cli/SKILL.md` and `Docs/ImageAI-CLI-Guide.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /mnt/d/Documents/Code/GitHub/ImageAI add .claude/skills/imageai-cli/SKILL.md Docs/ImageAI-CLI-Guide.md
+git -C /mnt/d/Documents/Code/GitHub/ImageAI commit -m "docs(video): document Omni prompt features and new CLI flags"
+```
+
+Note: `Docs/ImageAI-CLI-Guide.md` is currently untracked — this commit tracks it. If that's undesired, flag it to Leland instead of committing it silently... it documents shipped CLI features, so tracking it is the expected outcome.
+
+---
+
+### Task 8: Version bump + full-suite gate
+
+**Files:**
+- Modify: `core/constants.py:9` (`VERSION = "0.39.0"` → `"0.40.0"`), `README.md` (version display + changelog entry — see `.claude/VERSION_LOCATIONS.md` for the authoritative list)
+
+- [ ] **Step 1: Bump version per `.claude/VERSION_LOCATIONS.md`**
+
+`core/constants.py`:
+
+```python
+VERSION = "0.40.0"
+```
+
+`README.md`: update the displayed version and add a changelog entry:
+
+```markdown
+### v0.40.0 (2026-07-01)
+- Gemini Omni docs parity: multiple reference images (reference_to_video),
+  edit uploaded videos (Files API), explicit video_config.task, delivery=uri.
+- CLI: `--refine-from` (conversational refine), `--edit-video`, `--delivery`;
+  `--ref-image` now up to 3 for Omni.
+```
+
+(Read `.claude/VERSION_LOCATIONS.md` first and update every listed location.)
+
+- [ ] **Step 2: Run the FULL suite**
+
+Run: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest /mnt/d/Documents/Code/GitHub/ImageAI/tests -q`
+Expected: all pass (440 baseline + ~20 new), 0 failures.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /mnt/d/Documents/Code/GitHub/ImageAI add core/constants.py README.md
+git -C /mnt/d/Documents/Code/GitHub/ImageAI commit -m "chore: bump version to 0.40.0 (Omni docs parity)"
+```
+
+---
+
+## Out of scope (deliberate)
+
+- **GUI multi-ref / edit-video pickers** — GUI keeps its current single seed-frame flow; it works unchanged through the `reference_image` back-compat field. A follow-up issue can add multi-ref pickers and an "edit this clip file" action.
+- **`store`/`background`/`stream` flags** — docs list them as perf tweaks; `store=false` would break the Refine flow, so defaults stay. Not exposed.
+- **Video extension** — unsupported by Omni per docs; CLI already rejects `--extend` for Omni.
+
+## Self-review notes
+
+- Spec coverage: gap 1 → Task 1, gap 2 → Task 4, gap 3 → Task 2, gap 4 → Task 3, gap 5 → Task 6 (+5 for flags), gap 6 → Task 7. Version/housekeeping → Task 8.
+- Type consistency: `reference_images: List[Path]`, `input_video: Optional[Path]`, `delivery: Optional[str]`, `to_interaction_kwargs(video_uri: Optional[str] = None)` used consistently across Tasks 1–6.
+- Existing-test compatibility checked against `tests/video/test_omni_client.py`: old assertions don't pin the absence of `generation_config`; single-ref content list shape unchanged; `test_omni_rejects_two_refs` is explicitly replaced in Task 5.

--- a/Plans/2026-07-01-omni-docs-parity.md
+++ b/Plans/2026-07-01-omni-docs-parity.md
@@ -1,5 +1,7 @@
 # Gemini Omni Flash Docs Parity Implementation Plan
 
+> **Status: ✅ COMPLETE (2026-07-01)** — all 8 tasks implemented and reviewed; suite 472 green; shipped as PR #33. Execution ledger: `.superpowers/sdd/progress.md`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Bring ImageAI's Gemini Omni video integration to full parity with the official docs (https://ai.google.dev/gemini-api/docs/omni): multiple reference images, uploaded-video editing, explicit `video_config.task`, `delivery="uri"`, CLI conversational refinement, and prompt-feature documentation.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### [ImageAI on GitHub](https://github.com/lelandg/ImageAI) Desktop + CLI for multi‑provider AI image and video generation with enterprise auth, prompt tools, and MIDI‑synced karaoke/video workflows.
 
-**Version 0.39.0**
+**Version 0.40.0**
 
 **See [LelandGreen.com](https://www.lelandgreen.com) for links to other code and free stuff**. _Under construction. Implementing social links soon._ 
 - **Chameleon Labs Discord - Support, AI Art & Community: [Chameleon Labs Discord](https://discord.gg/chameleonlabs)**

--- a/cli/commands/video.py
+++ b/cli/commands/video.py
@@ -60,6 +60,13 @@ def build_omni_config(args):
         kwargs["reference_images"] = refs
     if getattr(args, "delivery", None):
         kwargs["delivery"] = args.delivery
+    if getattr(args, "refine_from", None):
+        kwargs["previous_interaction_id"] = args.refine_from
+    if getattr(args, "edit_video", None):
+        vid = Path(args.edit_video).expanduser()
+        if not vid.exists():
+            raise VideoCliError(f"--edit-video video not found: {vid}")
+        kwargs["input_video"] = vid
     try:
         return OmniGenerationConfig(**kwargs)  # __post_init__ validates aspect/task; infers task
     except ValueError as e:
@@ -84,6 +91,10 @@ def build_veo_config(args):
     from core.video.veo_client import VeoGenerationConfig
     if getattr(args, "delivery", None):
         raise VideoCliError("--delivery is only supported with --video-provider omni.")
+    if getattr(args, "refine_from", None):
+        raise VideoCliError("--refine-from is only supported with --video-provider omni.")
+    if getattr(args, "edit_video", None):
+        raise VideoCliError("--edit-video is only supported with --video-provider omni.")
     refs = _ref_images(args)
     if len(refs) > VEO_MAX_REFS:
         raise VideoCliError(

--- a/cli/commands/video.py
+++ b/cli/commands/video.py
@@ -11,7 +11,7 @@ from cli.runner import resolve_api_key
 
 logger = logging.getLogger("imageai.cli.video")
 
-OMNI_MAX_REFS = 1
+OMNI_MAX_REFS = 3
 VEO_MAX_REFS = 3
 
 
@@ -52,15 +52,16 @@ def build_omni_config(args):
         )
     kwargs = dict(
         prompt=getattr(args, "prompt", None) or "",
-        task="image_to_video" if refs else "text_to_video",
         aspect_ratio=getattr(args, "aspect", None) or "16:9",
     )
     if getattr(args, "video_model", None):
         kwargs["model"] = args.video_model
     if refs:
-        kwargs["reference_image"] = refs[0]
+        kwargs["reference_images"] = refs
+    if getattr(args, "delivery", None):
+        kwargs["delivery"] = args.delivery
     try:
-        return OmniGenerationConfig(**kwargs)  # __post_init__ validates aspect/task
+        return OmniGenerationConfig(**kwargs)  # __post_init__ validates aspect/task; infers task
     except ValueError as e:
         raise VideoCliError(str(e))
 
@@ -81,6 +82,8 @@ def _veo_model(args):
 def build_veo_config(args):
     """Map CLI args to a VeoGenerationConfig (raises VideoCliError on misuse)."""
     from core.video.veo_client import VeoGenerationConfig
+    if getattr(args, "delivery", None):
+        raise VideoCliError("--delivery is only supported with --video-provider omni.")
     refs = _ref_images(args)
     if len(refs) > VEO_MAX_REFS:
         raise VideoCliError(

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -252,7 +252,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--ref-image",
         action="append",
         metavar="PATH",
-        help="Reference image (repeatable; omni: 1, veo: up to 3)",
+        help="Reference image (repeatable; omni: up to 3, veo: up to 3)",
     )
     video_group.add_argument(
         "--last-frame",
@@ -263,6 +263,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--extend",
         metavar="PATH",
         help="Extend this existing video (veo only); implies extend mode",
+    )
+    video_group.add_argument(
+        "--delivery",
+        choices=["inline", "uri"],
+        help="Omni only: video delivery ('uri' recommended for large/720p clips)",
     )
     video_group.add_argument(
         "--json",

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -270,6 +270,17 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Omni only: video delivery ('uri' recommended for large/720p clips)",
     )
     video_group.add_argument(
+        "--refine-from",
+        metavar="INTERACTION_ID",
+        help="Omni only: conversationally refine a previous generation "
+             "(interaction id = 'operation_id' in the JSON sidecar)",
+    )
+    video_group.add_argument(
+        "--edit-video",
+        metavar="PATH",
+        help="Omni only: upload this video and edit it with the prompt",
+    )
+    video_group.add_argument(
         "--json",
         action="store_true",
         help="Emit a single machine-readable JSON result on stdout",

--- a/core/constants.py
+++ b/core/constants.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 # Application metadata
 APP_NAME = "ImageAI"
-VERSION = "0.39.0"
+VERSION = "0.40.0"
 __version__ = VERSION
 __author__ = "Leland Green"
 __email__ = "contact@lelandgreen.com"

--- a/core/video/omni_client.py
+++ b/core/video/omni_client.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from core.llm_models import resolve_model
 
@@ -78,14 +78,29 @@ class OmniGenerationConfig:
     prompt: str = ""
     model: str = ""  # Resolved Omni model ID; defaults via __post_init__.
     aspect_ratio: str = "16:9"  # "16:9" (landscape) or "9:16" (portrait).
-    reference_image: Optional[Path] = None  # Start/reference frame (image-to-video).
+    reference_image: Optional[Path] = None  # Back-compat single ref; folds into reference_images.
+    reference_images: List[Path] = field(default_factory=list)  # Subject/first-frame refs.
     previous_interaction_id: Optional[str] = None  # Chain a conversational edit.
-    # Task is inferred from the input shape; kept for logging/metadata only.
-    task: str = "text_to_video"
+    # Task sent as generation_config.video_config.task; inferred when left "".
+    task: str = ""
 
     def __post_init__(self):
         if not self.model:
             self.model = OmniModel.default_id()
+
+        if self.reference_image is not None and not self.reference_images:
+            self.reference_images = [Path(self.reference_image)]
+        self.reference_images = [Path(p) for p in self.reference_images]
+
+        max_refs = OmniClient.MODEL_CONSTRAINTS["max_reference_images"]
+        if len(self.reference_images) > max_refs:
+            raise ValueError(
+                f"Gemini Omni supports at most {max_refs} reference image(s); "
+                f"got {len(self.reference_images)}."
+            )
+
+        if not self.task:
+            self.task = self._infer_task()
 
         if self.aspect_ratio not in OmniClient.MODEL_CONSTRAINTS["aspect_ratios"]:
             raise ValueError(
@@ -98,10 +113,20 @@ class OmniGenerationConfig:
             raise ValueError(f"task {self.task!r} invalid. Use one of {valid_tasks}.")
 
         # image_to_video / reference_to_video require a reference image.
-        if self.task in ("image_to_video", "reference_to_video") and not self.reference_image:
+        if self.task in ("image_to_video", "reference_to_video") and not self.reference_images:
             raise ValueError(
                 f"task {self.task!r} requires a reference_image, but none was provided."
             )
+
+    def _infer_task(self) -> str:
+        """Infer the video_config task from the input shape (docs task enum)."""
+        if self.previous_interaction_id:
+            return "edit"
+        if len(self.reference_images) >= 2:
+            return "reference_to_video"
+        if self.reference_images:
+            return "image_to_video"
+        return "text_to_video"
 
     def to_interaction_kwargs(self) -> Dict[str, Any]:
         """Build the kwargs for ``client.interactions.create(**kwargs)``.
@@ -109,21 +134,19 @@ class OmniGenerationConfig:
         Matches the documented Gemini Omni request shape: video output and
         aspect ratio are requested via ``response_format={"type": "video",
         "aspect_ratio": ...}`` (a dict). The aspect ratio is never placed in the
-        prompt text (AGENTS.md §9). For image-to-video, ``input`` is a content
-        list ``[{image}, {text}]``; otherwise it is the plain prompt string.
+        prompt text (AGENTS.md §9). With reference images, ``input`` is a content
+        list ``[{image}, ..., {text}]``; otherwise it is the plain prompt string.
         """
-        # Build the input: a plain string for text-to-video, or a content list
-        # when a reference image is supplied.
-        if self.reference_image is not None:
-            image_bytes = Path(self.reference_image).read_bytes()
+        content: List[Dict[str, Any]] = []
+        for ref in self.reference_images:
+            image_bytes = Path(ref).read_bytes()
             b64 = base64.b64encode(image_bytes).decode("ascii")
-            mime = _IMAGE_MIME_BY_SUFFIX.get(
-                Path(self.reference_image).suffix.lower(), "image/png"
-            )
-            input_payload: Any = [
-                {"type": "image", "data": b64, "mime_type": mime},
-                {"type": "text", "text": self.prompt},
-            ]
+            mime = _IMAGE_MIME_BY_SUFFIX.get(Path(ref).suffix.lower(), "image/png")
+            content.append({"type": "image", "data": b64, "mime_type": mime})
+
+        if content:
+            content.append({"type": "text", "text": self.prompt})
+            input_payload: Any = content
         else:
             input_payload = self.prompt
 
@@ -156,6 +179,7 @@ class OmniClient:
     MODEL_CONSTRAINTS = {
         "aspect_ratios": ["16:9", "9:16"],
         "tasks": ["text_to_video", "image_to_video", "reference_to_video", "edit"],
+        "max_reference_images": 3,  # Docs show multi-subject refs (<IMAGE_REF_N>, N=0..2).
         "duration_range": (3, 10),  # seconds (informational; no SDK duration field)
         "fps": 24,
         "resolution": "720p",
@@ -193,8 +217,9 @@ class OmniClient:
             )
         if config.task not in self.MODEL_CONSTRAINTS["tasks"]:
             return False, f"Task {config.task} not supported."
-        if config.reference_image is not None and not Path(config.reference_image).exists():
-            return False, f"Reference image not found: {config.reference_image}"
+        for ref in (config.reference_images or []):
+            if not Path(ref).exists():
+                return False, f"Reference image not found: {ref}"
         return True, None
 
     async def generate_video_async(self, config: OmniGenerationConfig,

--- a/core/video/omni_client.py
+++ b/core/video/omni_client.py
@@ -55,6 +55,12 @@ _IMAGE_MIME_BY_SUFFIX = {
 }
 
 
+def _file_state(f: Any) -> Optional[str]:
+    """Files-API state as a string ('PROCESSING'/'ACTIVE'/'FAILED')."""
+    state = getattr(f, "state", None)
+    return getattr(state, "name", None) or (str(state) if state else None)
+
+
 class OmniModel(Enum):
     """Available Gemini Omni models.
 
@@ -80,6 +86,7 @@ class OmniGenerationConfig:
     aspect_ratio: str = "16:9"  # "16:9" (landscape) or "9:16" (portrait).
     reference_image: Optional[Path] = None  # Back-compat single ref; folds into reference_images.
     reference_images: List[Path] = field(default_factory=list)  # Subject/first-frame refs.
+    input_video: Optional[Path] = None  # Existing video to edit (uploaded via Files API).
     previous_interaction_id: Optional[str] = None  # Chain a conversational edit.
     delivery: Optional[str] = None  # None/"inline" (base64) or "uri" (Files API; big clips).
     # Task sent as generation_config.video_config.task; inferred when left "".
@@ -119,6 +126,11 @@ class OmniGenerationConfig:
                 f"task {self.task!r} requires a reference_image, but none was provided."
             )
 
+        if self.task == "edit" and not (self.previous_interaction_id or self.input_video):
+            raise ValueError(
+                "task 'edit' requires previous_interaction_id or input_video."
+            )
+
         if self.delivery not in (None, "inline", "uri"):
             raise ValueError(
                 f"delivery {self.delivery!r} invalid. Use 'inline' or 'uri'."
@@ -126,7 +138,7 @@ class OmniGenerationConfig:
 
     def _infer_task(self) -> str:
         """Infer the video_config task from the input shape (docs task enum)."""
-        if self.previous_interaction_id:
+        if self.input_video is not None or self.previous_interaction_id:
             return "edit"
         if len(self.reference_images) >= 2:
             return "reference_to_video"
@@ -134,7 +146,7 @@ class OmniGenerationConfig:
             return "image_to_video"
         return "text_to_video"
 
-    def to_interaction_kwargs(self) -> Dict[str, Any]:
+    def to_interaction_kwargs(self, video_uri: Optional[str] = None) -> Dict[str, Any]:
         """Build the kwargs for ``client.interactions.create(**kwargs)``.
 
         Matches the documented Gemini Omni request shape: video output and
@@ -142,8 +154,13 @@ class OmniGenerationConfig:
         "aspect_ratio": ...}`` (a dict). The aspect ratio is never placed in the
         prompt text (AGENTS.md §9). With reference images, ``input`` is a content
         list ``[{image}, ..., {text}]``; otherwise it is the plain prompt string.
+        When ``video_uri`` is given (an uploaded video to edit), a ``document``
+        item referencing that URI is placed first in the content list.
         """
         content: List[Dict[str, Any]] = []
+        if video_uri:
+            # Uploaded video to edit — documented as a "document" item by URI.
+            content.append({"type": "document", "uri": video_uri})
         for ref in self.reference_images:
             image_bytes = Path(ref).read_bytes()
             b64 = base64.b64encode(image_bytes).decode("ascii")
@@ -235,6 +252,8 @@ class OmniClient:
         for ref in (config.reference_images or []):
             if not Path(ref).exists():
                 return False, f"Reference image not found: {ref}"
+        if config.input_video is not None and not Path(config.input_video).exists():
+            return False, f"Input video not found: {config.input_video}"
         return True, None
 
     async def generate_video_async(self, config: OmniGenerationConfig,
@@ -265,13 +284,17 @@ class OmniClient:
             return result
 
         try:
-            kwargs = config.to_interaction_kwargs()
+            video_uri = None
+            if config.input_video is not None:
+                video_uri = await self._upload_video(Path(config.input_video))
+            kwargs = config.to_interaction_kwargs(video_uri=video_uri)
 
             # Log the full request (AGENTS.md §8 — show everything sent to the LLM).
             self.logger.info("=" * 60)
             self.logger.info(f"Gemini Omni request — model={config.model} task={config.task}")
             self.logger.info(f"  aspect_ratio={config.aspect_ratio} "
                              f"reference_image={config.reference_image} "
+                             f"input_video={config.input_video} "
                              f"previous_interaction_id={config.previous_interaction_id}")
             self.logger.info(f"  Prompt:\n{config.prompt}")
             self.logger.info("=" * 60)
@@ -380,6 +403,28 @@ class OmniClient:
             f"Omni interaction {interaction_id} did not finish within {self.timeout}s"
         )
         return interaction
+
+    async def _upload_video(self, path: Path) -> str:
+        """Upload a video via the Files API and wait until it is ACTIVE.
+
+        Returns the file URI to reference as a ``document`` input item.
+        Raises RuntimeError if processing fails or times out.
+        """
+        self.logger.info(f"Uploading video for Omni edit: {path}")
+        video_file = await asyncio.to_thread(self.client.files.upload, file=str(path))
+        deadline = time.time() + self.timeout
+        while _file_state(video_file) == "PROCESSING" and time.time() < deadline:
+            await asyncio.sleep(self.polling_interval)
+            video_file = await asyncio.to_thread(
+                self.client.files.get, name=video_file.name
+            )
+        state = _file_state(video_file)
+        if state != "ACTIVE":
+            raise RuntimeError(
+                f"Files API upload of {path} did not become ACTIVE (state={state})."
+            )
+        self.logger.info(f"Omni edit video uploaded: {video_file.uri}")
+        return video_file.uri
 
     @classmethod
     def _extract_video(cls, interaction: Any) -> Tuple[Optional[bytes], Optional[str], Optional[str]]:

--- a/core/video/omni_client.py
+++ b/core/video/omni_client.py
@@ -293,7 +293,7 @@ class OmniClient:
             self.logger.info("=" * 60)
             self.logger.info(f"Gemini Omni request — model={config.model} task={config.task}")
             self.logger.info(f"  aspect_ratio={config.aspect_ratio} "
-                             f"reference_image={config.reference_image} "
+                             f"reference_images={[str(p) for p in config.reference_images]} "
                              f"input_video={config.input_video} "
                              f"previous_interaction_id={config.previous_interaction_id}")
             self.logger.info(f"  Prompt:\n{config.prompt}")

--- a/core/video/omni_client.py
+++ b/core/video/omni_client.py
@@ -295,7 +295,8 @@ class OmniClient:
             self.logger.info(f"  aspect_ratio={config.aspect_ratio} "
                              f"reference_images={[str(p) for p in config.reference_images]} "
                              f"input_video={config.input_video} "
-                             f"previous_interaction_id={config.previous_interaction_id}")
+                             f"previous_interaction_id={config.previous_interaction_id} "
+                             f"delivery={config.delivery}")
             self.logger.info(f"  Prompt:\n{config.prompt}")
             self.logger.info("=" * 60)
 

--- a/core/video/omni_client.py
+++ b/core/video/omni_client.py
@@ -154,6 +154,7 @@ class OmniGenerationConfig:
             "model": self.model,
             "input": input_payload,
             "response_format": {"type": "video", "aspect_ratio": self.aspect_ratio},
+            "generation_config": {"video_config": {"task": self.task}},
         }
         if self.previous_interaction_id:
             kwargs["previous_interaction_id"] = self.previous_interaction_id

--- a/core/video/omni_client.py
+++ b/core/video/omni_client.py
@@ -81,6 +81,7 @@ class OmniGenerationConfig:
     reference_image: Optional[Path] = None  # Back-compat single ref; folds into reference_images.
     reference_images: List[Path] = field(default_factory=list)  # Subject/first-frame refs.
     previous_interaction_id: Optional[str] = None  # Chain a conversational edit.
+    delivery: Optional[str] = None  # None/"inline" (base64) or "uri" (Files API; big clips).
     # Task sent as generation_config.video_config.task; inferred when left "".
     task: str = ""
 
@@ -118,6 +119,11 @@ class OmniGenerationConfig:
                 f"task {self.task!r} requires a reference_image, but none was provided."
             )
 
+        if self.delivery not in (None, "inline", "uri"):
+            raise ValueError(
+                f"delivery {self.delivery!r} invalid. Use 'inline' or 'uri'."
+            )
+
     def _infer_task(self) -> str:
         """Infer the video_config task from the input shape (docs task enum)."""
         if self.previous_interaction_id:
@@ -150,10 +156,17 @@ class OmniGenerationConfig:
         else:
             input_payload = self.prompt
 
+        response_format: Dict[str, Any] = {
+            "type": "video", "aspect_ratio": self.aspect_ratio
+        }
+        if self.delivery == "uri":
+            # Docs recommend URI delivery for clips over ~4MB / higher res.
+            response_format["delivery"] = "uri"
+
         kwargs: Dict[str, Any] = {
             "model": self.model,
             "input": input_payload,
-            "response_format": {"type": "video", "aspect_ratio": self.aspect_ratio},
+            "response_format": response_format,
             "generation_config": {"video_config": {"task": self.task}},
         }
         if self.previous_interaction_id:
@@ -181,6 +194,7 @@ class OmniClient:
         "aspect_ratios": ["16:9", "9:16"],
         "tasks": ["text_to_video", "image_to_video", "reference_to_video", "edit"],
         "max_reference_images": 3,  # Docs show multi-subject refs (<IMAGE_REF_N>, N=0..2).
+        "deliveries": ["inline", "uri"],
         "duration_range": (3, 10),  # seconds (informational; no SDK duration field)
         "fps": 24,
         "resolution": "720p",

--- a/tests/video/test_cli_video_config.py
+++ b/tests/video/test_cli_video_config.py
@@ -19,7 +19,7 @@ def test_omni_text_to_video():
 def test_omni_single_ref_is_image_to_video():
     cfg = build_omni_config(_ns(ref_image=["a.png"]))
     assert cfg.task == "image_to_video"
-    assert str(cfg.reference_image).endswith("a.png")
+    assert str(cfg.reference_images[0]).endswith("a.png")
 
 
 def test_omni_rejects_extend():
@@ -32,9 +32,31 @@ def test_omni_rejects_last_frame():
         build_omni_config(_ns(last_frame="end.png"))
 
 
-def test_omni_rejects_two_refs():
-    with pytest.raises(VideoCliError, match="1 reference"):
-        build_omni_config(_ns(ref_image=["a.png", "b.png"]))
+def test_omni_accepts_three_refs(tmp_path):
+    refs = []
+    for i in range(3):
+        p = tmp_path / f"r{i}.png"
+        p.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+        refs.append(str(p))
+    cfg = build_omni_config(_ns(prompt="together", ref_image=refs))
+    assert len(cfg.reference_images) == 3
+    assert cfg.task == "reference_to_video"
+
+
+def test_omni_rejects_four_refs(tmp_path):
+    refs = [str(tmp_path / f"r{i}.png") for i in range(4)]
+    with pytest.raises(VideoCliError, match="3"):
+        build_omni_config(_ns(prompt="x", ref_image=refs))
+
+
+def test_omni_delivery_uri_passthrough():
+    cfg = build_omni_config(_ns(prompt="a sunset", delivery="uri"))
+    assert cfg.delivery == "uri"
+
+
+def test_veo_rejects_delivery():
+    with pytest.raises(VideoCliError, match="omni"):
+        build_veo_config(_ns(prompt="x", delivery="uri"))
 
 
 def test_veo_accepts_three_refs():

--- a/tests/video/test_cli_video_config.py
+++ b/tests/video/test_cli_video_config.py
@@ -78,3 +78,33 @@ def test_veo_default_model():
     from core.video.veo_client import VeoModel
     cfg = build_veo_config(_ns())
     assert cfg.model == VeoModel.VEO_3_1_GENERATE
+
+
+def test_omni_refine_from_maps_to_previous_interaction():
+    cfg = build_omni_config(_ns(prompt="make the violin invisible",
+                                refine_from="int_abc123"))
+    assert cfg.previous_interaction_id == "int_abc123"
+    assert cfg.task == "edit"
+
+
+def test_omni_edit_video_maps_to_input_video(tmp_path):
+    vid = tmp_path / "clip.mp4"
+    vid.write_bytes(b"\x00\x00\x00\x18ftypmp42fake")
+    cfg = build_omni_config(_ns(prompt="ripple the mirror", edit_video=str(vid)))
+    assert cfg.input_video == vid
+    assert cfg.task == "edit"
+
+
+def test_omni_edit_video_missing_file_errors(tmp_path):
+    with pytest.raises(VideoCliError, match="not found"):
+        build_omni_config(_ns(prompt="x", edit_video=str(tmp_path / "nope.mp4")))
+
+
+def test_veo_rejects_refine_from():
+    with pytest.raises(VideoCliError, match="omni"):
+        build_veo_config(_ns(prompt="x", refine_from="int_abc"))
+
+
+def test_veo_rejects_edit_video():
+    with pytest.raises(VideoCliError, match="omni"):
+        build_veo_config(_ns(prompt="x", edit_video="clip.mp4"))

--- a/tests/video/test_cli_video_parser.py
+++ b/tests/video/test_cli_video_parser.py
@@ -43,3 +43,13 @@ def test_run_cli_routes_to_video_command():
         rc = run_cli(args)
     assert rc == 0
     m.assert_called_once()
+
+
+def test_refine_and_edit_video_flags_parse():
+    parser = build_arg_parser()
+    args = parser.parse_args(
+        ["--video", "-p", "x", "--video-provider", "omni",
+         "--refine-from", "int_1", "--edit-video", "clip.mp4"]
+    )
+    assert args.refine_from == "int_1"
+    assert args.edit_video == "clip.mp4"

--- a/tests/video/test_cli_video_parser.py
+++ b/tests/video/test_cli_video_parser.py
@@ -27,6 +27,14 @@ def test_video_provider_defaults_to_veo():
     assert args.video_provider == "veo"
 
 
+def test_delivery_flag_parses():
+    parser = build_arg_parser()
+    args = parser.parse_args(
+        ["--video", "-p", "x", "--video-provider", "omni", "--delivery", "uri"]
+    )
+    assert args.delivery == "uri"
+
+
 def test_run_cli_routes_to_video_command():
     parser = build_arg_parser()
     args = parser.parse_args(["--video", "-p", "x", "-o", "x.mp4"])

--- a/tests/video/test_omni_client.py
+++ b/tests/video/test_omni_client.py
@@ -391,3 +391,87 @@ def test_delivery_inline_omits_key():
 def test_invalid_delivery_rejected():
     with pytest.raises(ValueError, match="delivery"):
         OmniGenerationConfig(prompt="x", delivery="carrier-pigeon")
+
+
+# --- Edit uploaded videos (Files API document input) --------------------------
+
+def test_input_video_infers_edit_task(tmp_path):
+    vid = tmp_path / "clip.mp4"
+    vid.write_bytes(MP4_BYTES)
+    cfg = OmniGenerationConfig(prompt="make the mirror ripple", input_video=vid)
+    assert cfg.task == "edit"
+
+
+def test_document_uri_first_in_content_list(tmp_path):
+    vid = tmp_path / "clip.mp4"
+    vid.write_bytes(MP4_BYTES)
+    cfg = OmniGenerationConfig(prompt="make the mirror ripple", input_video=vid)
+    kw = cfg.to_interaction_kwargs(video_uri="https://files.example/files/abc123")
+    assert kw["input"][0] == {"type": "document",
+                              "uri": "https://files.example/files/abc123"}
+    assert kw["input"][-1] == {"type": "text", "text": "make the mirror ripple"}
+    assert kw["generation_config"]["video_config"]["task"] == "edit"
+
+
+def test_generate_uploads_input_video_then_creates(tmp_path):
+    vid = tmp_path / "clip.mp4"
+    vid.write_bytes(MP4_BYTES)
+    b64 = base64.b64encode(MP4_BYTES).decode("ascii")
+    interaction = _FakeInteraction(output_video=_FakeVideoContent(data=b64))
+    client = _make_client(interaction)
+
+    uploaded = pytypes.SimpleNamespace(
+        name="files/upload1", uri="https://files.example/files/upload1",
+        state=pytypes.SimpleNamespace(name="ACTIVE"),
+    )
+    upload_calls = []
+
+    def _upload(file):
+        upload_calls.append(file)
+        return uploaded
+
+    client.client.files = pytypes.SimpleNamespace(
+        upload=_upload, get=lambda name: uploaded, download=lambda file: MP4_BYTES,
+    )
+    client.polling_interval = 0
+
+    out = tmp_path / "out.mp4"
+    cfg = OmniGenerationConfig(prompt="ripple the mirror", input_video=vid)
+    result = client.generate_video(cfg, out)
+
+    assert result.success is True
+    assert upload_calls == [str(vid)]
+    sent = client.client.interactions.create_calls[0]
+    assert sent["input"][0] == {"type": "document",
+                                "uri": "https://files.example/files/upload1"}
+
+
+def test_generate_fails_cleanly_if_upload_fails(tmp_path):
+    vid = tmp_path / "clip.mp4"
+    vid.write_bytes(MP4_BYTES)
+    interaction = _FakeInteraction()
+    client = _make_client(interaction)
+    failed = pytypes.SimpleNamespace(
+        name="files/upload1", uri=None, state=pytypes.SimpleNamespace(name="FAILED"),
+    )
+    client.client.files = pytypes.SimpleNamespace(
+        upload=lambda file: failed, get=lambda name: failed,
+        download=lambda file: MP4_BYTES,
+    )
+    client.polling_interval = 0
+
+    cfg = OmniGenerationConfig(prompt="ripple", input_video=vid)
+    result = client.generate_video(cfg, tmp_path / "out.mp4")
+
+    assert result.success is False
+    assert "upload" in result.error.lower() or "failed" in result.error.lower()
+    assert client.client.interactions.create_calls == []  # never created
+
+
+def test_validate_config_checks_input_video_exists(tmp_path):
+    cfg = OmniGenerationConfig(prompt="x")
+    cfg.input_video = tmp_path / "missing.mp4"  # bypass __post_init__
+    client = OmniClient(api_key="test-key")
+    is_valid, error = client.validate_config(cfg)
+    assert is_valid is False
+    assert "missing.mp4" in error

--- a/tests/video/test_omni_client.py
+++ b/tests/video/test_omni_client.py
@@ -349,3 +349,20 @@ def test_validate_config_checks_all_reference_images_exist(tmp_path):
     is_valid, error = client.validate_config(cfg)
     assert is_valid is False
     assert "missing.png" in error
+
+
+# --- Explicit generation_config.video_config.task ----------------------------
+
+def test_task_sent_in_generation_config_text_to_video():
+    cfg = OmniGenerationConfig(prompt="a sunset")
+    kw = cfg.to_interaction_kwargs()
+    assert kw["generation_config"] == {"video_config": {"task": "text_to_video"}}
+
+
+def test_task_sent_in_generation_config_reference_to_video(tmp_path):
+    refs = [_write_png(tmp_path, f"s{i}.png") for i in range(2)]
+    cfg = OmniGenerationConfig(prompt="together in a park", reference_images=refs)
+    kw = cfg.to_interaction_kwargs()
+    # Disambiguates subject references from a first-frame image (identical
+    # input shapes otherwise).
+    assert kw["generation_config"]["video_config"]["task"] == "reference_to_video"

--- a/tests/video/test_omni_client.py
+++ b/tests/video/test_omni_client.py
@@ -291,3 +291,61 @@ def test_reference_image_mime_detection(tmp_path):
     cfg = OmniGenerationConfig(prompt="go", task="image_to_video", reference_image=webp)
     kw = cfg.to_interaction_kwargs()
     assert kw["input"][0]["mime_type"] == "image/webp"
+
+
+# --- Multi-reference images (reference_to_video) -----------------------------
+
+def _write_png(tmp_path, name):
+    p = tmp_path / name
+    p.write_bytes(b"\x89PNG\r\n\x1a\nfakepng-" + name.encode())
+    return p
+
+
+def test_multiple_reference_images_build_content_list(tmp_path):
+    cat = _write_png(tmp_path, "cat.png")
+    yarn = _write_png(tmp_path, "yarn.png")
+    cfg = OmniGenerationConfig(prompt="A cat playfully batting at a ball of yarn.",
+                               reference_images=[cat, yarn])
+    kw = cfg.to_interaction_kwargs()
+    # Documented shape: N image items followed by exactly one text item.
+    assert [item["type"] for item in kw["input"]] == ["image", "image", "text"]
+    assert kw["input"][2]["text"] == "A cat playfully batting at a ball of yarn."
+    # Two subject references => reference_to_video (inferred).
+    assert cfg.task == "reference_to_video"
+
+
+def test_single_reference_image_infers_image_to_video(tmp_path):
+    ref = _write_png(tmp_path, "ref.png")
+    cfg = OmniGenerationConfig(prompt="make it move", reference_images=[ref])
+    assert cfg.task == "image_to_video"
+
+
+def test_legacy_reference_image_folds_into_list(tmp_path):
+    ref = _write_png(tmp_path, "ref.png")
+    cfg = OmniGenerationConfig(prompt="go", task="image_to_video", reference_image=ref)
+    assert cfg.reference_images == [ref]
+    kw = cfg.to_interaction_kwargs()
+    assert [item["type"] for item in kw["input"]] == ["image", "text"]
+
+
+def test_too_many_reference_images_rejected(tmp_path):
+    refs = [_write_png(tmp_path, f"r{i}.png") for i in range(4)]
+    with pytest.raises(ValueError, match="reference image"):
+        OmniGenerationConfig(prompt="x", reference_images=refs)
+
+
+def test_previous_interaction_id_infers_edit_task():
+    cfg = OmniGenerationConfig(prompt="make the violin invisible",
+                               previous_interaction_id="int_prev")
+    assert cfg.task == "edit"
+
+
+def test_validate_config_checks_all_reference_images_exist(tmp_path):
+    ok = _write_png(tmp_path, "ok.png")
+    missing = tmp_path / "missing.png"
+    cfg = OmniGenerationConfig(prompt="x", reference_images=[ok])
+    cfg.reference_images.append(missing)  # bypass __post_init__ to hit validate_config
+    client = OmniClient(api_key="test-key")
+    is_valid, error = client.validate_config(cfg)
+    assert is_valid is False
+    assert "missing.png" in error

--- a/tests/video/test_omni_client.py
+++ b/tests/video/test_omni_client.py
@@ -366,3 +366,28 @@ def test_task_sent_in_generation_config_reference_to_video(tmp_path):
     # Disambiguates subject references from a first-frame image (identical
     # input shapes otherwise).
     assert kw["generation_config"]["video_config"]["task"] == "reference_to_video"
+
+
+# --- delivery="uri" -----------------------------------------------------------
+
+def test_delivery_uri_in_response_format():
+    cfg = OmniGenerationConfig(prompt="a sunset", delivery="uri")
+    kw = cfg.to_interaction_kwargs()
+    assert kw["response_format"] == {
+        "type": "video", "aspect_ratio": "16:9", "delivery": "uri"
+    }
+
+
+def test_delivery_default_omits_key():
+    cfg = OmniGenerationConfig(prompt="a sunset")
+    assert "delivery" not in cfg.to_interaction_kwargs()["response_format"]
+
+
+def test_delivery_inline_omits_key():
+    cfg = OmniGenerationConfig(prompt="a sunset", delivery="inline")
+    assert "delivery" not in cfg.to_interaction_kwargs()["response_format"]
+
+
+def test_invalid_delivery_rejected():
+    with pytest.raises(ValueError, match="delivery"):
+        OmniGenerationConfig(prompt="x", delivery="carrier-pigeon")


### PR DESCRIPTION
## Summary

Brings the Gemini Omni video integration to full parity with the official docs (https://ai.google.dev/gemini-api/docs/omni), closing every gap found in a feature audit:

- **Multiple reference images** — `OmniGenerationConfig.reference_images` (up to 3) builds the documented `[{image}, {image}, {text}]` content list; 2+ refs infer the `reference_to_video` task. Legacy singular `reference_image` folds in for back-compat (GUI unchanged).
- **Edit your own videos** — `input_video` uploads via the Files API (poll `PROCESSING`→`ACTIVE`), then passes `{"type": "document", "uri": ...}` as the first input item. Upload failure fails cleanly before any `interactions.create` call.
- **Explicit task** — every request now sends `generation_config={"video_config": {"task": ...}}`, disambiguating first-frame vs subject-reference images.
- **URI delivery** — `delivery="uri"` adds `"delivery": "uri"` to `response_format` for large/720p clips (download path already existed).
- **CLI** — new Omni-only flags `--refine-from INTERACTION_ID` (conversational edit chained on the sidecar's `operation_id`), `--edit-video PATH`, `--delivery {inline,uri}`; `--ref-image` now up to 3 for Omni. Veo rejects all three with clear exit-2 errors.
- **Docs** — imageai-cli skill + CLI guide now cover video generation, including Omni prompt-level features (role tags `<FIRST_FRAME>`/`<IMAGE_REF_N>`, `[# Sources ...]`, timecode timing, audio direction, on-screen text) and Omni's unsupported list.
- **Version** 0.39.0 → 0.40.0 (constants, README, CHANGELOG).

## Process

Plan: `Plans/2026-07-01-omni-docs-parity.md` (committed first). 8 TDD tasks, each implemented by a fresh subagent and gated by a spec+quality review; final whole-branch review (Opus) passed with fixes applied (changelog accuracy, request-trace logging of `reference_images`/`delivery`, skill trigger description).

## Test plan

- [x] Full suite: 472 passed (was 440 baseline; ~32 new tests covering multi-ref shape/inference, upload success/failure short-circuit, delivery variants, CLI mappings and Veo guards)
- [x] All tests mock the SDK — no network
- [ ] Follow-up: one live `--delivery uri` smoke test with a real Google key (opt-in flag; fails cleanly if the URI shape ever changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ayVJ2uEjUBgdv4thVHgnG