### PR TITLE
fix: Custom Styles post-merge follow-ups (issue #37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.0] - 2026-07-27
+
+### Added
+- Style Manager polish: the style list now shows each style's exemplar as a thumbnail, drag-and-drop image files straight onto the reference grid, and the dialog remembers its size and your vision LLM provider/model between sessions.
+- Styles analyzed in the GUI now record their provenance (which LLM, when, from how many images), matching CLI-created styles.
+- Creating or editing a style now refreshes the style picker on every surface (Generate tab, video workspace), not just the one that opened the manager.
+
+### Fixed
+- Smart merge no longer freezes the GUI for up to ~14 seconds when the LLM is flaky — it makes a single attempt and falls back to plain concatenation immediately.
+- `--style-create` works without PySide6 installed: the LLM response parser moved into `core`, so CLI-only environments no longer die with a misleading "No module named 'PySide6'".
+- `styles.json` is written atomically (temp file + rename), so a crash mid-save can no longer truncate the index of all styles.
+- Hardened handling of malformed or hostile style records: non-string reference entries no longer raise, filenames containing ".." (e.g. `a..b.jpg`) are accepted while traversal is still rejected, deleting a record with an unsafe id cleans the index without touching the filesystem, and the manager dialog skips unsafe paths in its thumbnail and duplicate flows.
+- Closing the Style Manager while an analysis is running no longer leaks the app-wide input blocker (which could spam errors and eventually crash the app).
+- The `--video` CLI sidecar now records `style_applied` as the same structured block image sidecars use (id, name, smart-merge flag, exemplar counts) instead of a bare id string.
+
+### Changed
+- Test coverage for the remaining Custom Styles gaps: `--batch --style` submissions, the live Analyze flow through a real worker thread, and orphan-worker detach on dialog close (issue #37).
+
 ## [0.41.0] - 2026-07-26
 
 ### Added

--- a/Docs/CustomStyles.md
+++ b/Docs/CustomStyles.md
@@ -178,12 +178,12 @@ Styles live outside the repo, in your platform's ImageAI user data directory:
 Inside: `styles.json` (the index of all styles) and one `<style-id>/refs/`
 folder per style holding its downscaled reference images.
 
-Every generated image's `.json` sidecar records a `style_applied` block
-(style id/name, whether smart merge was used, how many exemplars were
-attached/dropped) when a style was used — so you can always tell which style
-produced a given image. The **prompt shown in History** is always your
-original, un-styled prompt; the style is provenance metadata, not something
-that rewrites what you typed.
+Every generated image's `.json` sidecar — and every `--video` CLI sidecar —
+records the same `style_applied` block (style id/name, whether smart merge
+was used, how many exemplars were attached/dropped) when a style was used —
+so you can always tell which style produced a given output. The **prompt
+shown in History** is always your original, un-styled prompt; the style is
+provenance metadata, not something that rewrites what you typed.
 
 ## Troubleshooting
 

--- a/Plans/2026-07-27-custom-styles-followups-plan.md
+++ b/Plans/2026-07-27-custom-styles-followups-plan.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
-**Last Updated:** 2026-07-27 09:05
+**Last Updated:** 2026-07-27 09:20
 
 **Goal:** Close every reviewer-adjudicated follow-up from PR #35 (issue #37): robustness (GUI-thread freeze cap, core/gui decoupling, atomic index write, path-safety guards), consistency (provenance shape, cross-surface picker refresh, dialog polish, drag-and-drop), and the two test-coverage gaps.
 
@@ -668,10 +668,10 @@ def test_dialog_close_detaches_running_worker(qapp, store, tmp_path, monkeypatch
 
 ### Task 10: Full suite, version bump, PR, issue bookkeeping
 
-- [ ] **Step 1:** Full suite: `QT_QPA_PLATFORM=offscreen /mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest` → must be all green.
-- [ ] **Step 2:** Version bump via the tool (never hand-edit): dry-run `python3 ~/.claude/skills/version-manager/version_tool.py --repo /mnt/d/Documents/Code/GitHub/ImageAI release minor`, write prose notes to a temp file, then `release minor --notes FILE --apply`; commit as the tool directs.
-- [ ] **Step 3:** Update this plan file's checkboxes + push branch; open PR titled `fix: Custom Styles post-merge follow-ups (issue #37)` with a body mapping each issue checkbox to its commit; `Closes #37` deliberately omitted — label `test` and comment instead (close after verification per house rules).
-- [ ] **Step 4:** Comment on issue #37 summarizing what shipped (note the smart-merge fix took the adjudicated "cap retries" candidate; full GenWorker move remains possible later), add label `test`, credit Claude Fable 5.
+- [x] **Step 1:** Full suite: `QT_QPA_PLATFORM=offscreen /mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest` → must be all green.
+- [x] **Step 2:** Version bump via the tool (never hand-edit): dry-run `python3 ~/.claude/skills/version-manager/version_tool.py --repo /mnt/d/Documents/Code/GitHub/ImageAI release minor`, write prose notes to a temp file, then `release minor --notes FILE --apply`; commit as the tool directs.
+- [x] **Step 3:** Update this plan file's checkboxes + push branch; open PR titled `fix: Custom Styles post-merge follow-ups (issue #37)` with a body mapping each issue checkbox to its commit; `Closes #37` deliberately omitted — label `test` and comment instead (close after verification per house rules).
+- [x] **Step 4:** Comment on issue #37 summarizing what shipped (note the smart-merge fix took the adjudicated "cap retries" candidate; full GenWorker move remains possible later), add label `test`, credit Claude Fable 5.
 
 ## Self-Review Notes
 

--- a/Plans/2026-07-27-custom-styles-followups-plan.md
+++ b/Plans/2026-07-27-custom-styles-followups-plan.md
@@ -1,8 +1,8 @@
 # Custom Styles Follow-ups (Issue #37) Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
-**Last Updated:** 2026-07-27 07:23
+**Last Updated:** 2026-07-27 09:05
 
 **Goal:** Close every reviewer-adjudicated follow-up from PR #35 (issue #37): robustness (GUI-thread freeze cap, core/gui decoupling, atomic index write, path-safety guards), consistency (provenance shape, cross-surface picker refresh, dialog polish, drag-and-drop), and the two test-coverage gaps.
 
@@ -34,7 +34,7 @@ Fixes: PySide6-less CLI `--style-create` fails with misleading `No module named 
 **Interfaces:**
 - Produces: `core.llm_parsing.LLMResponseParser` — identical static API (`parse_json_response(content, expected_type)`, `extract_text_prompts`, `create_fallback_prompts`). `gui.llm_utils.LLMResponseParser` keeps working as an alias.
 
-- [ ] **Step 1: Create `core/llm_parsing.py`** — move the `LLMResponseParser` class verbatim from `gui/llm_utils.py:15-124` with module header:
+- [x] **Step 1: Create `core/llm_parsing.py`** — move the `LLMResponseParser` class verbatim from `gui/llm_utils.py:15-124` with module header:
 
 ```python
 """LLM response parsing shared by core pipelines and GUI dialogs.
@@ -55,15 +55,15 @@ class LLMResponseParser:
     ...  # class body verbatim from gui/llm_utils.py:15-124
 ```
 
-- [ ] **Step 2: Slim `gui/llm_utils.py`** — delete the class and the now-unused `import json` / `import re`; add near the top:
+- [x] **Step 2: Slim `gui/llm_utils.py`** — delete the class and the now-unused `import json` / `import re`; add near the top:
 
 ```python
 from core.llm_parsing import LLMResponseParser  # noqa: F401 — back-compat re-export
 ```
 
-- [ ] **Step 3: Repoint the six core import sites** listed above to `from core.llm_parsing import LLMResponseParser` (they are all function-local imports except `core/prompt_enhancer_llm.py:13`, which is top-level).
+- [x] **Step 3: Repoint the six core import sites** listed above to `from core.llm_parsing import LLMResponseParser` (they are all function-local imports except `core/prompt_enhancer_llm.py:13`, which is top-level).
 
-- [ ] **Step 4: Write the failing test** — `tests/styles/test_core_no_gui.py`:
+- [x] **Step 4: Write the failing test** — `tests/styles/test_core_no_gui.py`:
 
 ```python
 """Style pipeline must import and parse without PySide6 (issue #37)."""
@@ -90,8 +90,8 @@ def test_style_pipeline_importable_without_pyside6():
     assert "OK" in out.stdout
 ```
 
-- [ ] **Step 5: Run** `.venv_linux/bin/python -m pytest tests/styles/test_core_no_gui.py -v` → PASS (fails before Step 1-3 with ImportError in stderr). Then the full styles dir → PASS.
-- [ ] **Step 6: Commit** `fix(styles): move LLMResponseParser to core so CLI paths need no PySide6`
+- [x] **Step 5: Run** `.venv_linux/bin/python -m pytest tests/styles/test_core_no_gui.py -v` → PASS (fails before Step 1-3 with ImportError in stderr). Then the full styles dir → PASS.
+- [x] **Step 6: Commit** `fix(styles): move LLMResponseParser to core so CLI paths need no PySide6`
 
 ### Task 2: StyleStore hardening (atomic index write, `_is_safe_rel` fixes, defensive delete)
 
@@ -99,7 +99,7 @@ def test_style_pipeline_importable_without_pyside6():
 - Modify: `core/styles/store.py:29-31` (`_is_safe_rel`), `:56-59` (`_write_index`), `:113-123` (`delete`)
 - Test: `tests/styles/test_store.py`
 
-- [ ] **Step 1: Write failing tests** (append to `tests/styles/test_store.py`):
+- [x] **Step 1: Write failing tests** (append to `tests/styles/test_store.py`):
 
 ```python
 def test_write_index_survives_midwrite_failure(tmp_path, monkeypatch):
@@ -149,8 +149,8 @@ def test_delete_unsafe_id_purges_index_without_touching_disk(tmp_path):
 
 (`test_store.py` already imports `json`, `pytest`, `Style`, `StyleStore` — verify and add missing imports.)
 
-- [ ] **Step 2: Run them** → FAIL (TypeError / corrupted index / ValueError respectively).
-- [ ] **Step 3: Implement.** In `core/styles/store.py` add `import os` and replace the three functions:
+- [x] **Step 2: Run them** → FAIL (TypeError / corrupted index / ValueError respectively).
+- [x] **Step 3: Implement.** In `core/styles/store.py` add `import os` and replace the three functions:
 
 ```python
 def _is_safe_rel(rel) -> bool:
@@ -192,8 +192,8 @@ def _is_safe_rel(rel) -> bool:
         return True
 ```
 
-- [ ] **Step 4: Run** `tests/styles/test_store.py tests/styles/test_store_zip.py -v` → PASS.
-- [ ] **Step 5: Commit** `fix(styles): atomic styles.json write, non-str/dotdot _is_safe_rel fixes, defensive delete`
+- [x] **Step 4: Run** `tests/styles/test_store.py tests/styles/test_store_zip.py -v` → PASS.
+- [x] **Step 5: Commit** `fix(styles): atomic styles.json write, non-str/dotdot _is_safe_rel fixes, defensive delete`
 
 ### Task 3: Cap smart-merge retries on the GUI seam (UI-freeze fix)
 
@@ -206,7 +206,7 @@ Issue-adjudicated candidate: "cap retries for that one call". The freeze is `ana
 **Interfaces:**
 - Produces: `build_completion_fn(config, provider=None, model=None, max_retries=None)`; `analyze_image(..., max_retries: int = 3)`. Defaults preserve current behavior everywhere else.
 
-- [ ] **Step 1: Write failing tests.** Append to `tests/styles/test_analyzer_service.py`:
+- [x] **Step 1: Write failing tests.** Append to `tests/styles/test_analyzer_service.py`:
 
 ```python
 def test_analyze_image_forwards_max_retries(monkeypatch):
@@ -246,8 +246,8 @@ def test_apply_style_for_surface_caps_smart_merge_retries(monkeypatch):
 
 (Adapt `_style()` to however `test_applicator.py` builds a Style; keep its conventions.)
 
-- [ ] **Step 2: Run** → FAIL (unexpected kwarg `max_retries`).
-- [ ] **Step 3: Implement.** `analyze_image`: add `max_retries: int = 3` to the signature and pass `max_retries=max_retries` in the `_retry_with_backoff(...)` call (replacing the literal `3`). `build_completion_fn`: add `max_retries=None` param; inside `fn`:
+- [x] **Step 2: Run** → FAIL (unexpected kwarg `max_retries`).
+- [x] **Step 3: Implement.** `analyze_image`: add `max_retries: int = 3` to the signature and pass `max_retries=max_retries` in the `_retry_with_backoff(...)` call (replacing the literal `3`). `build_completion_fn`: add `max_retries=None` param; inside `fn`:
 
 ```python
     def fn(messages):
@@ -263,8 +263,8 @@ def test_apply_style_for_surface_caps_smart_merge_retries(monkeypatch):
 `apply_style_for_surface`: change the build call to
 `build_completion_fn(config, max_retries=0)` with a comment: runs on the GUI thread — one transient failure degrades to plain concat instead of freezing the UI for the ~14s retry backoff.
 
-- [ ] **Step 4: Run** `tests/styles/ -v` → PASS.
-- [ ] **Step 5: Commit** `fix(styles): cap GUI smart-merge to a single LLM attempt (no 14s backoff freeze)`
+- [x] **Step 4: Run** `tests/styles/ -v` → PASS.
+- [x] **Step 5: Commit** `fix(styles): cap GUI smart-merge to a single LLM attempt (no 14s backoff freeze)`
 
 ### Task 4: Unify `style_applied` provenance shape (video CLI → dict)
 
@@ -273,7 +273,7 @@ def test_apply_style_for_surface_caps_smart_merge_retries(monkeypatch):
 - Modify: `Docs/CustomStyles.md:181` area
 - Test: `tests/styles/test_cli_style_video.py:109-126`
 
-- [ ] **Step 1: Update the two tests** — in `test_run_video_cmd_adds_style_applied_to_payload` replace the assert with:
+- [x] **Step 1: Update the two tests** — in `test_run_video_cmd_adds_style_applied_to_payload` replace the assert with:
 
 ```python
     assert data["style_applied"]["style_id"] == "water"
@@ -283,7 +283,7 @@ def test_apply_style_for_surface_caps_smart_merge_retries(monkeypatch):
 
 (`test_run_video_cmd_no_style_omits_style_applied` stays as-is.) Run → FAIL (payload is the bare string `"water"`).
 
-- [ ] **Step 2: Implement** in `cli/commands/video.py`: initialize `style_meta = None` next to `style = None`; in the style branch capture the full result:
+- [x] **Step 2: Implement** in `cli/commands/video.py`: initialize `style_meta = None` next to `style = None`; in the style branch capture the full result:
 
 ```python
         style = _resolve_style(args)
@@ -298,9 +298,9 @@ def test_apply_style_for_surface_caps_smart_merge_retries(monkeypatch):
 
 and at payload time replace `payload["style_applied"] = style.id` with `payload["style_applied"] = style_meta` (guard stays `if style is not None:`).
 
-- [ ] **Step 3: Update `Docs/CustomStyles.md`** provenance paragraph: state that image sidecars **and** `--video` CLI sidecars record the same `style_applied` block (id/name, smart-merge flag, exemplar counts).
-- [ ] **Step 4: Run** `tests/styles/test_cli_style_video.py -v` → PASS.
-- [ ] **Step 5: Commit** `fix(cli): video sidecar style_applied uses the same dict shape as image sidecars`
+- [x] **Step 3: Update `Docs/CustomStyles.md`** provenance paragraph: state that image sidecars **and** `--video` CLI sidecars record the same `style_applied` block (id/name, smart-merge flag, exemplar counts).
+- [x] **Step 4: Run** `tests/styles/test_cli_style_video.py -v` → PASS.
+- [x] **Step 5: Commit** `fix(cli): video sidecar style_applied uses the same dict shape as image sidecars`
 
 ### Task 5: `_is_safe_rel` guards in Style Manager thumbnail + duplicate paths
 
@@ -308,7 +308,7 @@ and at payload time replace `payload["style_applied"] = style.id` with `payload[
 - Modify: `gui/styles/style_manager_dialog.py:222-233` (`_on_selected`), `:293-299` (`_on_duplicate`)
 - Test: `tests/styles/test_style_manager_dialog.py`
 
-- [ ] **Step 1: Write failing test:**
+- [x] **Step 1: Write failing test:**
 
 ```python
 def test_unsafe_ref_entries_are_skipped_in_ui(qapp, store):
@@ -323,8 +323,8 @@ def test_unsafe_ref_entries_are_skipped_in_ui(qapp, store):
     assert dup.reference_images == []
 ```
 
-- [ ] **Step 2: Run** → FAIL (`TypeError` from `base / 7` or the unsafe item appears).
-- [ ] **Step 3: Implement.** Add `_is_safe_rel` to the `from core.styles.store import ...` line. In `_on_selected`'s loop over `s.reference_images` insert first:
+- [x] **Step 2: Run** → FAIL (`TypeError` from `base / 7` or the unsafe item appears).
+- [x] **Step 3: Implement.** Add `_is_safe_rel` to the `from core.styles.store import ...` line. In `_on_selected`'s loop over `s.reference_images` insert first:
 
 ```python
         for rel in s.reference_images:
@@ -336,7 +336,7 @@ def test_unsafe_ref_entries_are_skipped_in_ui(qapp, store):
 
 In `_on_duplicate`'s loop, same guard before `src = self.store.style_dir(s.id) / rel`.
 
-- [ ] **Step 4: Run dialog tests** → PASS. **Step 5: Commit** `fix(gui): style manager skips unsafe reference paths in thumbnail/duplicate paths`
+- [x] **Step 4: Run dialog tests** → PASS. **Step 5: Commit** `fix(gui): style manager skips unsafe reference paths in thumbnail/duplicate paths`
 
 ### Task 6: Cross-surface picker refresh when the Style Manager closes
 
@@ -344,7 +344,7 @@ In `_on_duplicate`'s loop, same guard before `src = self.store.style_dir(s.id) /
 - Modify: `gui/styles/style_picker.py`
 - Test: `tests/styles/test_style_picker.py`
 
-- [ ] **Step 1: Write failing test** (reuse the file's `FakeConfig`; import `Style`, `StyleStore`):
+- [x] **Step 1: Write failing test** (reuse the file's `FakeConfig`; import `Style`, `StyleStore`):
 
 ```python
 def test_manager_close_refreshes_all_pickers(qapp, tmp_path, monkeypatch):
@@ -366,8 +366,8 @@ def test_manager_close_refreshes_all_pickers(qapp, tmp_path, monkeypatch):
     assert b.combo.findData("fresh") >= 0   # the OTHER picker refreshed too
 ```
 
-- [ ] **Step 2: Run** → FAIL (`b` still lacks "fresh").
-- [ ] **Step 3: Implement** in `style_picker.py`: add `import weakref`; module-level `_PICKERS = weakref.WeakSet()`; in `__init__` (before the final `self.refresh()`): `_PICKERS.add(self)`; replace `_open_manager`'s tail:
+- [x] **Step 2: Run** → FAIL (`b` still lacks "fresh").
+- [x] **Step 3: Implement** in `style_picker.py`: add `import weakref`; module-level `_PICKERS = weakref.WeakSet()`; in `__init__` (before the final `self.refresh()`): `_PICKERS.add(self)`; replace `_open_manager`'s tail:
 
 ```python
     def _open_manager(self) -> None:
@@ -381,7 +381,7 @@ def test_manager_close_refreshes_all_pickers(qapp, tmp_path, monkeypatch):
                 pass          # underlying C++ widget already deleted
 ```
 
-- [ ] **Step 4: Run** `tests/styles/test_style_picker.py -v` → PASS. **Step 5: Commit** `feat(gui): refresh style pickers on every surface when the Style Manager closes`
+- [x] **Step 4: Run** `tests/styles/test_style_picker.py -v` → PASS. **Step 5: Commit** `feat(gui): refresh style pickers on every surface when the Style Manager closes`
 
 ### Task 7: Dialog polish (design §6): list thumbnails, geometry + LLM-combo persistence, GUI `source` provenance
 
@@ -389,7 +389,7 @@ def test_manager_close_refreshes_all_pickers(qapp, tmp_path, monkeypatch):
 - Modify: `gui/styles/style_manager_dialog.py` (`__init__`, `_build_ui`, `_load_styles`, `_on_selected`, `_on_analyze`, `_on_analysis_done`, `_save_current`, `on_dialog_close`)
 - Test: `tests/styles/test_style_manager_dialog.py`
 
-- [ ] **Step 1: Write failing tests:**
+- [x] **Step 1: Write failing tests:**
 
 ```python
 def test_style_list_shows_exemplar_thumbnail(qapp, store, tmp_path):
@@ -426,8 +426,8 @@ def test_gui_analysis_populates_source_on_save(qapp, store):
     assert src["image_count"] == 2 and src["created"]
 ```
 
-- [ ] **Step 2: Run** → FAIL.
-- [ ] **Step 3: Implement:**
+- [x] **Step 2: Run** → FAIL.
+- [x] **Step 3: Implement:**
   - Imports: add `QSize` to the `PySide6.QtCore` import; add `from datetime import datetime`.
   - `_build_ui`: after creating `self.style_list` add `self.style_list.setIconSize(QSize(48, 48))`.
   - `_load_styles` loop, after `item = QListWidgetItem(s.name)`:
@@ -475,7 +475,7 @@ def test_gui_analysis_populates_source_on_save(qapp, store):
                 self._pending_source = None
 ```
 
-- [ ] **Step 4: Run dialog tests** → PASS. **Step 5: Commit** `feat(gui): style manager polish — list thumbnails, geometry/LLM persistence, source provenance`
+- [x] **Step 4: Run dialog tests** → PASS. **Step 5: Commit** `feat(gui): style manager polish — list thumbnails, geometry/LLM persistence, source provenance`
 
 ### Task 8: Drag-and-drop onto the refs grid
 
@@ -483,7 +483,7 @@ def test_gui_analysis_populates_source_on_save(qapp, store):
 - Modify: `gui/styles/style_manager_dialog.py` (new `_RefsListWidget` + helper; `_build_ui` uses it; `_on_add_folder` reuses the ext set)
 - Test: `tests/styles/test_style_manager_dialog.py`
 
-- [ ] **Step 1: Write failing tests:**
+- [x] **Step 1: Write failing tests:**
 
 ```python
 def test_image_paths_from_mime_filters_to_local_images(qapp, tmp_path):
@@ -507,8 +507,8 @@ def test_refs_grid_accepts_drops_and_adds(qapp, store, tmp_path):
     assert store.get("water").reference_images  # image landed in the store
 ```
 
-- [ ] **Step 2: Run** → FAIL (no `_image_paths_from_mime` / `files_dropped`).
-- [ ] **Step 3: Implement.** Module-level, above the dialog class:
+- [x] **Step 2: Run** → FAIL (no `_image_paths_from_mime` / `files_dropped`).
+- [x] **Step 3: Implement.** Module-level, above the dialog class:
 
 ```python
 _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
@@ -559,14 +559,14 @@ class _RefsListWidget(QListWidget):
 
 In `_build_ui`: `self.refs_list = _RefsListWidget()`; in the wiring block: `self.refs_list.files_dropped.connect(self._add_paths)`. `_on_add_folder`: replace its inline `exts = {...}` with `_IMAGE_EXTS`.
 
-- [ ] **Step 4: Run dialog tests** → PASS. **Step 5: Commit** `feat(gui): drag-and-drop image files onto the Style Manager refs grid`
+- [x] **Step 4: Run dialog tests** → PASS. **Step 5: Commit** `feat(gui): drag-and-drop image files onto the Style Manager refs grid`
 
 ### Task 9: Coverage gaps — `--batch --style`, live Analyze click, orphan detach on real close
 
 **Files:**
 - Test: `tests/styles/test_cli_style_generation.py`, `tests/styles/test_style_manager_dialog.py`
 
-- [ ] **Step 1: `--batch` + `--style` test.** In `_fake_provider()` add `prov.submit_batch_job.return_value = "job-123"`. Append:
+- [x] **Step 1: `--batch` + `--style` test.** In `_fake_provider()` add `prov.submit_batch_job.return_value = "job-123"`. Append:
 
 ```python
 def test_batch_with_style_is_text_only(tmp_path, capsys):
@@ -589,7 +589,7 @@ def test_batch_with_style_is_text_only(tmp_path, capsys):
     assert "text only" in capsys.readouterr().err
 ```
 
-- [ ] **Step 2: Live Analyze-click + orphan tests.** Append to `test_style_manager_dialog.py`:
+- [x] **Step 2: Live Analyze-click + orphan tests.** Append to `test_style_manager_dialog.py`:
 
 ```python
 class _FakeService:
@@ -663,8 +663,8 @@ def test_dialog_close_detaches_running_worker(qapp, store, tmp_path, monkeypatch
     assert _wait_until(qapp, lambda: w not in smd._ORPHAN_WORKERS)
 ```
 
-- [ ] **Step 3: Run** the two files → PASS (Task 7 must land first for `_analysis_source`).
-- [ ] **Step 4: Commit** `test(styles): cover --batch --style, live Analyze flow, and orphan-worker detach`
+- [x] **Step 3: Run** the two files → PASS (Task 7 must land first for `_analysis_source`).
+- [x] **Step 4: Commit** `test(styles): cover --batch --style, live Analyze flow, and orphan-worker detach`
 
 ### Task 10: Full suite, version bump, PR, issue bookkeeping
 

--- a/Plans/2026-07-27-custom-styles-followups-plan.md
+++ b/Plans/2026-07-27-custom-styles-followups-plan.md
@@ -1,0 +1,680 @@
+# Custom Styles Follow-ups (Issue #37) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Last Updated:** 2026-07-27 07:23
+
+**Goal:** Close every reviewer-adjudicated follow-up from PR #35 (issue #37): robustness (GUI-thread freeze cap, core/gui decoupling, atomic index write, path-safety guards), consistency (provenance shape, cross-surface picker refresh, dialog polish, drag-and-drop), and the two test-coverage gaps.
+
+**Architecture:** All changes stay inside the existing Custom Styles architecture (`core/styles/` + `gui/styles/` + CLI seams). The one relocation is `LLMResponseParser` moving from `gui/llm_utils.py` to a new `core/llm_parsing.py` (gui re-exports it for back-compat) so no `core/` module imports `gui/`.
+
+**Tech Stack:** Python 3.12 (`.venv_linux`), PySide6 (offscreen in tests), pytest.
+
+## Global Constraints
+
+- No `cd`; absolute paths only (AGENTS.md §6). Repo root: `/mnt/d/Documents/Code/GitHub/ImageAI`.
+- Run tests with the Linux venv: `/mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest` (pytest.ini limits collection to `tests/`).
+- GUI tests: offscreen — prefix with `QT_QPA_PLATFORM=offscreen`.
+- Conventional Commits; never hand-edit version numbers or changelog headings (version-manager tool owns both).
+- Branch: `fix/custom-styles-followups` cut from `origin/main`; the plan file is committed in the branch's first commit.
+- The `style_applied` sidecar dict shape is: `{"style_id", "style_name", "smart_merge_used", "exemplars_attached", "exemplars_dropped"}` (from `apply_style()` meta, `core/styles/applicator.py:115-117`).
+
+---
+
+### Task 1: Relocate `LLMResponseParser` to core (`core/llm_parsing.py`)
+
+Fixes: PySide6-less CLI `--style-create` fails with misleading `No module named 'PySide6'`. Root cause is `core` importing `gui.llm_utils`; per the systemic-root-cause rule, ALL core importers move over, not just `core/styles`.
+
+**Files:**
+- Create: `core/llm_parsing.py`
+- Modify: `gui/llm_utils.py` (delete class, re-export from core)
+- Modify: `core/styles/analyzer.py:95,133`, `core/styles/applicator.py:89`, `core/prompt_enhancer_llm.py:13`, `core/layout/designer.py:238`, `core/layout/prompt_helper.py:113`
+- Test: `tests/styles/test_core_no_gui.py` (new)
+
+**Interfaces:**
+- Produces: `core.llm_parsing.LLMResponseParser` — identical static API (`parse_json_response(content, expected_type)`, `extract_text_prompts`, `create_fallback_prompts`). `gui.llm_utils.LLMResponseParser` keeps working as an alias.
+
+- [ ] **Step 1: Create `core/llm_parsing.py`** — move the `LLMResponseParser` class verbatim from `gui/llm_utils.py:15-124` with module header:
+
+```python
+"""LLM response parsing shared by core pipelines and GUI dialogs.
+
+Lives in core (no Qt imports) so PySide6-less CLI paths — e.g.
+--style-create — can use it. gui/llm_utils.py re-exports it for
+back-compat with existing dialog imports.
+"""
+import json
+import logging
+import re
+from typing import Any, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class LLMResponseParser:
+    ...  # class body verbatim from gui/llm_utils.py:15-124
+```
+
+- [ ] **Step 2: Slim `gui/llm_utils.py`** — delete the class and the now-unused `import json` / `import re`; add near the top:
+
+```python
+from core.llm_parsing import LLMResponseParser  # noqa: F401 — back-compat re-export
+```
+
+- [ ] **Step 3: Repoint the six core import sites** listed above to `from core.llm_parsing import LLMResponseParser` (they are all function-local imports except `core/prompt_enhancer_llm.py:13`, which is top-level).
+
+- [ ] **Step 4: Write the failing test** — `tests/styles/test_core_no_gui.py`:
+
+```python
+"""Style pipeline must import and parse without PySide6 (issue #37)."""
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_style_pipeline_importable_without_pyside6():
+    code = (
+        "import sys\n"
+        "sys.modules['PySide6'] = None\n"  # any 'import PySide6' now raises
+        "from core.styles.analyzer import parse_descriptor\n"
+        "from core.styles.applicator import apply_style\n"
+        "d = parse_descriptor('{\"summary\": \"s\"}')\n"
+        "assert d and d['summary'] == 's'\n"
+        "print('OK')\n"
+    )
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True,
+                         text=True, cwd=REPO)
+    assert out.returncode == 0, out.stderr
+    assert "OK" in out.stdout
+```
+
+- [ ] **Step 5: Run** `.venv_linux/bin/python -m pytest tests/styles/test_core_no_gui.py -v` → PASS (fails before Step 1-3 with ImportError in stderr). Then the full styles dir → PASS.
+- [ ] **Step 6: Commit** `fix(styles): move LLMResponseParser to core so CLI paths need no PySide6`
+
+### Task 2: StyleStore hardening (atomic index write, `_is_safe_rel` fixes, defensive delete)
+
+**Files:**
+- Modify: `core/styles/store.py:29-31` (`_is_safe_rel`), `:56-59` (`_write_index`), `:113-123` (`delete`)
+- Test: `tests/styles/test_store.py`
+
+- [ ] **Step 1: Write failing tests** (append to `tests/styles/test_store.py`):
+
+```python
+def test_write_index_survives_midwrite_failure(tmp_path, monkeypatch):
+    store = StyleStore(base_dir=tmp_path)
+    store.save(Style(id="a", name="A"))
+    original = store.index_path.read_text()
+    monkeypatch.setattr("core.styles.store.json.dump",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")))
+    with pytest.raises(OSError):
+        store.save(Style(id="b", name="B"))
+    assert store.index_path.read_text() == original  # old index intact
+
+
+def test_is_safe_rel_non_string_entries(tmp_path):
+    from core.styles.store import _is_safe_rel
+    assert _is_safe_rel(None) is False
+    assert _is_safe_rel(7) is False
+    assert _is_safe_rel(["refs/a.jpg"]) is False
+
+
+def test_is_safe_rel_allows_dotdot_inside_filename(tmp_path):
+    from core.styles.store import _is_safe_rel
+    assert _is_safe_rel("refs/a..b.jpg") is True     # legit filename
+    assert _is_safe_rel("refs/..") is False          # traversal
+    assert _is_safe_rel("refs/.") is False
+    assert _is_safe_rel("refs/../x.jpg") is False    # separator: regex rejects
+
+
+def test_resolve_refs_skips_non_string_entries(tmp_path):
+    store = StyleStore(base_dir=tmp_path)
+    s = Style(id="a", name="A", reference_images=[7, "refs/0001.jpg"])
+    assert store.resolve_refs(s) == []  # no TypeError; both skipped/missing
+
+
+def test_delete_unsafe_id_purges_index_without_touching_disk(tmp_path):
+    store = StyleStore(base_dir=tmp_path)
+    store.save(Style(id="good", name="Good"))
+    # inject a malformed record with a traversal id directly into the index
+    raw = json.loads(store.index_path.read_text())
+    raw["styles"].append({"id": "../evil", "name": "Evil"})
+    store.index_path.write_text(json.dumps(raw))
+    assert store.delete("../evil") is True        # no ValueError
+    assert store.get("good") is not None
+    ids = [r["id"] for r in json.loads(store.index_path.read_text())["styles"]]
+    assert "../evil" not in ids
+```
+
+(`test_store.py` already imports `json`, `pytest`, `Style`, `StyleStore` — verify and add missing imports.)
+
+- [ ] **Step 2: Run them** → FAIL (TypeError / corrupted index / ValueError respectively).
+- [ ] **Step 3: Implement.** In `core/styles/store.py` add `import os` and replace the three functions:
+
+```python
+def _is_safe_rel(rel) -> bool:
+    """True for 'refs/<plain-basename>' entries — no separators, no traversal.
+
+    Accepts only str (malformed index records may hold ints/lists). '..' is
+    fine INSIDE a filename (refs/a..b.jpg); only a whole-segment '.'/'..' is
+    traversal, and the regex already rejects further separators.
+    """
+    if not isinstance(rel, str) or not _SAFE_REL.match(rel):
+        return False
+    return rel[len("refs/"):] not in (".", "..")
+```
+
+```python
+    def _write_index(self, records: List[dict]) -> None:
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        tmp = self.index_path.parent / (self.index_path.name + ".tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump({"styles": records}, f, indent=2, ensure_ascii=False)
+        os.replace(tmp, self.index_path)  # atomic: never a half-written index
+```
+
+```python
+    def delete(self, style_id: str) -> bool:
+        records = self._read_index()
+        kept = [r for r in records if r.get("id") != style_id]
+        if len(kept) == len(records):
+            return False
+        self._write_index(kept)
+        if not isinstance(style_id, str) or not _SAFE_ID.match(style_id):
+            logger.warning(f"Deleted malformed style record {style_id!r} from "
+                           f"index; unsafe id, no directory removed")
+            return True
+        d = self.style_dir(style_id)
+        if d.exists():
+            shutil.rmtree(d, ignore_errors=True)
+        logger.info(f"Deleted style {style_id}")
+        return True
+```
+
+- [ ] **Step 4: Run** `tests/styles/test_store.py tests/styles/test_store_zip.py -v` → PASS.
+- [ ] **Step 5: Commit** `fix(styles): atomic styles.json write, non-str/dotdot _is_safe_rel fixes, defensive delete`
+
+### Task 3: Cap smart-merge retries on the GUI seam (UI-freeze fix)
+
+Issue-adjudicated candidate: "cap retries for that one call". The freeze is `analyze_image`'s retry backoff (2s+4s+8s = ~14s worst case, `core/video/prompt_engine.py:1009-1015`). GUI smart merge degrades to plain concat on failure anyway, so the GUI seam gets `max_retries=0`; CLI keeps full retries.
+
+**Files:**
+- Modify: `core/video/prompt_engine.py:939-1015` (`analyze_image` gains `max_retries=3` param), `core/styles/analyzer.py:221-257` (`build_completion_fn` gains `max_retries=None`), `core/styles/applicator.py:151-177` (`apply_style_for_surface` passes `max_retries=0`)
+- Test: `tests/styles/test_applicator.py`, `tests/styles/test_analyzer_service.py`
+
+**Interfaces:**
+- Produces: `build_completion_fn(config, provider=None, model=None, max_retries=None)`; `analyze_image(..., max_retries: int = 3)`. Defaults preserve current behavior everywhere else.
+
+- [ ] **Step 1: Write failing tests.** Append to `tests/styles/test_analyzer_service.py`:
+
+```python
+def test_analyze_image_forwards_max_retries(monkeypatch):
+    from core.video.prompt_engine import UnifiedLLMProvider
+    llm = UnifiedLLMProvider({})
+    captured = {}
+
+    def fake_retry(func, max_retries=3, **kw):
+        captured["max_retries"] = max_retries
+        return "ok"
+
+    monkeypatch.setattr(llm, "_retry_with_backoff", fake_retry)
+    out = llm.analyze_image(messages=[{"role": "user", "content": "hi"}],
+                            model="gpt-4o", max_retries=0)
+    assert out == "ok" and captured["max_retries"] == 0
+```
+
+Append to `tests/styles/test_applicator.py`:
+
+```python
+def test_apply_style_for_surface_caps_smart_merge_retries(monkeypatch):
+    from core.styles.applicator import apply_style_for_surface
+    captured = {}
+
+    def fake_build(config, provider=None, model=None, max_retries=None):
+        captured["max_retries"] = max_retries
+        return (lambda messages: '{"prompt": "merged"}'), "openai", "gpt-x"
+
+    monkeypatch.setattr("core.styles.analyzer.build_completion_fn", fake_build)
+    style = _style()  # reuse this file's existing Style factory/fixture
+    prompt, extra, meta = apply_style_for_surface(
+        "a fox", style, "google", "m", smart=True, config=object(),
+        store=None, existing_references=None)
+    assert captured["max_retries"] == 0
+    assert meta["smart_merge_used"] is True and prompt == "merged"
+```
+
+(Adapt `_style()` to however `test_applicator.py` builds a Style; keep its conventions.)
+
+- [ ] **Step 2: Run** → FAIL (unexpected kwarg `max_retries`).
+- [ ] **Step 3: Implement.** `analyze_image`: add `max_retries: int = 3` to the signature and pass `max_retries=max_retries` in the `_retry_with_backoff(...)` call (replacing the literal `3`). `build_completion_fn`: add `max_retries=None` param; inside `fn`:
+
+```python
+    def fn(messages):
+        logger.info(f"Style LLM request -> {full_model} "
+                    f"({sum(len(str(m)) for m in messages)} chars)")
+        call_kwargs = {"messages": messages, "model": full_model,
+                       "max_tokens": 1500}
+        if max_retries is not None:
+            call_kwargs["max_retries"] = max_retries
+        return llm.analyze_image(**call_kwargs)
+```
+
+`apply_style_for_surface`: change the build call to
+`build_completion_fn(config, max_retries=0)` with a comment: runs on the GUI thread — one transient failure degrades to plain concat instead of freezing the UI for the ~14s retry backoff.
+
+- [ ] **Step 4: Run** `tests/styles/ -v` → PASS.
+- [ ] **Step 5: Commit** `fix(styles): cap GUI smart-merge to a single LLM attempt (no 14s backoff freeze)`
+
+### Task 4: Unify `style_applied` provenance shape (video CLI → dict)
+
+**Files:**
+- Modify: `cli/commands/video.py:259-282`
+- Modify: `Docs/CustomStyles.md:181` area
+- Test: `tests/styles/test_cli_style_video.py:109-126`
+
+- [ ] **Step 1: Update the two tests** — in `test_run_video_cmd_adds_style_applied_to_payload` replace the assert with:
+
+```python
+    assert data["style_applied"]["style_id"] == "water"
+    assert data["style_applied"]["smart_merge_used"] is False
+    assert data["style_applied"]["exemplars_attached"] == 0
+```
+
+(`test_run_video_cmd_no_style_omits_style_applied` stays as-is.) Run → FAIL (payload is the bare string `"water"`).
+
+- [ ] **Step 2: Implement** in `cli/commands/video.py`: initialize `style_meta = None` next to `style = None`; in the style branch capture the full result:
+
+```python
+        style = _resolve_style(args)
+        if style is not None:
+            from core.styles import apply_style
+            styled = apply_style(
+                getattr(args, "prompt", None) or "", style, "", "")
+            args.prompt = styled.prompt
+            style_meta = styled.meta
+            _emit(f"Applying style '{style.name}' to prompt (text only)")
+```
+
+and at payload time replace `payload["style_applied"] = style.id` with `payload["style_applied"] = style_meta` (guard stays `if style is not None:`).
+
+- [ ] **Step 3: Update `Docs/CustomStyles.md`** provenance paragraph: state that image sidecars **and** `--video` CLI sidecars record the same `style_applied` block (id/name, smart-merge flag, exemplar counts).
+- [ ] **Step 4: Run** `tests/styles/test_cli_style_video.py -v` → PASS.
+- [ ] **Step 5: Commit** `fix(cli): video sidecar style_applied uses the same dict shape as image sidecars`
+
+### Task 5: `_is_safe_rel` guards in Style Manager thumbnail + duplicate paths
+
+**Files:**
+- Modify: `gui/styles/style_manager_dialog.py:222-233` (`_on_selected`), `:293-299` (`_on_duplicate`)
+- Test: `tests/styles/test_style_manager_dialog.py`
+
+- [ ] **Step 1: Write failing test:**
+
+```python
+def test_unsafe_ref_entries_are_skipped_in_ui(qapp, store):
+    s = store.get("water")
+    s.reference_images = ["../../evil.jpg", 7]
+    store.save(s)
+    dlg = _dialog(store)
+    dlg.style_list.setCurrentRow(0)          # must not raise
+    assert dlg.refs_list.count() == 0        # unsafe entries never listed
+    dlg._on_duplicate()                      # must not raise / copy them
+    dup = store.get_by_name("Water copy")
+    assert dup.reference_images == []
+```
+
+- [ ] **Step 2: Run** → FAIL (`TypeError` from `base / 7` or the unsafe item appears).
+- [ ] **Step 3: Implement.** Add `_is_safe_rel` to the `from core.styles.store import ...` line. In `_on_selected`'s loop over `s.reference_images` insert first:
+
+```python
+        for rel in s.reference_images:
+            if not _is_safe_rel(rel):
+                logger.warning(f"Style {s.id}: skipping unsafe reference "
+                               f"path {rel!r} in UI")
+                continue
+```
+
+In `_on_duplicate`'s loop, same guard before `src = self.store.style_dir(s.id) / rel`.
+
+- [ ] **Step 4: Run dialog tests** → PASS. **Step 5: Commit** `fix(gui): style manager skips unsafe reference paths in thumbnail/duplicate paths`
+
+### Task 6: Cross-surface picker refresh when the Style Manager closes
+
+**Files:**
+- Modify: `gui/styles/style_picker.py`
+- Test: `tests/styles/test_style_picker.py`
+
+- [ ] **Step 1: Write failing test** (reuse the file's `FakeConfig`; import `Style`, `StyleStore`):
+
+```python
+def test_manager_close_refreshes_all_pickers(qapp, tmp_path, monkeypatch):
+    from gui.styles.style_picker import StylePickerWidget
+    store = StyleStore(base_dir=tmp_path / "styles")
+    a = StylePickerWidget(FakeConfig(), "image"); a.set_store(store); a.refresh()
+    b = StylePickerWidget(FakeConfig(), "video"); b.set_store(store); b.refresh()
+
+    class FakeDlg:
+        def __init__(self, config, store=None, parent=None):
+            self._s = store
+        def exec(self):
+            self._s.save(Style(id="fresh", name="Fresh"))
+
+    monkeypatch.setattr(
+        "gui.styles.style_manager_dialog.StyleManagerDialog", FakeDlg)
+    a._open_manager()
+    assert a.combo.findData("fresh") >= 0
+    assert b.combo.findData("fresh") >= 0   # the OTHER picker refreshed too
+```
+
+- [ ] **Step 2: Run** → FAIL (`b` still lacks "fresh").
+- [ ] **Step 3: Implement** in `style_picker.py`: add `import weakref`; module-level `_PICKERS = weakref.WeakSet()`; in `__init__` (before the final `self.refresh()`): `_PICKERS.add(self)`; replace `_open_manager`'s tail:
+
+```python
+    def _open_manager(self) -> None:
+        from gui.styles.style_manager_dialog import StyleManagerDialog
+        dlg = StyleManagerDialog(self.config, store=self._store, parent=self)
+        dlg.exec()
+        for w in list(_PICKERS):
+            try:
+                w.refresh()   # every surface's picker, not just the opener
+            except RuntimeError:
+                pass          # underlying C++ widget already deleted
+```
+
+- [ ] **Step 4: Run** `tests/styles/test_style_picker.py -v` → PASS. **Step 5: Commit** `feat(gui): refresh style pickers on every surface when the Style Manager closes`
+
+### Task 7: Dialog polish (design §6): list thumbnails, geometry + LLM-combo persistence, GUI `source` provenance
+
+**Files:**
+- Modify: `gui/styles/style_manager_dialog.py` (`__init__`, `_build_ui`, `_load_styles`, `_on_selected`, `_on_analyze`, `_on_analysis_done`, `_save_current`, `on_dialog_close`)
+- Test: `tests/styles/test_style_manager_dialog.py`
+
+- [ ] **Step 1: Write failing tests:**
+
+```python
+def test_style_list_shows_exemplar_thumbnail(qapp, store, tmp_path):
+    from PIL import Image
+    s = store.get("water")
+    p = tmp_path / "t.png"
+    Image.new("RGB", (16, 16), (255, 0, 0)).save(p)
+    store.add_reference_images(s, [p])
+    s.exemplars = list(s.reference_images)
+    store.save(s)
+    dlg = _dialog(store)
+    assert not dlg.style_list.item(0).icon().isNull()
+
+
+def test_llm_combo_and_geometry_persist(qapp, store):
+    dlg = _dialog(store)
+    dlg.llm_provider_combo.setCurrentText("anthropic")
+    dlg.llm_model_combo.setCurrentText("claude-test")
+    dlg.reject()                       # real exit path -> on_dialog_close
+    dlg2 = _dialog(store)
+    assert dlg2.llm_provider_combo.currentText() == "anthropic"
+    assert dlg2.llm_model_combo.currentText() == "claude-test"
+
+
+def test_gui_analysis_populates_source_on_save(qapp, store):
+    dlg = _dialog(store)
+    dlg.style_list.setCurrentRow(0)
+    dlg._analysis_source = {"provider": "openai", "model": "gpt-test",
+                            "image_count": 2}
+    dlg._on_analysis_done({"descriptor": {"summary": "x"}, "prompt_text": "t"})
+    dlg._save_current()
+    src = store.get("water").source
+    assert src["provider"] == "openai" and src["model"] == "gpt-test"
+    assert src["image_count"] == 2 and src["created"]
+```
+
+- [ ] **Step 2: Run** → FAIL.
+- [ ] **Step 3: Implement:**
+  - Imports: add `QSize` to the `PySide6.QtCore` import; add `from datetime import datetime`.
+  - `_build_ui`: after creating `self.style_list` add `self.style_list.setIconSize(QSize(48, 48))`.
+  - `_load_styles` loop, after `item = QListWidgetItem(s.name)`:
+
+```python
+            rels = s.exemplars or s.reference_images
+            if rels and _is_safe_rel(rels[0]):
+                p = self.store.style_dir(s.id) / rels[0]
+                if p.exists():
+                    item.setIcon(QIcon(QPixmap(str(p)).scaled(
+                        48, 48, Qt.KeepAspectRatio, Qt.SmoothTransformation)))
+```
+
+  - `__init__` after `self._build_ui()`: restore geometry + combos:
+
+```python
+        geo = self.settings.value("geometry")
+        if geo is not None:
+            self.restoreGeometry(geo)
+        saved_provider = self.settings.value("llm_provider")
+        if saved_provider:
+            idx = self.llm_provider_combo.findText(saved_provider)
+            if idx >= 0:
+                self.llm_provider_combo.setCurrentIndex(idx)
+        saved_model = self.settings.value("llm_model")
+        if saved_model:
+            self.llm_model_combo.setCurrentText(saved_model)
+```
+
+  - `on_dialog_close` (end): `self.settings.setValue("geometry", self.saveGeometry())`, `self.settings.setValue("llm_provider", self.llm_provider_combo.currentText())`, `self.settings.setValue("llm_model", self.llm_model_combo.currentText())`.
+  - Provenance: `_on_selected` and `_on_analyze` clear `self._pending_source = None` right where `_pending_descriptor` is cleared. `_on_analyze` after the service is constructed: `self._analysis_source = {"provider": service.provider, "model": service.model, "image_count": len(paths)}`. `_on_analysis_done`:
+
+```python
+        src = getattr(self, "_analysis_source", None)
+        self._pending_source = (
+            {**src, "created": datetime.now().strftime("%Y-%m-%d %H:%M")}
+            if src else None)
+```
+
+  - `_save_current`, inside `if pending:`: also
+
+```python
+            if getattr(self, "_pending_source", None):
+                s.source = self._pending_source
+                self._pending_source = None
+```
+
+- [ ] **Step 4: Run dialog tests** → PASS. **Step 5: Commit** `feat(gui): style manager polish — list thumbnails, geometry/LLM persistence, source provenance`
+
+### Task 8: Drag-and-drop onto the refs grid
+
+**Files:**
+- Modify: `gui/styles/style_manager_dialog.py` (new `_RefsListWidget` + helper; `_build_ui` uses it; `_on_add_folder` reuses the ext set)
+- Test: `tests/styles/test_style_manager_dialog.py`
+
+- [ ] **Step 1: Write failing tests:**
+
+```python
+def test_image_paths_from_mime_filters_to_local_images(qapp, tmp_path):
+    from PySide6.QtCore import QMimeData, QUrl
+    from gui.styles.style_manager_dialog import _image_paths_from_mime
+    mime = QMimeData()
+    mime.setUrls([QUrl.fromLocalFile(str(tmp_path / "a.png")),
+                  QUrl.fromLocalFile(str(tmp_path / "b.txt")),
+                  QUrl("https://example.com/c.jpg")])
+    assert _image_paths_from_mime(mime) == [tmp_path / "a.png"]
+
+
+def test_refs_grid_accepts_drops_and_adds(qapp, store, tmp_path):
+    from PIL import Image
+    p = tmp_path / "d.png"
+    Image.new("RGB", (16, 16), (0, 0, 255)).save(p)
+    dlg = _dialog(store)
+    dlg.style_list.setCurrentRow(0)
+    assert dlg.refs_list.acceptDrops()
+    dlg.refs_list.files_dropped.emit([p])   # wiring under test
+    assert store.get("water").reference_images  # image landed in the store
+```
+
+- [ ] **Step 2: Run** → FAIL (no `_image_paths_from_mime` / `files_dropped`).
+- [ ] **Step 3: Implement.** Module-level, above the dialog class:
+
+```python
+_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
+
+
+def _image_paths_from_mime(mime) -> List[Path]:
+    """Local image files in a drag payload, order preserved."""
+    if not mime.hasUrls():
+        return []
+    out = []
+    for url in mime.urls():
+        if not url.isLocalFile():
+            continue
+        p = Path(url.toLocalFile())
+        if p.suffix.lower() in _IMAGE_EXTS:
+            out.append(p)
+    return out
+
+
+class _RefsListWidget(QListWidget):
+    """Refs grid that accepts image-file drops from the OS file manager."""
+    files_dropped = Signal(list)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAcceptDrops(True)
+
+    def dragEnterEvent(self, event):
+        if _image_paths_from_mime(event.mimeData()):
+            event.acceptProposedAction()
+        else:
+            super().dragEnterEvent(event)
+
+    def dragMoveEvent(self, event):
+        if _image_paths_from_mime(event.mimeData()):
+            event.acceptProposedAction()
+        else:
+            super().dragMoveEvent(event)
+
+    def dropEvent(self, event):
+        paths = _image_paths_from_mime(event.mimeData())
+        if paths:
+            event.acceptProposedAction()
+            self.files_dropped.emit(paths)
+        else:
+            super().dropEvent(event)
+```
+
+In `_build_ui`: `self.refs_list = _RefsListWidget()`; in the wiring block: `self.refs_list.files_dropped.connect(self._add_paths)`. `_on_add_folder`: replace its inline `exts = {...}` with `_IMAGE_EXTS`.
+
+- [ ] **Step 4: Run dialog tests** → PASS. **Step 5: Commit** `feat(gui): drag-and-drop image files onto the Style Manager refs grid`
+
+### Task 9: Coverage gaps — `--batch --style`, live Analyze click, orphan detach on real close
+
+**Files:**
+- Test: `tests/styles/test_cli_style_generation.py`, `tests/styles/test_style_manager_dialog.py`
+
+- [ ] **Step 1: `--batch` + `--style` test.** In `_fake_provider()` add `prov.submit_batch_job.return_value = "job-123"`. Append:
+
+```python
+def test_batch_with_style_is_text_only(tmp_path, capsys):
+    """--batch submits the STYLED prompt; exemplars are dropped with a notice."""
+    def _add_exemplar(store):
+        ex_dir = store.style_dir("water") / "refs"
+        ex_dir.mkdir(parents=True)
+        (ex_dir / "0001.jpg").write_bytes(b"X")
+        s = store.get("water")
+        s.reference_images = ["refs/0001.jpg"]
+        s.exemplars = ["refs/0001.jpg"]
+        store.save(s)
+
+    rc, prov, _ = _run(tmp_path, "--provider", "openai", "-p", "a fox",
+                       "--style", "Water", "--batch", setup=_add_exemplar)
+    assert rc == 0
+    (reqs,) = prov.submit_batch_job.call_args.args
+    assert reqs[0]["prompt"] == "a fox. In this style: washes"
+    assert "reference_images" not in reqs[0]
+    assert "text only" in capsys.readouterr().err
+```
+
+- [ ] **Step 2: Live Analyze-click + orphan tests.** Append to `test_style_manager_dialog.py`:
+
+```python
+class _FakeService:
+    provider = "openai"
+    model = "gpt-test"
+
+    def __init__(self, config, provider=None, model=None):
+        pass
+
+    def derive(self, paths, progress_cb=None):
+        if progress_cb:
+            progress_cb("chunk 1/1")
+        return {"descriptor": {"summary": "derived"}, "prompt_text": "derived text"}
+
+
+def _wait_until(qapp, predicate, timeout_s=8.0):
+    import time
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def _seed_ref(store, tmp_path, color=(255, 0, 0)):
+    from PIL import Image
+    s = store.get("water")
+    p = tmp_path / "ref.png"
+    Image.new("RGB", (16, 16), color).save(p)
+    store.add_reference_images(s, [p])
+    store.save(s)
+
+
+def test_analyze_click_end_to_end(qapp, store, tmp_path, monkeypatch):
+    """Real button click -> real QThread worker -> UI updated on completion."""
+    _seed_ref(store, tmp_path)
+    monkeypatch.setattr("core.styles.analyzer.StyleAnalysisService", _FakeService)
+    dlg = _dialog(store)
+    dlg.style_list.setCurrentRow(0)
+    dlg.analyze_btn.click()
+    assert _wait_until(qapp, lambda: getattr(dlg, "_pending_descriptor", None))
+    assert dlg.prompt_text_edit.toPlainText() == "derived text"
+    assert dlg.analyze_btn.isEnabled()
+    assert dlg._analysis_source["model"] == "gpt-test"
+
+
+def test_dialog_close_detaches_running_worker(qapp, store, tmp_path, monkeypatch):
+    """Real close with an in-flight analysis exercises the _ORPHAN_WORKERS
+    detach branch (issue #37 coverage item)."""
+    import time
+    from gui.styles import style_manager_dialog as smd
+
+    class _SlowService(_FakeService):
+        def derive(self, paths, progress_cb=None):
+            time.sleep(3.0)      # outlives on_dialog_close's 2s wait
+            return {"descriptor": {}, "prompt_text": ""}
+
+    _seed_ref(store, tmp_path, color=(0, 255, 0))
+    monkeypatch.setattr("core.styles.analyzer.StyleAnalysisService", _SlowService)
+    dlg = _dialog(store)
+    dlg.style_list.setCurrentRow(0)
+    dlg.analyze_btn.click()
+    w = dlg._worker
+    assert w is not None and w.isRunning()
+    dlg.reject()                             # DialogCleanupMixin -> on_dialog_close
+    assert w in smd._ORPHAN_WORKERS          # detached, kept alive
+    assert dlg._worker is None
+    assert w.wait(8000)                      # worker finishes on its own
+    assert _wait_until(qapp, lambda: w not in smd._ORPHAN_WORKERS)
+```
+
+- [ ] **Step 3: Run** the two files → PASS (Task 7 must land first for `_analysis_source`).
+- [ ] **Step 4: Commit** `test(styles): cover --batch --style, live Analyze flow, and orphan-worker detach`
+
+### Task 10: Full suite, version bump, PR, issue bookkeeping
+
+- [ ] **Step 1:** Full suite: `QT_QPA_PLATFORM=offscreen /mnt/d/Documents/Code/GitHub/ImageAI/.venv_linux/bin/python -m pytest` → must be all green.
+- [ ] **Step 2:** Version bump via the tool (never hand-edit): dry-run `python3 ~/.claude/skills/version-manager/version_tool.py --repo /mnt/d/Documents/Code/GitHub/ImageAI release minor`, write prose notes to a temp file, then `release minor --notes FILE --apply`; commit as the tool directs.
+- [ ] **Step 3:** Update this plan file's checkboxes + push branch; open PR titled `fix: Custom Styles post-merge follow-ups (issue #37)` with a body mapping each issue checkbox to its commit; `Closes #37` deliberately omitted — label `test` and comment instead (close after verification per house rules).
+- [ ] **Step 4:** Comment on issue #37 summarizing what shipped (note the smart-merge fix took the adjudicated "cap retries" candidate; full GenWorker move remains possible later), add label `test`, credit Claude Fable 5.
+
+## Self-Review Notes
+
+- All 13 issue checkboxes are covered: Tasks 3 (freeze), 1 (parser relocation), 2 (atomic write, isinstance, delete, `..` filenames), 5 (thumbnail/duplicate guards), 4 (provenance), 6 (picker refresh), 7 (dialog polish §6), 8 (drag-and-drop), 9 (batch+style, Analyze E2E, orphan detach).
+- Type consistency: `_is_safe_rel` stays a module function of `core/styles/store.py`, imported by the dialog (Tasks 5, 7). `build_completion_fn`'s new kwarg is keyword-only-by-convention with default `None` (CLI call sites unchanged).
+- Deliberate scope choice: the UI-freeze item takes the issue's "cap retries" candidate rather than the GenWorker relocation — the generation seam (streaming + non-streaming workers) is the riskiest code in the app, and the adjudicated pain is specifically the retry backoff.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### [ImageAI on GitHub](https://github.com/lelandg/ImageAI) Desktop + CLI for multi‑provider AI image and video generation with enterprise auth, prompt tools, and MIDI‑synced karaoke/video workflows.
 
-**Version 0.41.0**
+**Version 0.42.0**
 
 **See [LelandGreen.com](https://www.lelandgreen.com) for links to other code and free stuff**. _Under construction. Implementing social links soon._ 
 - **Chameleon Labs Discord - Support, AI Art & Community: [Chameleon Labs Discord](https://discord.gg/chameleonlabs)**

--- a/cli/commands/video.py
+++ b/cli/commands/video.py
@@ -257,12 +257,15 @@ def run_video_cmd(args) -> int:
         return _report(payload, as_json, code)
 
     style = None
+    style_meta = None
     try:
         style = _resolve_style(args)
         if style is not None:
             from core.styles import apply_style
-            args.prompt = apply_style(
-                getattr(args, "prompt", None) or "", style, "", "").prompt
+            styled = apply_style(
+                getattr(args, "prompt", None) or "", style, "", "")
+            args.prompt = styled.prompt
+            style_meta = styled.meta
             _emit(f"Applying style '{style.name}' to prompt (text only)")
         if provider == "omni":
             result = _run_omni(args, out_path)
@@ -278,6 +281,8 @@ def run_video_cmd(args) -> int:
 
     payload = _status_payload(result)
     if style is not None:
-        payload["style_applied"] = style.id
+        # Same dict shape as image sidecars (issue #37): style_id/style_name/
+        # smart_merge_used/exemplars_attached/exemplars_dropped.
+        payload["style_applied"] = style_meta
     _write_sidecar(out_path, payload)
     return _report(payload, as_json, 0 if result["success"] else 1)

--- a/core/constants.py
+++ b/core/constants.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 # Application metadata
 APP_NAME = "ImageAI"
-VERSION = "0.41.0"
+VERSION = "0.42.0"
 __version__ = VERSION
 __author__ = "Leland Green"
 __email__ = "contact@lelandgreen.com"

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -235,7 +235,7 @@ def _normalize_region_dict(rd: Dict) -> Dict:
 
 
 def parse_response(content: str, page_px: Tuple[int, int]) -> DesignerResult:
-    from gui.llm_utils import LLMResponseParser
+    from core.llm_parsing import LLMResponseParser
     data = LLMResponseParser.parse_json_response(content, expected_type=dict)
     if not isinstance(data, dict):
         logger.warning("Designer: unparseable response, using fallback")

--- a/core/layout/prompt_helper.py
+++ b/core/layout/prompt_helper.py
@@ -110,7 +110,7 @@ def parse_prompt_response(content: str) -> str:
     """
     if not content or not content.strip():
         return ""
-    from gui.llm_utils import LLMResponseParser
+    from core.llm_parsing import LLMResponseParser
     data = LLMResponseParser.parse_json_response(content, expected_type=dict)
     if isinstance(data, dict):
         p = data.get("prompt")

--- a/core/llm_parsing.py
+++ b/core/llm_parsing.py
@@ -1,0 +1,124 @@
+"""LLM response parsing shared by core pipelines and GUI dialogs.
+
+Lives in core (no Qt imports) so PySide6-less CLI paths — e.g.
+--style-create — can use it. gui/llm_utils.py re-exports it for
+back-compat with existing dialog imports.
+"""
+import json
+import logging
+import re
+from typing import Any, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class LLMResponseParser:
+    """Shared parser for LLM responses with fallback handling."""
+
+    @staticmethod
+    def parse_json_response(content: str, expected_type: type = list) -> Optional[Any]:
+        """
+        Parse JSON from LLM response with cleanup.
+
+        Args:
+            content: Raw response content
+            expected_type: Expected type of parsed result (list or dict)
+
+        Returns:
+            Parsed JSON or None if parsing fails
+        """
+        if not content or not content.strip():
+            return None
+
+        content = content.strip()
+
+        # Remove markdown formatting if present
+        if content.startswith("```"):
+            # Extract content between backticks
+            parts = content.split("```")
+            if len(parts) >= 2:
+                content = parts[1]
+                # Remove language identifier if present
+                if content.startswith("json"):
+                    content = content[4:]
+                elif content.startswith("JSON"):
+                    content = content[4:]
+                content = content.strip()
+
+        # Try to parse JSON
+        try:
+            result = json.loads(content)
+
+            # Validate type
+            if expected_type and not isinstance(result, expected_type):
+                logger.warning(f"Expected {expected_type.__name__}, got {type(result).__name__}")
+                return None
+
+            return result
+        except json.JSONDecodeError as e:
+            logger.debug(f"JSON parsing failed: {e}")
+            return None
+
+    @staticmethod
+    def extract_text_prompts(content: str, num_items: int = 3) -> List[str]:
+        """
+        Extract prompts from plain text response.
+
+        Args:
+            content: Text content
+            num_items: Maximum number of items to extract
+
+        Returns:
+            List of extracted prompts
+        """
+        if not content:
+            return []
+
+        lines = content.split('\n')
+        prompts = []
+
+        for line in lines:
+            line = line.strip()
+
+            # Skip empty lines and headers
+            if not line or line.startswith('#') or len(line) < 20:
+                continue
+
+            # Clean up common prefixes (1., -, *, etc.)
+            cleaned = re.sub(r'^[\d\.\-\*\s]+', '', line).strip()
+
+            # Clean up quotes
+            if cleaned.startswith('"') and cleaned.endswith('"'):
+                cleaned = cleaned[1:-1]
+            elif cleaned.startswith("'") and cleaned.endswith("'"):
+                cleaned = cleaned[1:-1]
+
+            if cleaned and len(cleaned) > 20:
+                prompts.append(cleaned)
+
+            if len(prompts) >= num_items:
+                break
+
+        return prompts[:num_items]
+
+    @staticmethod
+    def create_fallback_prompts(input_text: str, num_variations: int = 3) -> List[str]:
+        """
+        Create fallback prompts when LLM fails.
+
+        Args:
+            input_text: Original input text
+            num_variations: Number of variations to create
+
+        Returns:
+            List of fallback prompts
+        """
+        base_prompts = [
+            f"A detailed, photorealistic image of {input_text}",
+            f"An artistic interpretation of {input_text}, cinematic lighting, highly detailed",
+            f"A creative visualization of {input_text}, trending on artstation, 8k resolution",
+            f"A futuristic rendering of {input_text}, volumetric lighting, ultra-detailed",
+            f"A stylized depiction of {input_text}, professional photography, high quality"
+        ]
+
+        return base_prompts[:num_variations]

--- a/core/prompt_enhancer_llm.py
+++ b/core/prompt_enhancer_llm.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from core.prompt_enhancer import PromptEnhancer, EnhancementLevel
 from core.llm_models import resolve_model
-from gui.llm_utils import LLMResponseParser
+from core.llm_parsing import LLMResponseParser
 
 
 class PromptEnhancerLLM:

--- a/core/styles/analyzer.py
+++ b/core/styles/analyzer.py
@@ -218,7 +218,7 @@ def default_vision_model(provider: str) -> str:
     return resolve_model(reg, family, static_default=static)
 
 
-def build_completion_fn(config, provider=None, model=None):
+def build_completion_fn(config, provider=None, model=None, max_retries=None):
     """Build an LLM callable over UnifiedLLMProvider.
 
     Args:
@@ -226,6 +226,9 @@ def build_completion_fn(config, provider=None, model=None):
         provider: openai|anthropic|google (default: config 'llm_provider',
             else openai).
         model: bare model id (default: registry vision default).
+        max_retries: transient-error retry cap for each call (None = the
+            transport default; GUI-thread callers pass 0 to avoid blocking
+            on the exponential backoff).
 
     Returns:
         (fn, provider, full_model) where fn(messages) -> str.
@@ -251,8 +254,11 @@ def build_completion_fn(config, provider=None, model=None):
     def fn(messages):
         logger.info(f"Style LLM request -> {full_model} "
                     f"({sum(len(str(m)) for m in messages)} chars)")
-        return llm.analyze_image(messages=messages, model=full_model,
-                                 max_tokens=1500)
+        call_kwargs = {"messages": messages, "model": full_model,
+                       "max_tokens": 1500}
+        if max_retries is not None:
+            call_kwargs["max_retries"] = max_retries
+        return llm.analyze_image(**call_kwargs)
 
     return fn, provider, full_model
 

--- a/core/styles/analyzer.py
+++ b/core/styles/analyzer.py
@@ -92,7 +92,7 @@ def build_chunk_messages(paths: List[Path]) -> List[Dict]:
 
 def parse_descriptor(content: str) -> Optional[Dict[str, str]]:
     """Parse an LLM reply into a descriptor dict (keys filtered/defaulted)."""
-    from gui.llm_utils import LLMResponseParser
+    from core.llm_parsing import LLMResponseParser
     data = LLMResponseParser.parse_json_response(content or "", expected_type=dict)
     if not isinstance(data, dict):
         return None
@@ -130,7 +130,7 @@ def merge_descriptors(descs: List[Dict[str, str]],
     try:
         reply = completion_fn([{"role": "user", "content": prompt}])
         logger.info(f"Style merge response ({len(reply or '')} chars): {reply}")
-        from gui.llm_utils import LLMResponseParser
+        from core.llm_parsing import LLMResponseParser
         data = LLMResponseParser.parse_json_response(reply or "", expected_type=dict)
     except Exception as e:  # noqa: BLE001 - fall back, never crash the reduce
         logger.warning(f"Style merge LLM call failed: {e}")

--- a/core/styles/applicator.py
+++ b/core/styles/applicator.py
@@ -86,7 +86,7 @@ def _smart_merge(prompt: str, style: Style,
         logger.info(f"Smart-merge request for style '{style.name}'")
         reply = completion_fn([{"role": "user", "content": payload}])
         logger.info(f"Smart-merge response ({len(reply or '')} chars): {reply}")
-        from gui.llm_utils import LLMResponseParser
+        from core.llm_parsing import LLMResponseParser
         data = LLMResponseParser.parse_json_response(reply or "", expected_type=dict)
         if isinstance(data, dict):
             merged = str(data.get("prompt") or "").strip()

--- a/core/styles/applicator.py
+++ b/core/styles/applicator.py
@@ -166,7 +166,9 @@ def apply_style_for_surface(prompt, style, provider, model, *, smart,
     if smart and config is not None:
         try:
             from core.styles.analyzer import build_completion_fn
-            completion_fn, _p, _m = build_completion_fn(config)
+            # Runs on the GUI thread: one transient failure degrades to plain
+            # concat instead of freezing the UI for the ~14s retry backoff.
+            completion_fn, _p, _m = build_completion_fn(config, max_retries=0)
         except Exception as e:  # noqa: BLE001 - degrade, never block generation
             logger.warning(f"Smart merge unavailable ({e}); plain concat")
     exemplars = (store.resolve_refs(style, exemplars_only=True)

--- a/core/styles/store.py
+++ b/core/styles/store.py
@@ -8,6 +8,7 @@ live in the repo (unlike data/prompts/custom_presets.json).
 """
 import json
 import logging
+import os
 import re
 import shutil
 from pathlib import Path
@@ -26,9 +27,16 @@ _SAFE_REL = re.compile(r"^refs/[A-Za-z0-9._-]+$")
 _SAFE_ID = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 
 
-def _is_safe_rel(rel: str) -> bool:
-    """True for 'refs/<plain-basename>' entries — no separators, no traversal."""
-    return bool(_SAFE_REL.match(rel)) and "/" not in rel[len("refs/"):] and ".." not in rel
+def _is_safe_rel(rel) -> bool:
+    """True for 'refs/<plain-basename>' entries — no separators, no traversal.
+
+    Accepts only str (malformed index records may hold ints/lists). '..' is
+    fine INSIDE a filename (refs/a..b.jpg); only a whole-segment '.'/'..' is
+    traversal, and the regex already rejects further separators.
+    """
+    if not isinstance(rel, str) or not _SAFE_REL.match(rel):
+        return False
+    return rel[len("refs/"):] not in (".", "..")
 
 
 class StyleStore:
@@ -55,8 +63,10 @@ class StyleStore:
 
     def _write_index(self, records: List[dict]) -> None:
         self.base_dir.mkdir(parents=True, exist_ok=True)
-        with open(self.index_path, "w", encoding="utf-8") as f:
+        tmp = self.index_path.parent / (self.index_path.name + ".tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
             json.dump({"styles": records}, f, indent=2, ensure_ascii=False)
+        os.replace(tmp, self.index_path)  # atomic: never a half-written index
 
     # ---- CRUD ------------------------------------------------------------
 
@@ -116,6 +126,10 @@ class StyleStore:
         if len(kept) == len(records):
             return False
         self._write_index(kept)
+        if not isinstance(style_id, str) or not _SAFE_ID.match(style_id):
+            logger.warning(f"Deleted malformed style record {style_id!r} from "
+                           f"index; unsafe id, no directory removed")
+            return True
         d = self.style_dir(style_id)
         if d.exists():
             shutil.rmtree(d, ignore_errors=True)

--- a/core/styles/store.py
+++ b/core/styles/store.py
@@ -23,16 +23,19 @@ JPEG_QUALITY = 90
 EXEMPLAR_DEFAULT_CAP = 3
 MAX_IMPORT_BYTES = 50 * 1024 * 1024  # per-entry cap for zip-imported images
 
-_SAFE_REL = re.compile(r"^refs/[A-Za-z0-9._-]+$")
-_SAFE_ID = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+# \Z, not $: $ would also match before a trailing newline ("refs/a.jpg\n").
+_SAFE_REL = re.compile(r"^refs/[A-Za-z0-9._-]+\Z")
+_SAFE_ID = re.compile(r"^[a-z0-9][a-z0-9-]*\Z")
 
 
-def _is_safe_rel(rel) -> bool:
+def is_safe_rel(rel) -> bool:
     """True for 'refs/<plain-basename>' entries — no separators, no traversal.
 
-    Accepts only str (malformed index records may hold ints/lists). '..' is
-    fine INSIDE a filename (refs/a..b.jpg); only a whole-segment '.'/'..' is
-    traversal, and the regex already rejects further separators.
+    Public: the Style Manager UI applies the same check before touching
+    reference paths. Accepts only str (malformed index records may hold
+    ints/lists). '..' is fine INSIDE a filename (refs/a..b.jpg); only a
+    whole-segment '.'/'..' is traversal, and the regex already rejects
+    further separators.
     """
     if not isinstance(rel, str) or not _SAFE_REL.match(rel):
         return False
@@ -64,8 +67,12 @@ class StyleStore:
     def _write_index(self, records: List[dict]) -> None:
         self.base_dir.mkdir(parents=True, exist_ok=True)
         tmp = self.index_path.parent / (self.index_path.name + ".tmp")
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump({"styles": records}, f, indent=2, ensure_ascii=False)
+        try:
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump({"styles": records}, f, indent=2, ensure_ascii=False)
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
         os.replace(tmp, self.index_path)  # atomic: never a half-written index
 
     # ---- CRUD ------------------------------------------------------------
@@ -181,7 +188,7 @@ class StyleStore:
         return added
 
     def remove_reference_image(self, style: Style, rel_path: str) -> None:
-        if not _is_safe_rel(rel_path):
+        if not is_safe_rel(rel_path):
             logger.warning(
                 f"Style {style.id}: refusing to remove unsafe reference path {rel_path!r}")
             return
@@ -197,7 +204,7 @@ class StyleStore:
         base = self.style_dir(style.id)
         out = []
         for rel in rels:
-            if not _is_safe_rel(rel):
+            if not is_safe_rel(rel):
                 logger.warning(f"Style {style.id}: skipping unsafe reference path {rel!r}")
                 continue
             p = base / rel
@@ -249,7 +256,7 @@ class StyleStore:
 
                 safe_refs = []
                 for rel in style.reference_images:
-                    if _is_safe_rel(rel):
+                    if is_safe_rel(rel):
                         safe_refs.append(rel)
                     else:
                         logger.warning(
@@ -259,7 +266,7 @@ class StyleStore:
 
                 safe_exemplars = []
                 for rel in style.exemplars:
-                    if _is_safe_rel(rel) and rel in style.reference_images:
+                    if is_safe_rel(rel) and rel in style.reference_images:
                         safe_exemplars.append(rel)
                     else:
                         logger.warning(

--- a/core/video/prompt_engine.py
+++ b/core/video/prompt_engine.py
@@ -943,7 +943,8 @@ Format: Just return numbered prompts (1. ... 2. ... etc.), no other text."""
                      max_tokens: int = 1000,
                      reasoning_effort: str = None,
                      response_format: Dict[str, str] = None,
-                     console_callback: Callable = None) -> str:
+                     console_callback: Callable = None,
+                     max_retries: int = 3) -> str:
         """
         Analyze an image using vision-capable models.
         Includes automatic retry with exponential backoff for transient errors.
@@ -956,6 +957,8 @@ Format: Just return numbered prompts (1. ... 2. ... etc.), no other text."""
             reasoning_effort: For GPT-5 models
             response_format: Response format specification
             console_callback: Optional callback for status messages during retries
+            max_retries: Retry attempts for transient errors (0 = single try;
+                GUI-thread callers cap this to avoid blocking on the backoff)
 
         Returns:
             Generated text description
@@ -1008,7 +1011,7 @@ Format: Just return numbered prompts (1. ... 2. ... etc.), no other text."""
             # Use retry with backoff for transient errors (overloaded, rate limits, etc.)
             return self._retry_with_backoff(
                 func=make_llm_call,
-                max_retries=3,
+                max_retries=max_retries,
                 initial_delay=2.0,  # Start with 2 second delay
                 backoff_factor=2.0,  # Double delay each retry (2s, 4s, 8s)
                 console_callback=console_callback

--- a/gui/llm_utils.py
+++ b/gui/llm_utils.py
@@ -1,127 +1,15 @@
 """Shared utilities for LLM interactions in dialogs."""
 
 import logging
-import json
-import re
 from typing import List, Dict, Any, Optional, Tuple
 from PySide6.QtWidgets import QTextEdit, QVBoxLayout, QGroupBox
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QTextCursor, QFont, QTextCharFormat, QColor
 
+from core.llm_parsing import LLMResponseParser  # noqa: F401 — back-compat re-export
+
 logger = logging.getLogger(__name__)
 console = logging.getLogger("console")
-
-
-class LLMResponseParser:
-    """Shared parser for LLM responses with fallback handling."""
-
-    @staticmethod
-    def parse_json_response(content: str, expected_type: type = list) -> Optional[Any]:
-        """
-        Parse JSON from LLM response with cleanup.
-
-        Args:
-            content: Raw response content
-            expected_type: Expected type of parsed result (list or dict)
-
-        Returns:
-            Parsed JSON or None if parsing fails
-        """
-        if not content or not content.strip():
-            return None
-
-        content = content.strip()
-
-        # Remove markdown formatting if present
-        if content.startswith("```"):
-            # Extract content between backticks
-            parts = content.split("```")
-            if len(parts) >= 2:
-                content = parts[1]
-                # Remove language identifier if present
-                if content.startswith("json"):
-                    content = content[4:]
-                elif content.startswith("JSON"):
-                    content = content[4:]
-                content = content.strip()
-
-        # Try to parse JSON
-        try:
-            result = json.loads(content)
-
-            # Validate type
-            if expected_type and not isinstance(result, expected_type):
-                logger.warning(f"Expected {expected_type.__name__}, got {type(result).__name__}")
-                return None
-
-            return result
-        except json.JSONDecodeError as e:
-            logger.debug(f"JSON parsing failed: {e}")
-            return None
-
-    @staticmethod
-    def extract_text_prompts(content: str, num_items: int = 3) -> List[str]:
-        """
-        Extract prompts from plain text response.
-
-        Args:
-            content: Text content
-            num_items: Maximum number of items to extract
-
-        Returns:
-            List of extracted prompts
-        """
-        if not content:
-            return []
-
-        lines = content.split('\n')
-        prompts = []
-
-        for line in lines:
-            line = line.strip()
-
-            # Skip empty lines and headers
-            if not line or line.startswith('#') or len(line) < 20:
-                continue
-
-            # Clean up common prefixes (1., -, *, etc.)
-            cleaned = re.sub(r'^[\d\.\-\*\s]+', '', line).strip()
-
-            # Clean up quotes
-            if cleaned.startswith('"') and cleaned.endswith('"'):
-                cleaned = cleaned[1:-1]
-            elif cleaned.startswith("'") and cleaned.endswith("'"):
-                cleaned = cleaned[1:-1]
-
-            if cleaned and len(cleaned) > 20:
-                prompts.append(cleaned)
-
-            if len(prompts) >= num_items:
-                break
-
-        return prompts[:num_items]
-
-    @staticmethod
-    def create_fallback_prompts(input_text: str, num_variations: int = 3) -> List[str]:
-        """
-        Create fallback prompts when LLM fails.
-
-        Args:
-            input_text: Original input text
-            num_variations: Number of variations to create
-
-        Returns:
-            List of fallback prompts
-        """
-        base_prompts = [
-            f"A detailed, photorealistic image of {input_text}",
-            f"An artistic interpretation of {input_text}, cinematic lighting, highly detailed",
-            f"A creative visualization of {input_text}, trending on artstation, 8k resolution",
-            f"A futuristic rendering of {input_text}, volumetric lighting, ultra-detailed",
-            f"A stylized depiction of {input_text}, professional photography, high quality"
-        ]
-
-        return base_prompts[:num_variations]
 
 
 class DialogStatusConsole(QGroupBox):

--- a/gui/styles/style_manager_dialog.py
+++ b/gui/styles/style_manager_dialog.py
@@ -30,6 +30,51 @@ _SPLITTER_KEY = "splitter_state"
 # preventing Python GC from destroying a QThread that is still running.
 _ORPHAN_WORKERS = set()
 
+_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
+
+
+def _image_paths_from_mime(mime) -> List[Path]:
+    """Local image files in a drag payload, order preserved."""
+    if not mime.hasUrls():
+        return []
+    out = []
+    for url in mime.urls():
+        if not url.isLocalFile():
+            continue
+        p = Path(url.toLocalFile())
+        if p.suffix.lower() in _IMAGE_EXTS:
+            out.append(p)
+    return out
+
+
+class _RefsListWidget(QListWidget):
+    """Refs grid that accepts image-file drops from the OS file manager."""
+    files_dropped = Signal(list)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAcceptDrops(True)
+
+    def dragEnterEvent(self, event):
+        if _image_paths_from_mime(event.mimeData()):
+            event.acceptProposedAction()
+        else:
+            super().dragEnterEvent(event)
+
+    def dragMoveEvent(self, event):
+        if _image_paths_from_mime(event.mimeData()):
+            event.acceptProposedAction()
+        else:
+            super().dragMoveEvent(event)
+
+    def dropEvent(self, event):
+        paths = _image_paths_from_mime(event.mimeData())
+        if paths:
+            event.acceptProposedAction()
+            self.files_dropped.emit(paths)
+        else:
+            super().dropEvent(event)
+
 
 class StyleAnalysisWorker(QThread):
     """Runs StyleAnalysisService.derive off the UI thread."""
@@ -126,7 +171,7 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         right_l.addWidget(QLabel(
             f"Reference images (check up to {EXEMPLAR_DEFAULT_CAP} as exemplars "
             f"sent to image-capable providers):"))
-        self.refs_list = QListWidget()
+        self.refs_list = _RefsListWidget()
         self.refs_list.setViewMode(QListView.IconMode)
         self.refs_list.setIconSize(QPixmap(96, 96).size())
         self.refs_list.setResizeMode(QListView.Adjust)
@@ -194,6 +239,7 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         self.export_btn.clicked.connect(self._on_export)
         self.add_files_btn.clicked.connect(self._on_add_files)
         self.add_folder_btn.clicked.connect(self._on_add_folder)
+        self.refs_list.files_dropped.connect(self._add_paths)
         self.remove_ref_btn.clicked.connect(self._on_remove_ref)
         self.save_btn.clicked.connect(self._save_current)
         self.analyze_btn.clicked.connect(self._on_analyze)
@@ -378,9 +424,8 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         d = QFileDialog.getExistingDirectory(self, "Add Folder of Images")
         if not d:
             return
-        exts = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
         self._add_paths([p for p in sorted(Path(d).iterdir())
-                         if p.suffix.lower() in exts])
+                         if p.suffix.lower() in _IMAGE_EXTS])
 
     def _add_paths(self, paths):
         s = self._current_style()

--- a/gui/styles/style_manager_dialog.py
+++ b/gui/styles/style_manager_dialog.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import (
 
 from core.llm_models import get_provider_models
 from core.styles.models import Style, StyleDescriptor
-from core.styles.store import EXEMPLAR_DEFAULT_CAP, StyleStore, _is_safe_rel
+from core.styles.store import EXEMPLAR_DEFAULT_CAP, StyleStore, is_safe_rel
 from gui.common.dialog_conventions import (
     DialogCleanupMixin, bind_primary_action, persist_splitter,
     restore_splitter, set_default_button, standard_splitter)
@@ -42,7 +42,7 @@ def _image_paths_from_mime(mime) -> List[Path]:
         if not url.isLocalFile():
             continue
         p = Path(url.toLocalFile())
-        if p.suffix.lower() in _IMAGE_EXTS:
+        if p.suffix.lower() in _IMAGE_EXTS and p.is_file():
             out.append(p)
     return out
 
@@ -252,12 +252,13 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         self.style_list.clear()
         for s in self.store.list_styles():
             item = QListWidgetItem(s.name)
-            rels = s.exemplars or s.reference_images
-            if rels and _is_safe_rel(rels[0]):
-                p = self.store.style_dir(s.id) / rels[0]
-                if p.exists():
-                    item.setIcon(QIcon(QPixmap(str(p)).scaled(
-                        48, 48, Qt.KeepAspectRatio, Qt.SmoothTransformation)))
+            base = self.store.style_dir(s.id)
+            icon_src = next(
+                (base / rel for rel in (s.exemplars or s.reference_images)
+                 if is_safe_rel(rel) and (base / rel).exists()), None)
+            if icon_src is not None:
+                item.setIcon(QIcon(QPixmap(str(icon_src)).scaled(
+                    48, 48, Qt.KeepAspectRatio, Qt.SmoothTransformation)))
             item.setData(Qt.UserRole, s.id)
             self.style_list.addItem(item)
             if select_id and s.id == select_id:
@@ -289,7 +290,7 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         self.refs_list.clear()
         base = self.store.style_dir(s.id)
         for rel in s.reference_images:
-            if not _is_safe_rel(rel):
+            if not is_safe_rel(rel):
                 logger.warning(f"Style {s.id}: skipping unsafe reference "
                                f"path {rel!r} in UI")
                 continue
@@ -365,7 +366,7 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         # prefix of reference_images, and a missing/unreadable source file
         # must not shift the mapping for everything after it.
         for rel in s.reference_images:
-            if not _is_safe_rel(rel):
+            if not is_safe_rel(rel):
                 logger.warning(f"Style {s.id}: skipping unsafe reference "
                                f"path {rel!r} in duplicate")
                 continue

--- a/gui/styles/style_manager_dialog.py
+++ b/gui/styles/style_manager_dialog.py
@@ -14,7 +14,7 @@ from PySide6.QtWidgets import (
 
 from core.llm_models import get_provider_models
 from core.styles.models import Style, StyleDescriptor
-from core.styles.store import EXEMPLAR_DEFAULT_CAP, StyleStore
+from core.styles.store import EXEMPLAR_DEFAULT_CAP, StyleStore, _is_safe_rel
 from gui.common.dialog_conventions import (
     DialogCleanupMixin, bind_primary_action, persist_splitter,
     restore_splitter, set_default_button, standard_splitter)
@@ -222,6 +222,10 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         self.refs_list.clear()
         base = self.store.style_dir(s.id)
         for rel in s.reference_images:
+            if not _is_safe_rel(rel):
+                logger.warning(f"Style {s.id}: skipping unsafe reference "
+                               f"path {rel!r} in UI")
+                continue
             item = QListWidgetItem(Path(rel).name)
             item.setData(Qt.UserRole, rel)
             item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
@@ -291,6 +295,10 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         # prefix of reference_images, and a missing/unreadable source file
         # must not shift the mapping for everything after it.
         for rel in s.reference_images:
+            if not _is_safe_rel(rel):
+                logger.warning(f"Style {s.id}: skipping unsafe reference "
+                               f"path {rel!r} in duplicate")
+                continue
             src = self.store.style_dir(s.id) / rel
             if not src.exists():
                 continue

--- a/gui/styles/style_manager_dialog.py
+++ b/gui/styles/style_manager_dialog.py
@@ -537,6 +537,12 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
                 _ORPHAN_WORKERS.add(w)
                 w.finished.connect(lambda w=w: _ORPHAN_WORKERS.discard(w))
             self._worker = None
+        # The orphan path disconnects finished_ok/failed, so end_operation()
+        # will never fire from a signal — remove the app-level input blocker
+        # here or it outlives the dialog and filters every event through a
+        # dead widget (AttributeError spam, eventual crash).
+        if self.is_operation_running():
+            self.end_operation()
         persist_splitter(self.settings, _SPLITTER_KEY, self.v_splitter)
         self.settings.setValue("geometry", self.saveGeometry())
         self.settings.setValue("llm_provider", self.llm_provider_combo.currentText())

--- a/gui/styles/style_manager_dialog.py
+++ b/gui/styles/style_manager_dialog.py
@@ -2,10 +2,11 @@
 import copy
 import json
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
-from PySide6.QtCore import Qt, QSettings, QThread, Signal
+from PySide6.QtCore import QSize, Qt, QSettings, QThread, Signal
 from PySide6.QtGui import QIcon, QPixmap
 from PySide6.QtWidgets import (
     QComboBox, QDialog, QFileDialog, QHBoxLayout, QInputDialog, QLabel,
@@ -62,6 +63,18 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         self.setWindowTitle("Style Manager")
         self.resize(980, 680)
         self._build_ui()
+        geo = self.settings.value("geometry")
+        if geo is not None:
+            self.restoreGeometry(geo)
+        # Restore provider first (repopulates the model combo), then model.
+        saved_provider = self.settings.value("llm_provider")
+        if saved_provider:
+            idx = self.llm_provider_combo.findText(saved_provider)
+            if idx >= 0:
+                self.llm_provider_combo.setCurrentIndex(idx)
+        saved_model = self.settings.value("llm_model")
+        if saved_model:
+            self.llm_model_combo.setCurrentText(saved_model)
         # init_operation_guard runs after UI construction so it can pick up
         # self.status_console (an alias for self.console — see _build_ui).
         self.init_operation_guard()
@@ -81,6 +94,7 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         left = QWidget()
         left_l = QVBoxLayout(left)
         self.style_list = QListWidget()
+        self.style_list.setIconSize(QSize(48, 48))
         left_l.addWidget(self.style_list)
         row1 = QHBoxLayout()
         self.new_btn = QPushButton("New")
@@ -192,6 +206,12 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         self.style_list.clear()
         for s in self.store.list_styles():
             item = QListWidgetItem(s.name)
+            rels = s.exemplars or s.reference_images
+            if rels and _is_safe_rel(rels[0]):
+                p = self.store.style_dir(s.id) / rels[0]
+                if p.exists():
+                    item.setIcon(QIcon(QPixmap(str(p)).scaled(
+                        48, 48, Qt.KeepAspectRatio, Qt.SmoothTransformation)))
             item.setData(Qt.UserRole, s.id)
             self.style_list.addItem(item)
             if select_id and s.id == select_id:
@@ -210,6 +230,7 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         # selected when analysis finished — switching styles must not let it
         # get applied to a different style's Save.
         self._pending_descriptor = None
+        self._pending_source = None
         s = self._current_style()
         if s is None:
             return
@@ -268,6 +289,9 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         if pending:
             s.descriptor = StyleDescriptor.from_dict(pending)
             self._pending_descriptor = None
+            if getattr(self, "_pending_source", None):
+                s.source = self._pending_source
+                self._pending_source = None
         self.store.save(s)
         self.console.log(f"Saved style '{s.name}'", "SUCCESS")
         self._load_styles(select_id=s.id)
@@ -391,6 +415,7 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         # if this run fails or the user switches styles before it finishes,
         # a leftover pending descriptor from a previous style must not survive.
         self._pending_descriptor = None
+        self._pending_source = None
         s = self._current_style()
         if s is None:
             show_warning(self, "Style Manager",
@@ -412,6 +437,10 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
             return
         if not self.start_operation("analyze"):
             return
+        # Recorded into the style's `source` when this analysis is Saved.
+        self._analysis_source = {"provider": service.provider,
+                                 "model": service.model,
+                                 "image_count": len(paths)}
         self.analyze_btn.setEnabled(False)
         self.console.separator()
         self.console.log(
@@ -433,6 +462,10 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         self.descriptor_view.setPlainText(
             json.dumps(data.get("descriptor", {}), indent=2, ensure_ascii=False))
         self._pending_descriptor = data.get("descriptor", {})
+        src = getattr(self, "_analysis_source", None)
+        self._pending_source = (
+            {**src, "created": datetime.now().strftime("%Y-%m-%d %H:%M")}
+            if src else None)
         self.console.log("Analysis complete — review, then Save Style.", "SUCCESS")
 
     def _on_analysis_failed(self, message: str):
@@ -460,3 +493,6 @@ class StyleManagerDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
                 w.finished.connect(lambda w=w: _ORPHAN_WORKERS.discard(w))
             self._worker = None
         persist_splitter(self.settings, _SPLITTER_KEY, self.v_splitter)
+        self.settings.setValue("geometry", self.saveGeometry())
+        self.settings.setValue("llm_provider", self.llm_provider_combo.currentText())
+        self.settings.setValue("llm_model", self.llm_model_combo.currentText())

--- a/gui/styles/style_picker.py
+++ b/gui/styles/style_picker.py
@@ -4,6 +4,7 @@ Dropped into the Generate tab, video workspace, and (via the Generate tab)
 layout fill. Selection and smart-merge state persist per surface.
 """
 import logging
+import weakref
 from typing import Optional
 
 from PySide6.QtCore import Qt, Signal
@@ -14,6 +15,10 @@ from core.styles.models import Style
 from core.styles.store import StyleStore
 
 logger = logging.getLogger(__name__)
+
+# Every live picker, across all surfaces — so closing the Style Manager can
+# refresh them all, not just the picker that opened it (issue #37).
+_PICKERS = weakref.WeakSet()
 
 
 class StylePickerWidget(QWidget):
@@ -47,6 +52,7 @@ class StylePickerWidget(QWidget):
 
         self.manage_btn.clicked.connect(self._open_manager)
         self.combo.currentIndexChanged.connect(self._on_changed)
+        _PICKERS.add(self)
         self.refresh()
 
     # -- store injection for tests / shared instances ----------------------
@@ -92,4 +98,8 @@ class StylePickerWidget(QWidget):
         from gui.styles.style_manager_dialog import StyleManagerDialog
         dlg = StyleManagerDialog(self.config, store=self._store, parent=self)
         dlg.exec()
-        self.refresh()
+        for w in list(_PICKERS):
+            try:
+                w.refresh()   # every surface's picker, not just the opener
+            except RuntimeError:
+                pass          # underlying C++ widget already deleted

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,31 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 import pytest
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _isolated_qsettings(tmp_path_factory):
+    """Redirect every QSettings("ImageAI", ...) write into a session temp dir.
+
+    Dialog tests exercise real close paths that persist geometry, splitter
+    state, and LLM combo selections — without this, running the suite
+    overwrites the developer's actual saved dialog settings (PR #38 review).
+    """
+    try:
+        from PySide6.QtCore import QSettings
+    except ImportError:
+        yield
+        return
+    settings_dir = str(tmp_path_factory.mktemp("qsettings"))
+    QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+    # The (org, app) constructor uses NativeFormat regardless of the default
+    # format, so redirect BOTH formats (on Linux they're the same backend but
+    # separately-registered paths).
+    QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope,
+                      settings_dir)
+    QSettings.setPath(QSettings.Format.NativeFormat, QSettings.Scope.UserScope,
+                      settings_dir)
+    yield
+
+
 @pytest.fixture(scope="session")
 def qapp():
     from PySide6.QtWidgets import QApplication

--- a/tests/styles/test_analyzer_service.py
+++ b/tests/styles/test_analyzer_service.py
@@ -64,3 +64,19 @@ def test_service_derive_end_to_end(tmp_path):
         result = svc.derive([img])
     assert result["prompt_text"]  # deterministic flatten of the single chunk
     assert set(result["descriptor"].keys()) == set(DESCRIPTOR_KEYS)
+
+
+def test_analyze_image_forwards_max_retries(monkeypatch):
+    """analyze_image passes its max_retries through to the retry wrapper."""
+    from core.video.prompt_engine import UnifiedLLMProvider
+    llm = UnifiedLLMProvider({})
+    captured = {}
+
+    def fake_retry(func, max_retries=3, **kw):
+        captured["max_retries"] = max_retries
+        return "ok"
+
+    monkeypatch.setattr(llm, "_retry_with_backoff", fake_retry)
+    out = llm.analyze_image(messages=[{"role": "user", "content": "hi"}],
+                            model="gpt-4o", max_retries=0)
+    assert out == "ok" and captured["max_retries"] == 0

--- a/tests/styles/test_applicator.py
+++ b/tests/styles/test_applicator.py
@@ -175,3 +175,20 @@ def test_apply_style_for_surface_attach_exemplars_off(tmp_path):
     assert prompt == "a fox. In this style: washes"
     assert kwargs == {}
     assert meta["exemplars_attached"] == 0
+
+
+def test_apply_style_for_surface_caps_smart_merge_retries(monkeypatch):
+    """GUI seam runs on the UI thread: one attempt, no ~14s retry backoff."""
+    from core.styles.applicator import apply_style_for_surface
+    captured = {}
+
+    def fake_build(config, provider=None, model=None, max_retries=None):
+        captured["max_retries"] = max_retries
+        return (lambda messages: '{"prompt": "merged"}'), "openai", "gpt-x"
+
+    monkeypatch.setattr("core.styles.analyzer.build_completion_fn", fake_build)
+    prompt, extra, meta = apply_style_for_surface(
+        "a fox", _style(), "google", "m", smart=True, config=object(),
+        store=None, existing_references=None)
+    assert captured["max_retries"] == 0
+    assert meta["smart_merge_used"] is True and prompt == "merged"

--- a/tests/styles/test_cli_style_generation.py
+++ b/tests/styles/test_cli_style_generation.py
@@ -18,6 +18,7 @@ def _fake_provider():
     prov.get_default_model.return_value = "fake-model"
     prov.generate.return_value = (["ok"], [b"PNGDATA"])
     prov.edit_image.return_value = (["ok"], [b"PNGDATA"])
+    prov.submit_batch_job.return_value = "job-123"
     return prov
 
 
@@ -89,3 +90,24 @@ def test_style_with_reference_is_text_only(tmp_path):
     kwargs = prov.edit_image.call_args.kwargs
     assert kwargs["prompt"] == "a fox. In this style: washes"
     assert "reference_images" not in kwargs
+
+
+def test_batch_with_style_is_text_only(tmp_path, capsys):
+    """--batch submits the STYLED prompt; exemplars are intentionally
+    dropped with a stderr notice (issue #37 coverage item)."""
+    def _add_exemplar(store):
+        ex_dir = store.style_dir("water") / "refs"
+        ex_dir.mkdir(parents=True)
+        (ex_dir / "0001.jpg").write_bytes(b"X")
+        s = store.get("water")
+        s.reference_images = ["refs/0001.jpg"]
+        s.exemplars = ["refs/0001.jpg"]
+        store.save(s)
+
+    rc, prov, _ = _run(tmp_path, "--provider", "openai", "-p", "a fox",
+                       "--style", "Water", "--batch", setup=_add_exemplar)
+    assert rc == 0
+    (reqs,) = prov.submit_batch_job.call_args.args
+    assert reqs[0]["prompt"] == "a fox. In this style: washes"
+    assert "reference_images" not in reqs[0]
+    assert "text only" in capsys.readouterr().err

--- a/tests/styles/test_cli_style_video.py
+++ b/tests/styles/test_cli_style_video.py
@@ -114,7 +114,10 @@ def test_run_video_cmd_adds_style_applied_to_payload(tmp_path):
         rc = run_video_cmd(_ns(out=str(out), style="Water"))
     assert rc == 0
     data = json.loads(out.with_suffix(".json").read_text())
-    assert data["style_applied"] == "water"
+    # Unified provenance shape (issue #37): same dict as image sidecars.
+    assert data["style_applied"]["style_id"] == "water"
+    assert data["style_applied"]["smart_merge_used"] is False
+    assert data["style_applied"]["exemplars_attached"] == 0
 
 
 def test_run_video_cmd_no_style_omits_style_applied(tmp_path):

--- a/tests/styles/test_core_no_gui.py
+++ b/tests/styles/test_core_no_gui.py
@@ -1,0 +1,22 @@
+"""Style pipeline must import and parse without PySide6 (issue #37)."""
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_style_pipeline_importable_without_pyside6():
+    code = (
+        "import sys\n"
+        "sys.modules['PySide6'] = None\n"  # any 'import PySide6' now raises
+        "from core.styles.analyzer import parse_descriptor\n"
+        "from core.styles.applicator import apply_style\n"
+        "d = parse_descriptor('{\"summary\": \"s\"}')\n"
+        "assert d and d['summary'] == 's'\n"
+        "print('OK')\n"
+    )
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True,
+                         text=True, cwd=REPO)
+    assert out.returncode == 0, out.stderr
+    assert "OK" in out.stdout

--- a/tests/styles/test_store.py
+++ b/tests/styles/test_store.py
@@ -134,3 +134,52 @@ def test_list_styles_skips_record_with_traversal_id(tmp_path):
     styles = store.list_styles()
     assert [s.id for s in styles] == [good.id]
     assert store.get("../../evil") is None
+
+
+# ---- issue #37 hardening: atomic writes, _is_safe_rel, defensive delete ----
+
+def test_write_index_survives_midwrite_failure(tmp_path, monkeypatch):
+    import json
+    store = StyleStore(base_dir=tmp_path)
+    store.save(Style(id="a", name="A"))
+    original = store.index_path.read_text()
+    monkeypatch.setattr("core.styles.store.json.dump",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")))
+    with pytest.raises(OSError):
+        store.save(Style(id="b", name="B"))
+    assert store.index_path.read_text() == original  # old index intact
+
+
+def test_is_safe_rel_non_string_entries():
+    from core.styles.store import _is_safe_rel
+    assert _is_safe_rel(None) is False
+    assert _is_safe_rel(7) is False
+    assert _is_safe_rel(["refs/a.jpg"]) is False
+
+
+def test_is_safe_rel_allows_dotdot_inside_filename():
+    from core.styles.store import _is_safe_rel
+    assert _is_safe_rel("refs/a..b.jpg") is True     # legit filename
+    assert _is_safe_rel("refs/..") is False          # traversal
+    assert _is_safe_rel("refs/.") is False
+    assert _is_safe_rel("refs/../x.jpg") is False    # separator: regex rejects
+
+
+def test_resolve_refs_skips_non_string_entries(tmp_path):
+    store = StyleStore(base_dir=tmp_path)
+    s = Style(id="a", name="A", reference_images=[7, "refs/0001.jpg"])
+    assert store.resolve_refs(s) == []  # no TypeError; both skipped/missing
+
+
+def test_delete_unsafe_id_purges_index_without_touching_disk(tmp_path):
+    import json
+    store = StyleStore(base_dir=tmp_path)
+    store.save(Style(id="good", name="Good"))
+    # inject a malformed record with a traversal id directly into the index
+    raw = json.loads(store.index_path.read_text())
+    raw["styles"].append({"id": "../evil", "name": "Evil"})
+    store.index_path.write_text(json.dumps(raw))
+    assert store.delete("../evil") is True        # no ValueError
+    assert store.get("good") is not None
+    ids = [r["id"] for r in json.loads(store.index_path.read_text())["styles"]]
+    assert "../evil" not in ids

--- a/tests/styles/test_store.py
+++ b/tests/styles/test_store.py
@@ -148,21 +148,31 @@ def test_write_index_survives_midwrite_failure(tmp_path, monkeypatch):
     with pytest.raises(OSError):
         store.save(Style(id="b", name="B"))
     assert store.index_path.read_text() == original  # old index intact
+    assert not list(tmp_path.glob("*.tmp"))          # failed write cleaned up
 
 
 def test_is_safe_rel_non_string_entries():
-    from core.styles.store import _is_safe_rel
-    assert _is_safe_rel(None) is False
-    assert _is_safe_rel(7) is False
-    assert _is_safe_rel(["refs/a.jpg"]) is False
+    from core.styles.store import is_safe_rel
+    assert is_safe_rel(None) is False
+    assert is_safe_rel(7) is False
+    assert is_safe_rel(["refs/a.jpg"]) is False
 
 
 def test_is_safe_rel_allows_dotdot_inside_filename():
-    from core.styles.store import _is_safe_rel
-    assert _is_safe_rel("refs/a..b.jpg") is True     # legit filename
-    assert _is_safe_rel("refs/..") is False          # traversal
-    assert _is_safe_rel("refs/.") is False
-    assert _is_safe_rel("refs/../x.jpg") is False    # separator: regex rejects
+    from core.styles.store import is_safe_rel
+    assert is_safe_rel("refs/a..b.jpg") is True     # legit filename
+    assert is_safe_rel("refs/..") is False          # traversal
+    assert is_safe_rel("refs/.") is False
+    assert is_safe_rel("refs/../x.jpg") is False    # separator: regex rejects
+
+
+def test_safety_regexes_reject_trailing_newline(tmp_path):
+    # re's $ matches before a trailing newline; the anchors must be \Z
+    from core.styles.store import is_safe_rel
+    assert is_safe_rel("refs/a.jpg\n") is False
+    store = StyleStore(base_dir=tmp_path)
+    with pytest.raises(ValueError):
+        store.style_dir("water\n")
 
 
 def test_resolve_refs_skips_non_string_entries(tmp_path):

--- a/tests/styles/test_style_manager_dialog.py
+++ b/tests/styles/test_style_manager_dialog.py
@@ -169,3 +169,37 @@ def test_unsafe_ref_entries_are_skipped_in_ui(qapp, store):
     dlg._on_duplicate()                      # must not raise / copy them
     dup = store.get_by_name("Water copy")
     assert dup.reference_images == []
+
+
+def test_style_list_shows_exemplar_thumbnail(qapp, store, tmp_path):
+    from PIL import Image
+    s = store.get("water")
+    p = tmp_path / "t.png"
+    Image.new("RGB", (16, 16), (255, 0, 0)).save(p)
+    store.add_reference_images(s, [p])
+    s.exemplars = list(s.reference_images)
+    store.save(s)
+    dlg = _dialog(store)
+    assert not dlg.style_list.item(0).icon().isNull()
+
+
+def test_llm_combo_and_geometry_persist(qapp, store):
+    dlg = _dialog(store)
+    dlg.llm_provider_combo.setCurrentText("anthropic")
+    dlg.llm_model_combo.setCurrentText("claude-test")
+    dlg.reject()                       # real exit path -> on_dialog_close
+    dlg2 = _dialog(store)
+    assert dlg2.llm_provider_combo.currentText() == "anthropic"
+    assert dlg2.llm_model_combo.currentText() == "claude-test"
+
+
+def test_gui_analysis_populates_source_on_save(qapp, store):
+    dlg = _dialog(store)
+    dlg.style_list.setCurrentRow(0)
+    dlg._analysis_source = {"provider": "openai", "model": "gpt-test",
+                            "image_count": 2}
+    dlg._on_analysis_done({"descriptor": {"summary": "x"}, "prompt_text": "t"})
+    dlg._save_current()
+    src = store.get("water").source
+    assert src["provider"] == "openai" and src["model"] == "gpt-test"
+    assert src["image_count"] == 2 and src["created"]

--- a/tests/styles/test_style_manager_dialog.py
+++ b/tests/styles/test_style_manager_dialog.py
@@ -20,8 +20,19 @@ class FakeConfig(dict):
 
 @pytest.fixture
 def qapp():
+    from PySide6.QtCore import QCoreApplication, QEvent
     from PySide6.QtWidgets import QApplication
-    yield QApplication.instance() or QApplication([])
+    import gc
+    app = QApplication.instance() or QApplication([])
+    yield app
+    # Collect this test's abandoned dialog at a safe point. Every dialog is
+    # a reference cycle (child QObjects/slots hold the dialog), and letting
+    # the cyclic GC free one mid-event-pump in a LATER test destroys a
+    # QDialog from inside Qt event delivery — an intermittent segfault.
+    app.processEvents()
+    QCoreApplication.sendPostedEvents(None, QEvent.DeferredDelete)
+    app.processEvents()
+    gc.collect()
 
 
 @pytest.fixture
@@ -224,3 +235,106 @@ def test_refs_grid_accepts_drops_and_adds(qapp, store, tmp_path):
     assert dlg.refs_list.acceptDrops()
     dlg.refs_list.files_dropped.emit([p])   # wiring under test
     assert store.get("water").reference_images  # image landed in the store
+
+
+# ---- issue #37 coverage: live Analyze flow + orphan-worker detach ----------
+
+class _FakeService:
+    provider = "openai"
+    model = "gpt-test"
+
+    def __init__(self, config, provider=None, model=None):
+        pass
+
+    def derive(self, paths, progress_cb=None):
+        if progress_cb:
+            progress_cb("chunk 1/1")
+        return {"descriptor": {"summary": "derived"},
+                "prompt_text": "derived text"}
+
+
+def _wait_until(qapp, predicate, timeout_s=8.0):
+    import time
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def _seed_ref(store, tmp_path, color=(255, 0, 0)):
+    from PIL import Image
+    s = store.get("water")
+    p = tmp_path / "ref.png"
+    Image.new("RGB", (16, 16), color).save(p)
+    store.add_reference_images(s, [p])
+    store.save(s)
+
+
+def _dispose(qapp, dlg):
+    """Deterministically destroy a dialog + its worker inside the test.
+
+    The Analyze path connects worker signals to lambdas that close over the
+    dialog (dlg -> worker -> lambda -> dlg cycle). Left to the cyclic GC,
+    that cycle can be collected mid-event-pump in a LATER test, destroying
+    the QDialog from inside Qt event delivery — an intermittent segfault.
+    Dispose at a safe point instead: flush pending queued signals, run the
+    deferred deletes (processEvents alone never handles DeferredDelete),
+    then collect the cycle."""
+    import gc
+    from PySide6.QtCore import QCoreApplication, QEvent
+    dlg.close()
+    dlg.deleteLater()
+    qapp.processEvents()
+    QCoreApplication.sendPostedEvents(None, QEvent.DeferredDelete)
+    qapp.processEvents()
+    gc.collect()
+
+
+def test_analyze_click_end_to_end(qapp, store, tmp_path, monkeypatch):
+    """Real button click -> real QThread worker -> UI updated on completion."""
+    _seed_ref(store, tmp_path)
+    monkeypatch.setattr("core.styles.analyzer.StyleAnalysisService", _FakeService)
+    dlg = _dialog(store)
+    dlg.style_list.setCurrentRow(0)
+    dlg.analyze_btn.click()
+    w = dlg._worker
+    assert _wait_until(qapp, lambda: getattr(dlg, "_pending_descriptor", None))
+    assert dlg.prompt_text_edit.toPlainText() == "derived text"
+    assert dlg.analyze_btn.isEnabled()
+    assert dlg._analysis_source["model"] == "gpt-test"
+    assert dlg._pending_source["provider"] == "openai"
+    assert w.wait(8000)
+    _dispose(qapp, dlg)
+
+
+def test_dialog_close_detaches_running_worker(qapp, store, tmp_path, monkeypatch):
+    """Real close with an in-flight analysis exercises the _ORPHAN_WORKERS
+    detach branch (issue #37 coverage item)."""
+    import time
+    from gui.styles import style_manager_dialog as smd
+
+    class _SlowService(_FakeService):
+        def derive(self, paths, progress_cb=None):
+            time.sleep(3.0)      # outlives on_dialog_close's 2s wait
+            return {"descriptor": {}, "prompt_text": ""}
+
+    _seed_ref(store, tmp_path, color=(0, 255, 0))
+    monkeypatch.setattr("core.styles.analyzer.StyleAnalysisService", _SlowService)
+    dlg = _dialog(store)
+    dlg.style_list.setCurrentRow(0)
+    dlg.analyze_btn.click()
+    w = dlg._worker
+    assert w is not None and w.isRunning()
+    dlg.reject()                             # DialogCleanupMixin -> on_dialog_close
+    assert w in smd._ORPHAN_WORKERS          # detached, kept alive
+    assert dlg._worker is None
+    # The app-level input blocker must be gone: leaving it installed after
+    # the dialog dies filters every event through a dead dialog (crash).
+    assert dlg._input_blocker is None
+    assert not dlg.is_operation_running()
+    assert w.wait(8000)                      # worker finishes on its own
+    assert _wait_until(qapp, lambda: w not in smd._ORPHAN_WORKERS)
+    _dispose(qapp, dlg)

--- a/tests/styles/test_style_manager_dialog.py
+++ b/tests/styles/test_style_manager_dialog.py
@@ -155,3 +155,17 @@ def test_pending_descriptor_persists_when_saved_on_same_style(qapp, store):
     saved = store.get("water")
     assert saved.descriptor.summary == "Water-derived"
     assert saved.prompt_text == "watery text"
+
+
+def test_unsafe_ref_entries_are_skipped_in_ui(qapp, store):
+    """Hostile/malformed reference_images entries must not crash the
+    thumbnail or duplicate paths (issue #37)."""
+    s = store.get("water")
+    s.reference_images = ["../../evil.jpg", 7]
+    store.save(s)
+    dlg = _dialog(store)
+    dlg.style_list.setCurrentRow(0)          # must not raise
+    assert dlg.refs_list.count() == 0        # unsafe entries never listed
+    dlg._on_duplicate()                      # must not raise / copy them
+    dup = store.get_by_name("Water copy")
+    assert dup.reference_images == []

--- a/tests/styles/test_style_manager_dialog.py
+++ b/tests/styles/test_style_manager_dialog.py
@@ -194,6 +194,22 @@ def test_style_list_shows_exemplar_thumbnail(qapp, store, tmp_path):
     assert not dlg.style_list.item(0).icon().isNull()
 
 
+def test_style_list_thumbnail_falls_back_past_missing_ref(qapp, store, tmp_path):
+    """First ref missing on disk -> icon comes from the next existing one."""
+    from PIL import Image
+    s = store.get("water")
+    imgs = []
+    for i in range(2):
+        p = tmp_path / f"f{i}.png"
+        Image.new("RGB", (16, 16), (0, 255, 0)).save(p)
+        imgs.append(p)
+    store.add_reference_images(s, imgs)
+    store.save(s)
+    (store.style_dir(s.id) / s.reference_images[0]).unlink()
+    dlg = _dialog(store)
+    assert not dlg.style_list.item(0).icon().isNull()
+
+
 def test_llm_combo_and_geometry_persist(qapp, store):
     dlg = _dialog(store)
     dlg.llm_provider_combo.setCurrentText("anthropic")
@@ -219,9 +235,13 @@ def test_gui_analysis_populates_source_on_save(qapp, store):
 def test_image_paths_from_mime_filters_to_local_images(qapp, tmp_path):
     from PySide6.QtCore import QMimeData, QUrl
     from gui.styles.style_manager_dialog import _image_paths_from_mime
+    (tmp_path / "a.png").write_bytes(b"x")
+    (tmp_path / "b.txt").write_bytes(b"x")
+    (tmp_path / "dir.png").mkdir()          # directory with image-like name
     mime = QMimeData()
     mime.setUrls([QUrl.fromLocalFile(str(tmp_path / "a.png")),
                   QUrl.fromLocalFile(str(tmp_path / "b.txt")),
+                  QUrl.fromLocalFile(str(tmp_path / "dir.png")),
                   QUrl("https://example.com/c.jpg")])
     assert _image_paths_from_mime(mime) == [tmp_path / "a.png"]
 

--- a/tests/styles/test_style_manager_dialog.py
+++ b/tests/styles/test_style_manager_dialog.py
@@ -203,3 +203,24 @@ def test_gui_analysis_populates_source_on_save(qapp, store):
     src = store.get("water").source
     assert src["provider"] == "openai" and src["model"] == "gpt-test"
     assert src["image_count"] == 2 and src["created"]
+
+
+def test_image_paths_from_mime_filters_to_local_images(qapp, tmp_path):
+    from PySide6.QtCore import QMimeData, QUrl
+    from gui.styles.style_manager_dialog import _image_paths_from_mime
+    mime = QMimeData()
+    mime.setUrls([QUrl.fromLocalFile(str(tmp_path / "a.png")),
+                  QUrl.fromLocalFile(str(tmp_path / "b.txt")),
+                  QUrl("https://example.com/c.jpg")])
+    assert _image_paths_from_mime(mime) == [tmp_path / "a.png"]
+
+
+def test_refs_grid_accepts_drops_and_adds(qapp, store, tmp_path):
+    from PIL import Image
+    p = tmp_path / "d.png"
+    Image.new("RGB", (16, 16), (0, 0, 255)).save(p)
+    dlg = _dialog(store)
+    dlg.style_list.setCurrentRow(0)
+    assert dlg.refs_list.acceptDrops()
+    dlg.refs_list.files_dropped.emit([p])   # wiring under test
+    assert store.get("water").reference_images  # image landed in the store

--- a/tests/styles/test_style_picker.py
+++ b/tests/styles/test_style_picker.py
@@ -80,3 +80,26 @@ def test_refresh_keeps_selection_when_possible(qapp, store):
     store.save(Style(id="extra", name="Extra"))
     w.refresh()
     assert w.current_style().id == "neon"
+
+
+def test_manager_close_refreshes_all_pickers(qapp, store, monkeypatch):
+    """Closing the Style Manager refreshes EVERY surface's picker, not just
+    the one that opened it (issue #37)."""
+    from gui.styles.style_picker import StylePickerWidget
+    a = _picker(qapp, store)
+    b = StylePickerWidget(FakeConfig(), "video")
+    b.set_store(store)
+    b.refresh()
+
+    class FakeDlg:
+        def __init__(self, config, store=None, parent=None):
+            self._s = store
+
+        def exec(self):
+            self._s.save(Style(id="fresh", name="Fresh"))
+
+    monkeypatch.setattr(
+        "gui.styles.style_manager_dialog.StyleManagerDialog", FakeDlg)
+    a._open_manager()
+    assert a.combo.findData("fresh") >= 0
+    assert b.combo.findData("fresh") >= 0   # the OTHER picker refreshed too


### PR DESCRIPTION
Closes out every item batched in issue #37 (post-merge follow-ups from the PR #35 Custom Styles review adjudication). v0.42.0. Suite: **615 passed** (was 597; +18 new tests).

## Issue-checkbox → commit map

**Robustness / architecture**
- UI freeze during smart merge → `fix(styles): cap GUI smart-merge to a single LLM attempt` — took the issue's adjudicated "cap retries" candidate: `analyze_image` gained `max_retries`, the GUI seam passes 0 (a transient failure degrades to plain concat immediately, the existing fallback). The full GenWorker relocation remains possible later if wanted; the ~14s backoff freeze is gone.
- `LLMResponseParser` → core → `fix(styles): move LLMResponseParser to core` — new `core/llm_parsing.py`; **all six** core import sites repointed (styles analyzer/applicator, prompt_enhancer_llm, layout designer/prompt_helper), gui re-exports for back-compat. PySide6-less `--style-create` now works (guarded by a subprocess test).
- Atomic `styles.json` write, `_is_safe_rel` isinstance guard, defensive `delete()` id validation → `fix(styles): atomic styles.json write, non-str/dotdot _is_safe_rel fixes, defensive delete`.
- Manager-dialog thumbnail/duplicate `_is_safe_rel` re-checks → `fix(gui): style manager skips unsafe reference paths`.

**Consistency / polish**
- `style_applied` provenance unification (video CLI dict shape) → `fix(cli): video sidecar style_applied uses the same dict shape` (+ docs).
- Cross-surface picker refresh on manager close → `feat(gui): refresh style pickers on every surface`.
- Dialog polish per design §6 (list thumbnails, geometry + LLM combo persistence, GUI `source` provenance) → `feat(gui): style manager polish`.
- `_is_safe_rel` now accepts legit `..`-in-filename (`refs/a..b.jpg`) → part of the store-hardening commit.
- Drag-and-drop onto the refs grid → `feat(gui): drag-and-drop image files onto the Style Manager refs grid`.

**Test coverage**
- `--batch` + `--style`, live Analyze-click E2E, `_ORPHAN_WORKERS` detach via real dialog close → `test(styles): cover --batch --style, live Analyze flow, and orphan-worker detach`.

## Found along the way

The new live-close coverage caught a **real production leak**: closing the Style Manager mid-analysis disconnects the worker's signals, so `end_operation()` never fired and the app-level `InputBlockerEventFilter` outlived the dialog — every subsequent app event filtered through a dead widget (error spam, eventual crash). Fixed in `on_dialog_close` (same commit as the tests).

Note for a future pass: `enhanced_prompt_dialog`, `prompt_question_dialog`, and `reference_image_dialog` share the same disconnect-signals-on-close pattern without ending their operation guards — same latent leak, left for the DialogUX-TLC backlog rather than widening this PR.

Also hardened the QThread dialog tests against an intermittent shutdown segfault (abandoned dialogs are GC cycles; collecting one mid-event-pump crashes Qt) — deterministic disposal + fixture-level settling; stress-tested 10× dialog file + 3× full styles dir clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kro9uaWQe3gKPM1Ca85Pcg
