### PR TITLE
feat: unified LLM parameter validation layer (v0.44.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.44.0] - 2026-08-03
+
+### Added
+- Unified LLM parameter validation layer (`core/llm_params.py`): every chat
+  call now populates, validates, and corrals its parameters against curated
+  per-model rules (clamp out-of-range values, drop unsupported ones with a
+  logged warning, error on nonsense). Registry-backed output-token caps and
+  automatic `max_tokens` → `max_completion_tokens` renaming for OpenAI
+  reasoning models.
+- Live API boundary test suite (`tests/test_live_llm_params.py`, pytest
+  marker `live`, gated by `IMAGEAI_LIVE_TESTS=1`) verifying documented
+  parameter limits against the real Anthropic, OpenAI, and Gemini APIs,
+  plus 26 offline unit tests for the rules engine.
+- CLI: `--lyrics-temperature` is validated against the chosen model —
+  corralled values print a warning; invalid values exit with an error.
+
+### Fixed
+- Style analysis no longer fails with an Anthropic 400 ("`temperature` is
+  deprecated for this model") on Claude 5-family models — the layer drops
+  sampling params these models reject (LiteLLM's own table is wrong here,
+  so `drop_params` never protected us).
+- Lyric timing sync: two silent failures that degraded every LLM sync to
+  estimation — a nonexistent `PROVIDER_PREFIXES` attribute (AttributeError
+  swallowed by broad except) and a `generate()` keyword mismatch in
+  duration estimation (TypeError swallowed likewise).
+- Storyboard generation and lyric sync now send the required `anthropic/`
+  route prefix for Claude models instead of bare model IDs.
+
+### Changed
+- Removed all scattered per-model request hacks (GPT-5 `temperature=1.0`
+  forcing and token-param ternaries, duplicated across five dialogs and
+  engines) in favor of the central rules table.
+
 ## [0.43.0] - 2026-07-29
 
 ### Added

--- a/Plans/LLM-Params-Standardization.md
+++ b/Plans/LLM-Params-Standardization.md
@@ -1,0 +1,147 @@
+# LLM Parameter Standardization
+
+**Status:** In progress
+**Started:** 2026-08-03
+**Branch:** `feat/llm-param-standardization`
+
+## Trigger bug (root cause)
+
+Style analysis (Image tab → style dialog) fails against Anthropic:
+
+```
+litellm.BadRequestError: AnthropicException - {"type":"error","error":
+{"type":"invalid_request_error","message":"`temperature` is deprecated for this model."}}
+```
+
+Path: `core/styles/analyzer.py:255` → `UnifiedLLMProvider.analyze_image()`
+(`core/video/prompt_engine.py:939`) which always sends `temperature=0.7`.
+The Claude 5 family (`claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`) and
+Opus 4.7/4.8 **reject** `temperature`/`top_p`/`top_k` with a 400.
+
+Two aggravating facts:
+
+1. **LiteLLM 1.89.0's capability table is wrong** — it claims `temperature` is
+   supported on `anthropic/claude-opus-5`, so `litellm.drop_params=True` (set
+   nearly everywhere) does *not* drop it. LiteLLM cannot be the validator.
+2. The same class of per-model constraint is hand-patched all over the code
+   (`if 'gpt-5' in model: temperature = 1.0` appears ≥5 times), so each new
+   model generation breaks a different subset of features.
+
+## Call-site inventory (from mapping workflow, 2026-08-03)
+
+~40 chat-completion call sites across four architectures:
+
+| Area | Sites | Notes |
+|---|---|---|
+| `core/video/prompt_engine.py` (`UnifiedLLMProvider`) | 5 | enhance, batch, video-batch, analyze_image, enhance_for_video; GPT-5 hack at :980 |
+| `core/video/` others | 8 | `llm_sync.py`, `llm_sync_v2.py` (×3), `scene_suggester.py`, `storyboard_v2.py` (×3), `end_prompt_generator.py` — inline prefix chains, hardcoded temperatures 0.1–0.8 |
+| `core/` others | 6 | `styles/analyzer.py` + `applicator.py` (via engine), `lyrics_to_prompts.py`, `prompt_enhancer_llm.py`, `layout/designer.py` (imports gui.llm_utils — inversion), `font_generator/glyph_identifier.py` (google-genai SDK, not LiteLLM) |
+| `gui/` dialogs | 17+ | `prompt_generation_dialog.py` (6 sites incl. direct-SDK fallbacks), `prompt_question_dialog.py` (3), `enhanced_prompt_dialog.py`, `layout/text_gen_dialog.py`, `video/start_prompt_dialog.py`, `video/workspace_widget.py` (delegating) |
+| `cli/` | 2 | `runner.py` lyrics (only `--lyrics-temperature`, **no range validation**), `commands/layout.py` (no temperature flag) |
+
+Latent bug found during mapping: `core/video/llm_sync.py:546-550` and
+`core/video/llm_sync_v2.py:641` read `self.llm_provider.PROVIDER_PREFIXES`,
+which **does not exist** on `UnifiedLLMProvider` → AttributeError swallowed by
+broad `try/except` → LLM sync silently degrades to estimated timing.
+
+Dead code: `gui/prompt_question_dialog_old.py` (unreferenced, duplicates all
+the quirk hacks). Follow-up candidate, not touched in this change.
+
+## Design — `core/llm_params.py`
+
+One core-level module (no gui imports) that owns *populate → validate →
+corral → error* for every chat call.
+
+```
+@dataclass LLMParams          # what callers want
+    temperature, max_tokens, top_p, top_k,
+    reasoning_effort, verbosity, response_format, timeout, seed, stop
+
+@dataclass ModelParamRules    # what the model accepts
+    temperature: Range | Fixed | Unsupported
+    top_p / top_k: Supported | Unsupported
+    tokens_param: 'max_tokens' | 'max_completion_tokens'
+    max_output_tokens: Optional[int]
+    supports_reasoning_effort / verbosity / response_format
+    temp_top_p_exclusive: bool     # Claude 4.x: only one of the two
+
+get_param_rules(provider_id, model) -> ModelParamRules
+    merge order (highest wins):
+      1. curated per-family pattern table (authoritative, in this module)
+      2. registry capabilities (core/model-registry.fallback.json:
+         max_output_tokens, context_window, mode, supports_*)
+      3. litellm.get_model_info() fallback for token limits
+    unknown model on a known provider -> provider defaults;
+    unknown provider (ollama/lmstudio custom) -> permissive defaults
+
+validate_params(provider_id, model, params, *, strict=False,
+                on_warning=None) -> (litellm_kwargs, warnings)
+    - out-of-range numeric  -> clamp to nearest bound   (corral, warn)
+    - unsupported param     -> drop                     (corral, warn)
+    - fixed-value param     -> drop unless equal        (corral, warn)
+    - tokens over model max -> clamp to max_output_tokens
+    - mutually exclusive    -> keep temperature, drop top_p (warn)
+    - nonsense (negative max_tokens, unknown reasoning_effort,
+      wrong type)           -> raise LLMParamError (or exit path in CLI)
+    - strict=True           -> corralling still applies, but anything that
+                               *would* be dropped/clamped raises instead
+                               (CLI opt-in via --strict-llm-params later; not
+                               wired anywhere by default)
+    Every correction is logged (logger.warning) and echoed to the optional
+    console callback — per the "log every LLM interaction" project rule.
+
+build_completion_kwargs(provider_id, model, messages, params,
+                        api_key=None, api_base=None, auth_mode=None)
+    -> dict ready for litellm.completion(**kwargs)
+    - prefixes model via get_provider_prefix() (gemini/ vs vertex_ai/ when
+      auth_mode='gcloud'; lmstudio -> bare model + api_base)
+    - applies validate_params()
+```
+
+### Curated rules table (initial; live tests verify)
+
+| Family (regex on model id) | temperature | top_p/top_k | tokens param | notes |
+|---|---|---|---|---|
+| anthropic: `opus-4-[78]`, `opus-5`, `sonnet-5`, `fable-5`, `mythos` | **unsupported** | unsupported | max_tokens | Claude 5-line removed sampling params |
+| anthropic: other `claude-*` (4.6, 4.5, 3.7, haiku-4-5…) | 0.0–1.0 | supported, exclusive with temperature | max_tokens | Anthropic range is 0–1, not 0–2 |
+| openai: `gpt-5*`, `o1*`, `o3*`, `o4*`, `chat-latest` | fixed 1.0 (only default) | unsupported | **max_completion_tokens** | reasoning_effort + verbosity supported |
+| openai: other (`gpt-4*`, `gpt-3.5*`) | 0.0–2.0 | 0–1 supported | max_tokens | |
+| gemini: `gemini-*` | 0.0–2.0 | supported | max_tokens | |
+| ollama / lmstudio | 0.0–2.0 (permissive) | supported | max_tokens | local servers ignore extras |
+
+## Rollout order
+
+1. **Plan committed** (this doc).
+2. `core/llm_params.py` + unit tests (`tests/test_llm_params.py`).
+3. Rewire `core/video/prompt_engine.py` (fixes the style-dialog bug at the
+   root — analyzer/applicator/enhancer all route through it).
+4. Rewire remaining `core/video/*` (incl. PROVIDER_PREFIXES bug), `core/*`,
+   `gui/*` call sites — mechanical: inline kwargs → `build_completion_kwargs`.
+   Remove all scattered GPT-5/temperature hacks.
+5. CLI: validate `--lyrics-temperature` (and layout LLM path) through
+   `validate_params` — corral with printed warning, exit(2) with the valid
+   range on un-corralable input.
+6. Live API boundary tests (`tests/test_live_llm_params.py`, marker `live`,
+   skipped unless `IMAGEAI_LIVE_TESTS=1`). Keys present: anthropic, openai,
+   google. Matrix verifies the curated table against reality:
+   - claude-sonnet-5: raw temperature → 400 (documents the bug); corralled → 200
+   - claude-haiku-4-5: t=1.0 → 200, t=1.5 raw → 400, corralled → 200;
+     temperature+top_p together → 400, corralled → 200
+   - gpt-5.6-luna: t=0.5 raw → 400, corralled → 200; reasoning_effort ok;
+     max_tokens→max_completion_tokens rename verified
+   - gpt-4o / gpt-4.1-mini: t=2.0 → 200, t=2.5 raw → 400, corralled → 200
+   - gemini flash-lite: t=2.0 → 200, t>2 raw → 400, corralled → 200;
+     max_output_tokens clamp verified
+   - end-to-end: style-analysis path (analyzer → analyze_image) succeeds on
+     claude-opus-5 with corralled params (regression for the trigger bug)
+   All calls: tiny prompts, max_tokens ≤ 32, cheapest family member available.
+7. Full suite + version bump (minor) + changelog in same commit; PR.
+
+## Non-goals / follow-ups
+
+- Deleting `gui/prompt_question_dialog_old.py` (dead) — separate cleanup.
+- Fixing the core→gui import inversion in `core/layout/designer.py` beyond
+  what the rewire requires.
+- Registry-side capability additions (temperature support flags upstream).
+- GUI widgets adapting ranges dynamically per model (only backend corralling
+  in this change; a UI pass can consume `get_param_rules` later).

--- a/Plans/LLM-Params-Standardization.md
+++ b/Plans/LLM-Params-Standardization.md
@@ -1,8 +1,14 @@
 # LLM Parameter Standardization
 
-**Status:** In progress
+**Status:** Complete (v0.44.0) — all rollout steps done 2026-08-03
 **Started:** 2026-08-03
 **Branch:** `feat/llm-param-standardization`
+
+> Outcome: 26 unit tests + 19 live boundary tests all green (Anthropic,
+> OpenAI, Gemini); full suite 683 passed. Style-analyzer regression verified
+> live on claude-opus-5 and claude-sonnet-5. Two additional silent bugs fixed
+> beyond the plan: `generate()` keyword mismatch in duration estimation, and
+> missing `anthropic/` prefixes in storyboard/llm-sync paths.
 
 ## Trigger bug (root cause)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### [ImageAI on GitHub](https://github.com/lelandg/ImageAI) Desktop + CLI for multi‑provider AI image and video generation with enterprise auth, prompt tools, and MIDI‑synced karaoke/video workflows.
 
-**Version 0.43.0**
+**Version 0.44.0**
 
 **See [LelandGreen.com](https://www.lelandgreen.com) for links to other code and free stuff**. _Under construction. Implementing social links soon._ 
 - **Chameleon Labs Discord - Support, AI Art & Community: [Chameleon Labs Discord](https://discord.gg/chameleonlabs)**

--- a/cli/runner.py
+++ b/cli/runner.py
@@ -101,6 +101,20 @@ def handle_lyrics_to_prompts(args) -> int:
     style_hint = getattr(args, "lyrics_style", None)
     output_file = getattr(args, "lyrics_output", None)
 
+    # Validate LLM params against the chosen model: corral (with a printed
+    # warning) where possible, error out otherwise.
+    from core.llm_params import (LLMParamError, infer_provider_from_model,
+                                 validate_params)
+    try:
+        _, param_warnings = validate_params(
+            infer_provider_from_model(model), model,
+            {"temperature": temperature})
+        for warning in param_warnings:
+            print(f"Warning: {warning}")
+    except LLMParamError as e:
+        print(f"Error: invalid LLM parameter: {e}")
+        return 2
+
     # Get API keys from config
     config = ConfigManager()
     config_dict = {}

--- a/core/constants.py
+++ b/core/constants.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 # Application metadata
 APP_NAME = "ImageAI"
-VERSION = "0.43.0"
+VERSION = "0.44.0"
 __version__ = VERSION
 __author__ = "Leland Green"
 __email__ = "contact@lelandgreen.com"

--- a/core/layout/designer.py
+++ b/core/layout/designer.py
@@ -311,6 +311,7 @@ def run_completion(config, provider: str, model: str, messages: List[Dict],
     """Real LLM call (mirrors TextGenerationWorker). Not unit-tested (network)."""
     from gui.llm_utils import LiteLLMHandler
     from core.llm_models import get_provider_models, get_provider_prefix
+    from core.llm_params import validate_params
     ok, litellm = LiteLLMHandler.setup_litellm(enable_console_logging=True)
     if not ok or litellm is None:
         raise RuntimeError("Failed to initialize LiteLLM")
@@ -331,7 +332,8 @@ def run_completion(config, provider: str, model: str, messages: List[Dict],
     full_model = f"{prefix}{model_name}" if prefix else model_name
     logger.info("Designer LLM request: provider=%s model=%s temperature=%s\nmessages=%s",
                 provider, full_model, temperature, messages)
-    kwargs = {"model": full_model, "messages": messages, "temperature": temperature}
+    param_kwargs, _ = validate_params(pid, full_model, {"temperature": temperature})
+    kwargs = {"model": full_model, "messages": messages, **param_kwargs}
     if api_key:
         kwargs["api_key"] = api_key
     resp = litellm.completion(**kwargs)

--- a/core/llm_params.py
+++ b/core/llm_params.py
@@ -1,0 +1,506 @@
+"""
+Unified LLM parameter population, validation, and corralling.
+
+Single source of truth for which chat-completion parameters each provider/model
+accepts. Every LiteLLM call site builds its kwargs through this module instead
+of hand-rolling ``temperature``/``max_tokens`` dicts and per-model hacks.
+
+Contract (see Plans/LLM-Params-Standardization.md):
+  - validate values against curated per-family rules,
+  - corral where possible (clamp to range, drop unsupported, cap tokens) with a
+    logged warning,
+  - raise ``LLMParamError`` for values that cannot be corralled (wrong type,
+    nonsense values, unknown reasoning effort), or for *any* correction when
+    ``strict=True``.
+
+Why curated rules instead of LiteLLM's tables: LiteLLM 1.89.0 claims
+``temperature`` is supported on ``anthropic/claude-opus-5``, but the live API
+rejects it with a 400 ("`temperature` is deprecated for this model"), so
+``litellm.drop_params`` does not protect us. The rules below are verified by
+the live boundary tests in ``tests/test_live_llm_params.py``.
+"""
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from core.llm_models import LLM_PROVIDERS, get_provider_prefix
+from core.model_registry import FALLBACK_PATH
+
+logger = logging.getLogger(__name__)
+
+# Known LiteLLM route prefixes that may arrive glued onto a model id.
+_ROUTE_PREFIXES = (
+    "anthropic/", "gemini/", "vertex_ai/", "openai/", "ollama/", "ollama_chat/",
+    "lm_studio/", "azure/", "bedrock/",
+)
+
+# Accepted reasoning-effort levels across providers (OpenAI o-series/gpt-5.x
+# plus Anthropic-style effort names). Unknown strings cannot be corralled.
+_REASONING_EFFORT_LEVELS = {
+    "none", "minimal", "low", "medium", "high", "xhigh", "max",
+}
+
+_VERBOSITY_LEVELS = {"low", "medium", "high"}
+
+# Display names / aliases -> canonical LLM provider id (LLM_PROVIDERS keys).
+_PROVIDER_ALIASES = {
+    "openai": "openai",
+    "anthropic": "anthropic",
+    "claude": "anthropic",
+    "gemini": "gemini",
+    "google": "gemini",
+    "ollama": "ollama",
+    "lmstudio": "lmstudio",
+    "lm studio": "lmstudio",
+    "lm_studio": "lmstudio",
+}
+
+
+class LLMParamError(ValueError):
+    """A parameter value that cannot be corralled into a valid request."""
+
+
+@dataclass
+class LLMParams:
+    """Provider-agnostic chat-completion parameters as the caller wants them.
+
+    ``None`` means "do not send" — the provider default applies.
+    """
+    temperature: Optional[float] = None
+    max_tokens: Optional[int] = None
+    top_p: Optional[float] = None
+    top_k: Optional[int] = None
+    reasoning_effort: Optional[str] = None
+    verbosity: Optional[str] = None
+    response_format: Optional[Dict[str, Any]] = None
+    timeout: Optional[float] = None
+    seed: Optional[int] = None
+    stop: Optional[Any] = None
+
+    @classmethod
+    def from_dict(cls, values: Dict[str, Any]) -> "LLMParams":
+        known = {f for f in cls.__dataclass_fields__}
+        return cls(**{k: v for k, v in values.items() if k in known})
+
+
+@dataclass
+class ModelParamRules:
+    """What one provider/model family actually accepts."""
+    # (lo, hi) inclusive range; None means the parameter is rejected outright.
+    temperature_range: Optional[Tuple[float, float]] = (0.0, 2.0)
+    # If set, only this value is accepted (e.g. GPT-5 requires default 1.0);
+    # corralling drops the parameter so the provider default applies.
+    temperature_fixed: Optional[float] = None
+    top_p_supported: bool = True
+    top_k_supported: bool = False
+    # Claude 4.x accepts temperature or top_p, not both.
+    temp_top_p_exclusive: bool = False
+    tokens_param: str = "max_tokens"  # or "max_completion_tokens"
+    max_output_tokens: Optional[int] = None
+    supports_reasoning_effort: bool = False
+    supports_verbosity: bool = False
+    supports_response_format: bool = True
+    description: str = ""  # short label used in warnings
+
+
+# --- Curated per-family rules (authoritative; verified by live tests) --------
+
+@dataclass
+class _FamilyRule:
+    provider: str
+    pattern: str  # regex matched against the unprefixed, lowercased model id
+    rules: ModelParamRules = field(default_factory=ModelParamRules)
+
+
+_FAMILY_RULES: List[_FamilyRule] = [
+    # Anthropic — Claude Opus 4.7/4.8, Opus/Sonnet 5, Fable/Mythos: sampling
+    # params removed entirely (400 if sent).
+    _FamilyRule(
+        provider="anthropic",
+        pattern=r"^claude-(opus-4-[78]|opus-5|sonnet-5|fable|mythos)",
+        rules=ModelParamRules(
+            temperature_range=None,
+            top_p_supported=False,
+            top_k_supported=False,
+            tokens_param="max_tokens",
+            supports_reasoning_effort=False,
+            description="Claude 5-line (no sampling params)",
+        ),
+    ),
+    # Anthropic — everything older: temperature 0..1, top_p exclusive with
+    # temperature, top_k accepted.
+    _FamilyRule(
+        provider="anthropic",
+        pattern=r"^claude-",
+        rules=ModelParamRules(
+            temperature_range=(0.0, 1.0),
+            top_p_supported=True,
+            top_k_supported=True,
+            temp_top_p_exclusive=True,
+            tokens_param="max_tokens",
+            description="Claude 4.x/3.x (temperature 0-1)",
+        ),
+    ),
+    # OpenAI — reasoning models (gpt-5.x, o-series, chat-latest): temperature
+    # locked to the default, top_p rejected, max_completion_tokens required.
+    _FamilyRule(
+        provider="openai",
+        pattern=r"^(gpt-5|o1|o3|o4|chat-latest)",
+        rules=ModelParamRules(
+            temperature_range=(1.0, 1.0),
+            temperature_fixed=1.0,
+            top_p_supported=False,
+            top_k_supported=False,
+            tokens_param="max_completion_tokens",
+            supports_reasoning_effort=True,
+            supports_verbosity=True,
+            description="OpenAI reasoning model (temperature fixed at 1)",
+        ),
+    ),
+    # OpenAI — classic chat models.
+    _FamilyRule(
+        provider="openai",
+        pattern=r"",
+        rules=ModelParamRules(
+            temperature_range=(0.0, 2.0),
+            top_p_supported=True,
+            tokens_param="max_tokens",
+            description="OpenAI chat model (temperature 0-2)",
+        ),
+    ),
+    # Google Gemini.
+    _FamilyRule(
+        provider="gemini",
+        pattern=r"",
+        rules=ModelParamRules(
+            temperature_range=(0.0, 2.0),
+            top_p_supported=True,
+            top_k_supported=True,
+            tokens_param="max_tokens",
+            description="Gemini (temperature 0-2)",
+        ),
+    ),
+    # Local servers — permissive; they ignore what they don't understand.
+    _FamilyRule(
+        provider="ollama",
+        pattern=r"",
+        rules=ModelParamRules(
+            temperature_range=(0.0, 2.0),
+            top_p_supported=True,
+            top_k_supported=True,
+            description="Ollama (local)",
+        ),
+    ),
+    _FamilyRule(
+        provider="lmstudio",
+        pattern=r"",
+        rules=ModelParamRules(
+            temperature_range=(0.0, 2.0),
+            top_p_supported=True,
+            top_k_supported=True,
+            description="LM Studio (local)",
+        ),
+    ),
+]
+
+
+# --- Registry capability metadata (max output tokens etc.) -------------------
+
+def _load_registry_capabilities() -> Dict[str, Dict[str, Any]]:
+    try:
+        with open(FALLBACK_PATH, encoding="utf-8") as fh:
+            return json.load(fh).get("capabilities", {})
+    except Exception as e:  # pragma: no cover - snapshot bundled with the app
+        logger.warning(f"model-registry capabilities unavailable: {e}")
+        return {}
+
+
+_REGISTRY_CAPABILITIES = _load_registry_capabilities()
+
+
+def normalize_provider(provider: str) -> str:
+    """Map any app alias/display name ('Google', 'claude', 'LM Studio') to the
+    canonical LLM provider id used by LLM_PROVIDERS."""
+    key = (provider or "").strip().lower()
+    return _PROVIDER_ALIASES.get(key, key)
+
+
+def strip_route_prefix(model: str) -> str:
+    """Remove a LiteLLM route prefix ('anthropic/', 'gemini/', ...) if present."""
+    for prefix in _ROUTE_PREFIXES:
+        if model.startswith(prefix):
+            return model[len(prefix):]
+    return model
+
+
+_PREFIX_TO_PROVIDER = {
+    "anthropic/": "anthropic",
+    "gemini/": "gemini",
+    "vertex_ai/": "gemini",
+    "openai/": "openai",
+    "azure/": "openai",
+    "ollama/": "ollama",
+    "ollama_chat/": "ollama",
+    "lm_studio/": "lmstudio",
+}
+
+
+def infer_provider_from_model(model: str, default: str = "openai") -> str:
+    """Best-effort provider id from a (possibly prefixed) model string.
+
+    For call sites that only receive a model name (e.g. analyze_image).
+    """
+    m = (model or "").strip().lower()
+    for prefix, provider in _PREFIX_TO_PROVIDER.items():
+        if m.startswith(prefix):
+            return provider
+    bare = strip_route_prefix(m)
+    if bare.startswith("claude"):
+        return "anthropic"
+    if bare.startswith("gemini"):
+        return "gemini"
+    if re.match(r"^(gpt|o[134]|chat-latest|davinci)", bare):
+        return "openai"
+    return normalize_provider(default)
+
+
+def _registry_max_output_tokens(model_id: str) -> Optional[int]:
+    caps = _REGISTRY_CAPABILITIES.get(model_id)
+    if caps:
+        return caps.get("max_output_tokens")
+    return None
+
+
+def _litellm_max_output_tokens(provider_id: str, model_id: str) -> Optional[int]:
+    try:
+        import litellm
+        prefix = get_provider_prefix(provider_id)
+        info = litellm.get_model_info(f"{prefix}{model_id}" if prefix else model_id)
+        return info.get("max_output_tokens") or info.get("max_tokens")
+    except Exception:
+        return None
+
+
+def get_param_rules(provider: str, model: str) -> ModelParamRules:
+    """Resolve the parameter rules for a provider/model.
+
+    Curated family rules are authoritative; the model registry (then LiteLLM's
+    tables) fill in ``max_output_tokens``. Unknown providers get permissive
+    defaults so local/custom endpoints keep working.
+    """
+    provider_id = normalize_provider(provider)
+    model_id = strip_route_prefix((model or "").strip())
+    model_lc = model_id.lower()
+
+    rules = None
+    for fam in _FAMILY_RULES:
+        if fam.provider == provider_id and re.search(fam.pattern, model_lc):
+            # Copy so per-call mutation (max_output_tokens) never leaks back.
+            rules = ModelParamRules(**vars(fam.rules))
+            break
+    if rules is None:
+        rules = ModelParamRules(description=f"unknown provider '{provider_id}' (permissive)")
+
+    if rules.max_output_tokens is None:
+        rules.max_output_tokens = (
+            _registry_max_output_tokens(model_id)
+            or _litellm_max_output_tokens(provider_id, model_id)
+        )
+    return rules
+
+
+# --- Validation / corralling -------------------------------------------------
+
+def _require_number(name: str, value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise LLMParamError(f"{name} must be a number, got {value!r}")
+    return float(value)
+
+
+def validate_params(
+    provider: str,
+    model: str,
+    params: "LLMParams | Dict[str, Any] | None",
+    *,
+    strict: bool = False,
+    on_warning: Optional[Callable[[str], None]] = None,
+) -> Tuple[Dict[str, Any], List[str]]:
+    """Validate and corral chat params for one provider/model.
+
+    Returns ``(litellm_kwargs, warnings)`` where ``litellm_kwargs`` contains
+    only parameters the model accepts (already renamed, clamped, capped).
+
+    Corralling (logged + reported via ``on_warning``):
+      - out-of-range numerics are clamped to the nearest bound,
+      - unsupported parameters are dropped,
+      - fixed-value parameters (GPT-5 temperature) are dropped unless equal,
+      - ``max_tokens`` above the model's output ceiling is capped.
+
+    Raises ``LLMParamError`` for values that cannot be corralled (wrong type,
+    non-positive token counts, unknown reasoning effort/verbosity), or for any
+    needed correction when ``strict=True``.
+    """
+    if params is None:
+        params = LLMParams()
+    elif isinstance(params, dict):
+        params = LLMParams.from_dict(params)
+
+    rules = get_param_rules(provider, model)
+    model = strip_route_prefix((model or "").strip())
+    warnings: List[str] = []
+    out: Dict[str, Any] = {}
+
+    def corral(message: str) -> None:
+        if strict:
+            raise LLMParamError(message)
+        warnings.append(message)
+        logger.warning(f"LLM param corralled for {provider}/{model}: {message}")
+        if on_warning:
+            on_warning(message)
+
+    # temperature -------------------------------------------------------------
+    if params.temperature is not None:
+        temp = _require_number("temperature", params.temperature)
+        if rules.temperature_range is None:
+            corral(f"temperature={temp} not supported by {model} "
+                   f"({rules.description}); dropped")
+        elif rules.temperature_fixed is not None and temp != rules.temperature_fixed:
+            corral(f"temperature={temp} not supported by {model} "
+                   f"({rules.description}); only {rules.temperature_fixed} allowed — dropped")
+        elif rules.temperature_fixed is not None:
+            pass  # equals the only accepted value; provider default — omit
+        else:
+            lo, hi = rules.temperature_range
+            if temp < lo or temp > hi:
+                clamped = min(max(temp, lo), hi)
+                corral(f"temperature={temp} outside [{lo}, {hi}] for {model}; "
+                       f"clamped to {clamped}")
+                temp = clamped
+            out["temperature"] = temp
+
+    # top_p / top_k -----------------------------------------------------------
+    if params.top_p is not None:
+        top_p = _require_number("top_p", params.top_p)
+        if not rules.top_p_supported:
+            corral(f"top_p={top_p} not supported by {model}; dropped")
+        elif rules.temp_top_p_exclusive and "temperature" in out:
+            corral(f"{model} accepts temperature or top_p, not both; top_p dropped")
+        else:
+            if top_p < 0.0 or top_p > 1.0:
+                clamped = min(max(top_p, 0.0), 1.0)
+                corral(f"top_p={top_p} outside [0, 1]; clamped to {clamped}")
+                top_p = clamped
+            out["top_p"] = top_p
+
+    if params.top_k is not None:
+        if isinstance(params.top_k, bool) or not isinstance(params.top_k, int):
+            raise LLMParamError(f"top_k must be an integer, got {params.top_k!r}")
+        if not rules.top_k_supported:
+            corral(f"top_k={params.top_k} not supported by {model}; dropped")
+        elif params.top_k < 1:
+            raise LLMParamError(f"top_k must be >= 1, got {params.top_k}")
+        else:
+            out["top_k"] = params.top_k
+
+    # max tokens --------------------------------------------------------------
+    if params.max_tokens is not None:
+        if isinstance(params.max_tokens, bool) or not isinstance(params.max_tokens, int):
+            raise LLMParamError(f"max_tokens must be an integer, got {params.max_tokens!r}")
+        if params.max_tokens <= 0:
+            raise LLMParamError(f"max_tokens must be positive, got {params.max_tokens}")
+        tokens = params.max_tokens
+        ceiling = rules.max_output_tokens
+        if ceiling and tokens > ceiling:
+            corral(f"max_tokens={tokens} exceeds {model} output limit {ceiling}; capped")
+            tokens = ceiling
+        out[rules.tokens_param] = tokens
+
+    # reasoning effort / verbosity -------------------------------------------
+    if params.reasoning_effort is not None:
+        effort = str(params.reasoning_effort).strip().lower()
+        if effort not in _REASONING_EFFORT_LEVELS:
+            raise LLMParamError(
+                f"unknown reasoning_effort {params.reasoning_effort!r}; "
+                f"expected one of {sorted(_REASONING_EFFORT_LEVELS)}")
+        if rules.supports_reasoning_effort:
+            out["reasoning_effort"] = effort
+        else:
+            corral(f"reasoning_effort={effort!r} not supported by {model}; dropped")
+
+    if params.verbosity is not None:
+        verbosity = str(params.verbosity).strip().lower()
+        if verbosity not in _VERBOSITY_LEVELS:
+            raise LLMParamError(
+                f"unknown verbosity {params.verbosity!r}; "
+                f"expected one of {sorted(_VERBOSITY_LEVELS)}")
+        if rules.supports_verbosity:
+            out["verbosity"] = verbosity
+        else:
+            corral(f"verbosity={verbosity!r} not supported by {model}; dropped")
+
+    # passthrough parameters ---------------------------------------------------
+    if params.response_format is not None:
+        if rules.supports_response_format:
+            out["response_format"] = params.response_format
+        else:
+            corral(f"response_format not supported by {model}; dropped")
+    if params.timeout is not None:
+        out["timeout"] = params.timeout
+    if params.seed is not None:
+        out["seed"] = params.seed
+    if params.stop is not None:
+        out["stop"] = params.stop
+
+    return out, warnings
+
+
+def build_completion_kwargs(
+    provider: str,
+    model: str,
+    messages: List[Dict[str, Any]],
+    params: "LLMParams | Dict[str, Any] | None" = None,
+    *,
+    api_key: Optional[str] = None,
+    api_base: Optional[str] = None,
+    strict: bool = False,
+    on_warning: Optional[Callable[[str], None]] = None,
+) -> Dict[str, Any]:
+    """Build a complete, validated kwargs dict for ``litellm.completion()``.
+
+    Handles route prefixing per provider (``anthropic/``, ``gemini/`` vs
+    ``vertex_ai/`` by auth mode, bare model + ``api_base`` for LM Studio) and
+    merges the corralled parameters from :func:`validate_params`.
+    """
+    if not model or not str(model).strip():
+        raise LLMParamError(f"no model specified for provider {provider!r}")
+
+    provider_id = normalize_provider(provider)
+    model_id = str(model).strip()
+
+    if "/" in model_id:
+        routed_model = model_id  # caller already prefixed — honor it
+    elif provider_id == "gemini":
+        # API-key auth -> Google AI Studio; otherwise gcloud/ADC -> Vertex AI.
+        routed_model = f"gemini/{model_id}" if api_key else f"vertex_ai/{model_id}"
+    elif provider_id == "lmstudio":
+        routed_model = model_id  # OpenAI-compatible local server via api_base
+        if api_base is None:
+            config = LLM_PROVIDERS.get("lmstudio")
+            api_base = config.endpoint if config else None
+    else:
+        prefix = get_provider_prefix(provider_id)
+        routed_model = f"{prefix}{model_id}" if prefix else model_id
+
+    kwargs, _ = validate_params(
+        provider_id, model_id, params, strict=strict, on_warning=on_warning)
+
+    kwargs["model"] = routed_model
+    kwargs["messages"] = messages
+    if api_key:
+        kwargs["api_key"] = api_key
+    if api_base:
+        kwargs["api_base"] = api_base
+    return kwargs

--- a/core/llm_params.py
+++ b/core/llm_params.py
@@ -83,6 +83,11 @@ class LLMParams:
     @classmethod
     def from_dict(cls, values: Dict[str, Any]) -> "LLMParams":
         known = {f for f in cls.__dataclass_fields__}
+        unknown = set(values) - known
+        if unknown:
+            # A typo here (e.g. 'max_completion_tokens' instead of 'max_tokens')
+            # would otherwise silently drop the caller's constraint.
+            logger.warning(f"ignoring unknown LLM params: {sorted(unknown)}")
         return cls(**{k: v for k, v in values.items() if k in known})
 
 
@@ -103,6 +108,7 @@ class ModelParamRules:
     supports_reasoning_effort: bool = False
     supports_verbosity: bool = False
     supports_response_format: bool = True
+    supports_seed: bool = True
     description: str = ""  # short label used in warnings
 
 
@@ -127,6 +133,7 @@ _FAMILY_RULES: List[_FamilyRule] = [
             top_k_supported=False,
             tokens_param="max_tokens",
             supports_reasoning_effort=False,
+            supports_seed=False,
             description="Claude 5-line (no sampling params)",
         ),
     ),
@@ -141,6 +148,7 @@ _FAMILY_RULES: List[_FamilyRule] = [
             top_k_supported=True,
             temp_top_p_exclusive=True,
             tokens_param="max_tokens",
+            supports_seed=False,
             description="Claude 4.x/3.x (temperature 0-1)",
         ),
     ),
@@ -279,7 +287,9 @@ def _litellm_max_output_tokens(provider_id: str, model_id: str) -> Optional[int]
         import litellm
         prefix = get_provider_prefix(provider_id)
         info = litellm.get_model_info(f"{prefix}{model_id}" if prefix else model_id)
-        return info.get("max_output_tokens") or info.get("max_tokens")
+        # Only trust the explicit output cap: in older LiteLLM table entries
+        # 'max_tokens' means the total context window, not the output ceiling.
+        return info.get("max_output_tokens")
     except Exception:
         return None
 
@@ -450,7 +460,10 @@ def validate_params(
     if params.timeout is not None:
         out["timeout"] = params.timeout
     if params.seed is not None:
-        out["seed"] = params.seed
+        if rules.supports_seed:
+            out["seed"] = params.seed
+        else:
+            corral(f"seed not supported by {model}; dropped")
     if params.stop is not None:
         out["stop"] = params.stop
 
@@ -465,6 +478,7 @@ def build_completion_kwargs(
     *,
     api_key: Optional[str] = None,
     api_base: Optional[str] = None,
+    auth_mode: Optional[str] = None,
     strict: bool = False,
     on_warning: Optional[Callable[[str], None]] = None,
 ) -> Dict[str, Any]:
@@ -473,6 +487,11 @@ def build_completion_kwargs(
     Handles route prefixing per provider (``anthropic/``, ``gemini/`` vs
     ``vertex_ai/`` by auth mode, bare model + ``api_base`` for LM Studio) and
     merges the corralled parameters from :func:`validate_params`.
+
+    Gemini routing: ``auth_mode`` ('api-key' -> ``gemini/``, 'gcloud'/'adc' ->
+    ``vertex_ai/``) wins when given; otherwise the presence of ``api_key``
+    decides (present -> Google AI Studio, absent -> Vertex AI/ADC). Callers
+    relying on the ``GEMINI_API_KEY`` env var must pass ``auth_mode='api-key'``.
     """
     if not model or not str(model).strip():
         raise LLMParamError(f"no model specified for provider {provider!r}")
@@ -480,16 +499,23 @@ def build_completion_kwargs(
     provider_id = normalize_provider(provider)
     model_id = str(model).strip()
 
-    if "/" in model_id:
-        routed_model = model_id  # caller already prefixed — honor it
-    elif provider_id == "gemini":
-        # API-key auth -> Google AI Studio; otherwise gcloud/ADC -> Vertex AI.
-        routed_model = f"gemini/{model_id}" if api_key else f"vertex_ai/{model_id}"
-    elif provider_id == "lmstudio":
-        routed_model = model_id  # OpenAI-compatible local server via api_base
+    if provider_id == "lmstudio":
+        # OpenAI-compatible local server via api_base. Checked before the
+        # route-prefix test: LM Studio model ids often contain slashes
+        # (e.g. 'lmstudio-community/Meta-Llama-3-8B-GGUF') that are not routes.
+        routed_model = model_id
         if api_base is None:
             config = LLM_PROVIDERS.get("lmstudio")
             api_base = config.endpoint if config else None
+    elif any(model_id.startswith(p) for p in _ROUTE_PREFIXES):
+        routed_model = model_id  # caller already prefixed — honor it
+    elif provider_id == "gemini":
+        if auth_mode:
+            use_api_key_route = auth_mode.strip().lower() in ("api-key", "api_key")
+        else:
+            use_api_key_route = bool(api_key)
+        routed_model = (f"gemini/{model_id}" if use_api_key_route
+                        else f"vertex_ai/{model_id}")
     else:
         prefix = get_provider_prefix(provider_id)
         routed_model = f"{prefix}{model_id}" if prefix else model_id

--- a/core/lyrics_to_prompts.py
+++ b/core/lyrics_to_prompts.py
@@ -11,6 +11,7 @@ from typing import List, Dict, Any, Optional
 from dataclasses import dataclass, asdict
 
 from core.llm_models import resolve_model
+from core.llm_params import infer_provider_from_model, validate_params
 
 logger = logging.getLogger(__name__)
 console = logging.getLogger("console")
@@ -205,6 +206,14 @@ Rules:
             console.info(f"Style: {style_hint}")
 
         try:
+            # Validate params against what this provider/model actually accepts.
+            provider_id = infer_provider_from_model(model)
+            param_kwargs, _ = validate_params(
+                provider_id, model,
+                {"temperature": temperature, "max_tokens": 4096},
+                on_warning=console.warning,
+            )
+
             # Call LLM
             response = self.litellm.completion(
                 model=model,
@@ -212,8 +221,7 @@ Rules:
                     {"role": "system", "content": self.SYSTEM_PROMPT},
                     {"role": "user", "content": user_prompt}
                 ],
-                temperature=temperature,
-                max_tokens=4096
+                **param_kwargs
             )
 
             raw_content = response.choices[0].message.content

--- a/core/prompt_enhancer_llm.py
+++ b/core/prompt_enhancer_llm.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from core.prompt_enhancer import PromptEnhancer, EnhancementLevel
 from core.llm_models import resolve_model
+from core.llm_params import validate_params
 from core.llm_parsing import LLMResponseParser
 
 
@@ -173,16 +174,12 @@ class PromptEnhancerLLM:
         if provider in provider_prefixes and not model_id.startswith(provider_prefixes[provider]):
             model_id = f"{provider_prefixes[provider]}{model_id}"
 
-        # Determine which token parameter to use
-        # Use max_completion_tokens for newer OpenAI models (GPT-4+, GPT-5), max_tokens for GPT-3.5 and other providers
-        if provider == "openai":
-            if "gpt-3.5" in model_id.lower():
-                token_param = "max_tokens"
-            else:
-                # GPT-4, GPT-5, and newer models use max_completion_tokens
-                token_param = "max_completion_tokens"
-        else:
-            token_param = "max_tokens"
+        # Validate params against what this provider/model actually accepts
+        # (handles max_tokens vs max_completion_tokens renaming, clamping, drops).
+        param_kwargs, _ = validate_params(
+            provider, model_id,
+            {"temperature": temperature, "max_tokens": max_tokens},
+        )
 
         kwargs = {
             "model": model_id,
@@ -190,8 +187,7 @@ class PromptEnhancerLLM:
                 {"role": "system", "content": self.enhancer.SYSTEM_PROMPT},
                 {"role": "user", "content": user_prompt}
             ],
-            "temperature": temperature,
-            token_param: max_tokens
+            **param_kwargs
         }
 
         # Check if LLM logging is enabled
@@ -206,8 +202,11 @@ class PromptEnhancerLLM:
         self.logger.info(f"LLM Request to {model_id} (Provider: {provider}):")
         console.info(f"LLM Request to {model_id} (Provider: {provider}):")
 
-        self.logger.info(f"  Token parameter: {token_param} = {kwargs[token_param]}")
-        console.info(f"  Token parameter: {token_param} = {kwargs[token_param]}")
+        token_param = ("max_completion_tokens" if "max_completion_tokens" in kwargs
+                       else "max_tokens")
+        if token_param in kwargs:
+            self.logger.info(f"  Token parameter: {token_param} = {kwargs[token_param]}")
+            console.info(f"  Token parameter: {token_param} = {kwargs[token_param]}")
 
         self.logger.info(f"  Temperature: {temperature}")
         console.info(f"  Temperature: {temperature}")

--- a/core/video/end_prompt_generator.py
+++ b/core/video/end_prompt_generator.py
@@ -9,7 +9,8 @@ import logging
 from typing import Optional
 from dataclasses import dataclass
 
-from core.llm_models import resolve_model
+from core.llm_models import get_provider_prefix, resolve_model
+from core.llm_params import normalize_provider, validate_params
 
 
 @dataclass
@@ -96,27 +97,25 @@ Describe a natural ending frame for this scene."""
             # Call LLM provider
             import litellm
 
-            # Prepare model string
-            if provider == 'gemini':
-                model_id = f"gemini/{model}"
-            elif provider == 'openai':
-                model_id = model
-            elif provider == 'anthropic' or provider == 'claude':
-                model_id = model
-            else:
-                model_id = model
+            # Prepare model string (anthropic/gemini need LiteLLM prefixes)
+            provider_id = normalize_provider(provider)
+            prefix = get_provider_prefix(provider_id)
+            model_id = f"{prefix}{model}" if prefix else model
 
             self.logger.info(f"Generating end prompt with {provider}/{model}")
             self.logger.debug(f"Context: start='{context.start_prompt[:50]}...', next='{context.next_start_prompt[:50] if context.next_start_prompt else 'None'}...'")
 
+            llm_kwargs, _ = validate_params(
+                provider_id, model,
+                {"temperature": temperature, "max_tokens": 150}
+            )
             response = litellm.completion(
                 model=model_id,
                 messages=[
                     {"role": "system", "content": self.SYSTEM_PROMPT},
                     {"role": "user", "content": user_prompt}
                 ],
-                temperature=temperature,
-                max_tokens=150
+                **llm_kwargs
             )
 
             # Extract response text

--- a/core/video/llm_sync.py
+++ b/core/video/llm_sync.py
@@ -306,14 +306,17 @@ Return JSON with duration_sec for each scene."""
             # Call LLM
             self.logger.debug(f"Sending timing estimation request to {self.provider}")
 
-            # Handle GPT-5's temperature restriction (only supports temperature=1)
-            temperature = 1.0 if self.model and "gpt-5" in self.model.lower() else 0.3
-
+            # Per-model parameter quirks (e.g. GPT-5's fixed temperature) are
+            # corralled by core.llm_params.validate_params in the provider layer.
+            # generate() is an alias of analyze_image(messages=...) — system and
+            # user prompts must be passed as chat messages.
             response = self.llm_provider.generate(
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
                 model=self.model,
-                system_prompt=system_prompt,
-                user_prompt=user_prompt,
-                temperature=temperature,
+                temperature=0.3,
                 max_tokens=2000
             )
 
@@ -540,12 +543,21 @@ Lyrics:
             api_start = time.time()
             
             # Use litellm through the UnifiedLLMProvider
-            if self.provider == 'lmstudio':
+            from core.llm_models import get_provider_prefix
+            from core.llm_params import normalize_provider, validate_params
+
+            provider_id = normalize_provider(self.provider)
+            if provider_id == 'lmstudio':
                 model_id = self.model
             else:
-                prefix = self.llm_provider.PROVIDER_PREFIXES.get(self.provider.lower(), '')
+                prefix = get_provider_prefix(provider_id)
                 model_id = f"{prefix}{self.model}" if prefix else self.model
-            
+
+            params = {'temperature': 0.3}  # Lower temperature for more consistent timing
+            if provider_id == 'openai':
+                params['response_format'] = {"type": "json_object"}
+            param_kwargs, _ = validate_params(provider_id, self.model, params)
+
             self.logger.info(f"Making LLM API call with model: {model_id}")
             response = self.llm_provider.litellm.completion(
                 model=model_id,
@@ -553,8 +565,7 @@ Lyrics:
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_message}
                 ],
-                temperature=0.3,  # Lower temperature for more consistent timing
-                response_format={"type": "json_object"} if self.provider == "openai" else None
+                **param_kwargs
             )
             
             api_elapsed = time.time() - api_start

--- a/core/video/llm_sync_v2.py
+++ b/core/video/llm_sync_v2.py
@@ -180,7 +180,13 @@ class LLMSyncAssistant:
             api_start = time.time()
             
             model_id = self.model
-            
+
+            from core.llm_params import validate_params
+            param_kwargs, _ = validate_params(
+                'openai', model_id,
+                {'temperature': 0.1,  # Very low temperature for consistent timing
+                 'response_format': {"type": "json_object"}})
+
             self.logger.info(f"Making LLM API call with model: {model_id}")
             response = self.llm_provider.litellm.completion(
                 model=model_id,
@@ -188,8 +194,7 @@ class LLMSyncAssistant:
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_message}
                 ],
-                temperature=0.1,  # Very low temperature for consistent timing
-                response_format={"type": "json_object"}
+                **param_kwargs
             )
             
             api_elapsed = time.time() - api_start
@@ -399,8 +404,17 @@ class LLMSyncAssistant:
             import time
             api_start = time.time()
 
-            # Get provider prefix - Anthropic doesn't need a prefix for LiteLLM
-            model_id = self.model
+            # Route via the canonical provider prefix (LiteLLM: 'anthropic/<model>')
+            from core.llm_models import get_provider_prefix
+            from core.llm_params import validate_params
+
+            prefix = get_provider_prefix('anthropic')
+            model_id = f"{prefix}{self.model}" if prefix else self.model
+
+            param_kwargs, _ = validate_params(
+                'anthropic', self.model,
+                {'temperature': 0.1,  # Low temperature for consistent timing
+                 'max_tokens': 4000})
 
             self.logger.info(f"Making LLM API call with model: {model_id}")
             response = self.llm_provider.litellm.completion(
@@ -409,8 +423,7 @@ class LLMSyncAssistant:
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_message}
                 ],
-                temperature=0.1,  # Low temperature for consistent timing
-                max_tokens=4000
+                **param_kwargs
             )
 
             api_elapsed = time.time() - api_start
@@ -634,9 +647,16 @@ class LLMSyncAssistant:
             api_start = time.time()
             
             # Use gemini prefix
-            prefix = self.llm_provider.PROVIDER_PREFIXES.get('gemini', 'gemini/')
+            from core.llm_models import get_provider_prefix
+            from core.llm_params import validate_params
+
+            prefix = get_provider_prefix('gemini')
             model_id = f"{prefix}{self.model}" if prefix else self.model
-            
+
+            param_kwargs, _ = validate_params(
+                'gemini', self.model,
+                {'temperature': 0.1})  # Low temperature for consistent timing
+
             self.logger.info(f"Making LLM API call with model: {model_id}")
             response = self.llm_provider.litellm.completion(
                 model=model_id,
@@ -644,7 +664,7 @@ class LLMSyncAssistant:
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_message}
                 ],
-                temperature=0.1  # Low temperature for consistent timing
+                **param_kwargs
             )
             
             api_elapsed = time.time() - api_start
@@ -923,14 +943,17 @@ Return JSON with duration_sec for each scene."""
             # Call LLM
             self.logger.debug(f"Sending timing estimation request to {self.provider}")
 
-            # Handle GPT-5's temperature restriction (only supports temperature=1)
-            temperature = 1.0 if self.model and "gpt-5" in self.model.lower() else 0.3
-
+            # Per-model parameter quirks (e.g. GPT-5's fixed temperature) are
+            # corralled by core.llm_params.validate_params in the provider layer.
+            # generate() is an alias of analyze_image(messages=...) — system and
+            # user prompts must be passed as chat messages.
             response = self.llm_provider.generate(
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
                 model=self.model,
-                system_prompt=system_prompt,
-                user_prompt=user_prompt,
-                temperature=temperature,
+                temperature=0.3,
                 max_tokens=2000
             )
 

--- a/core/video/prompt_engine.py
+++ b/core/video/prompt_engine.py
@@ -392,17 +392,22 @@ Be highly descriptive and detailed. Aim for 75-150 words."""
             api_base = None
         
         try:
-            # Build kwargs for litellm
+            # Build kwargs for litellm with validated/corralled params
+            from core.llm_params import validate_params
+            param_kwargs, _ = validate_params(
+                provider, model_id,
+                {"temperature": temperature, "max_tokens": max_tokens},
+                on_warning=(lambda msg: console_callback(msg, "WARNING"))
+                if console_callback else None)
             kwargs = {
                 "model": model_id,
                 "messages": [
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt}
                 ],
-                "temperature": temperature,
-                "max_tokens": max_tokens
+                **param_kwargs
             }
-            
+
             # Add api_base for LM Studio
             if api_base:
                 kwargs["api_base"] = api_base
@@ -643,15 +648,18 @@ Return one enhanced visual description per line, numbered:
             else:
                 max_tokens = 150 * len(texts)
 
+            from core.llm_params import validate_params
+            param_kwargs, _ = validate_params(
+                provider, model_id,
+                {"temperature": temperature, "max_tokens": max_tokens,
+                 "timeout": 120})  # 2 minute timeout to prevent hanging
             kwargs = {
                 "model": model_id,
                 "messages": [
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": batch_prompt}
                 ],
-                "temperature": temperature,
-                "max_tokens": max_tokens,
-                "timeout": 120  # 2 minute timeout to prevent hanging
+                **param_kwargs
             }
 
             if api_base:
@@ -878,15 +886,18 @@ Format: Just return numbered prompts (1. ... 2. ... etc.), no other text."""
             # Adjust max_tokens for video prompts (slightly longer than image prompts)
             max_tokens = 200 * len(texts)  # ~200 tokens per video prompt
 
+            from core.llm_params import validate_params
+            param_kwargs, _ = validate_params(
+                provider, model_id,
+                {"temperature": temperature, "max_tokens": max_tokens,
+                 "timeout": 120})
             kwargs = {
                 "model": model_id,
                 "messages": [
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": batch_prompt}
                 ],
-                "temperature": temperature,
-                "max_tokens": max_tokens,
-                "timeout": 120
+                **param_kwargs
             }
 
             if api_base:
@@ -968,23 +979,21 @@ Format: Just return numbered prompts (1. ... 2. ... etc.), no other text."""
             from core.llm_models import resolve_model
             model = resolve_model('openai', 'gpt', static_default='gpt-4o')  # vision-capable
 
-        # Prepare kwargs for litellm
+        # Prepare kwargs for litellm with validated/corralled params
+        from core.llm_params import infer_provider_from_model, validate_params
+        provider = infer_provider_from_model(model)
+        param_kwargs, _ = validate_params(
+            provider, model,
+            {"temperature": temperature, "max_tokens": max_tokens,
+             "reasoning_effort": reasoning_effort,
+             "response_format": response_format},
+            on_warning=(lambda msg: console_callback(msg, "WARNING"))
+            if console_callback else None)
         kwargs = {
             'model': model,
             'messages': messages,
-            'temperature': temperature,
-            'max_tokens': max_tokens
+            **param_kwargs
         }
-
-        # Handle GPT-5 specific parameters
-        if 'gpt-5' in model.lower():
-            # GPT-5 requires temperature=1
-            kwargs['temperature'] = 1.0
-            # Note: reasoning_effort is not yet supported by the API
-            # It's a UI-only parameter for now
-
-        if response_format:
-            kwargs['response_format'] = response_format
 
         # Get appropriate API configuration
         if 'gpt' in model.lower() or 'openai' in model.lower():
@@ -1424,14 +1433,17 @@ Return only the enhanced video prompt."""
                 model_id = f"{prefix}{model}" if prefix else model
                 api_base = None
 
+            from core.llm_params import validate_params
+            param_kwargs, _ = validate_params(
+                provider, model_id,
+                {"temperature": 0.7, "max_tokens": 300})
             kwargs = {
                 "model": model_id,
                 "messages": [
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt}
                 ],
-                "temperature": 0.7,
-                "max_tokens": 300
+                **param_kwargs
             }
 
             if api_base:

--- a/core/video/scene_suggester.py
+++ b/core/video/scene_suggester.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from .tag_parser import TagParser, TagType, Tag
 from .prompt_engine import UnifiedLLMProvider
 from core.llm_models import get_provider_prefix
+from core.llm_params import normalize_provider, validate_params
 
 logger = logging.getLogger(__name__)
 
@@ -216,7 +217,8 @@ OUTPUT: Return the COMPLETE lyrics with tags inserted on new lines. Include ALL 
             return None
 
         # Build model identifier
-        prefix = get_provider_prefix(provider)
+        provider_id = normalize_provider(provider)
+        prefix = get_provider_prefix(provider_id)
         model_id = f"{prefix}{model}" if prefix else model
 
         # System message
@@ -227,14 +229,21 @@ OUTPUT: Return the COMPLETE lyrics with tags inserted on new lines. Include ALL 
         )
 
         try:
+            # Validate/corral params for this provider/model (clamps, drops,
+            # renames as needed — e.g. temperature dropped for Claude 5-line).
+            llm_kwargs, _ = validate_params(
+                provider_id, model, {
+                    "temperature": temperature,
+                    "max_tokens": 4000  # Allow for longer responses with tags
+                }
+            )
             kwargs = {
                 "model": model_id,
                 "messages": [
                     {"role": "system", "content": system_msg},
                     {"role": "user", "content": prompt}
                 ],
-                "temperature": temperature,
-                "max_tokens": 4000  # Allow for longer responses with tags
+                **llm_kwargs
             }
 
             logger.info(f"Calling LLM: {model_id}")

--- a/core/video/storyboard_v2.py
+++ b/core/video/storyboard_v2.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 from core.video.project import Scene, ReferenceImage
 from core.video.prompt_engine import UnifiedLLMProvider, PromptStyle
+from core.llm_models import get_provider_prefix
+from core.llm_params import normalize_provider, validate_params
 import re
 import uuid
 
@@ -359,27 +361,25 @@ CRITICAL: The video_prompt MUST include explicit time ranges (e.g., "0-3s:", "3-
 
             import litellm
 
-            # Prepare the model string
-            if provider == 'gemini':
-                model_id = f"gemini/{model}"
-            elif provider == 'openai':
-                model_id = model
-            elif provider == 'claude':
-                model_id = model
-            else:
-                model_id = model
+            # Prepare the model string (anthropic/gemini need LiteLLM prefixes)
+            provider_id = normalize_provider(provider)
+            prefix = get_provider_prefix(provider_id)
+            model_id = f"{prefix}{model}" if prefix else model
 
             self.logger.info(f"Generating Veo batched prompts with {provider}/{model}...")
             self.logger.info(f"Prompt sent to LLM:\n{'-'*80}\n{prompt}\n{'-'*80}")
 
+            llm_kwargs, _ = validate_params(
+                provider_id, model,
+                {"temperature": 0.7, "max_tokens": 3000}
+            )
             response = litellm.completion(
                 model=model_id,
                 messages=[
                     {"role": "system", "content": "You are a music video director. Respond only with valid JSON."},
                     {"role": "user", "content": prompt}
                 ],
-                temperature=0.7,
-                max_tokens=3000
+                **llm_kwargs
             )
 
             # Extract response text
@@ -538,25 +538,23 @@ CRITICAL: The video_prompt MUST include explicit time ranges (e.g., "0-3s:", "3-
             
             # Call the LLM directly for structured output
             import litellm
-            
-            # Prepare the model string
-            if provider == 'openai':
-                model_id = model
-            elif provider == 'claude':
-                model_id = model
-            elif provider == 'gemini':
-                model_id = f"gemini/{model}"
-            else:
-                model_id = model
-            
+
+            # Prepare the model string (anthropic/gemini need LiteLLM prefixes)
+            provider_id = normalize_provider(provider)
+            prefix = get_provider_prefix(provider_id)
+            model_id = f"{prefix}{model}" if prefix else model
+
+            llm_kwargs, _ = validate_params(
+                provider_id, model,
+                {"temperature": 0.7, "max_tokens": 4000}
+            )
             response = litellm.completion(
                 model=model_id,
                 messages=[
                     {"role": "system", "content": "You are a senior film editor. Respond only with valid JSON."},
                     {"role": "user", "content": prompt}
                 ],
-                temperature=0.7,
-                max_tokens=4000
+                **llm_kwargs
             )
             
             # Extract response text
@@ -620,25 +618,23 @@ CRITICAL: The video_prompt MUST include explicit time ranges (e.g., "0-3s:", "3-
                 return None, []
             
             import litellm
-            
-            # Prepare the model string
-            if provider == 'gemini':
-                model_id = f"gemini/{model}"
-            elif provider == 'openai':
-                model_id = model
-            elif provider == 'claude':
-                model_id = model
-            else:
-                model_id = model
-            
+
+            # Prepare the model string (anthropic/gemini need LiteLLM prefixes)
+            provider_id = normalize_provider(provider)
+            prefix = get_provider_prefix(provider_id)
+            model_id = f"{prefix}{model}" if prefix else model
+
+            llm_kwargs, _ = validate_params(
+                provider_id, model,
+                {"temperature": 0.7, "max_tokens": 4000}
+            )
             response = litellm.completion(
                 model=model_id,
                 messages=[
                     {"role": "system", "content": "You are a music video director. Respond only with valid JSON."},
                     {"role": "user", "content": prompt}
                 ],
-                temperature=0.7,
-                max_tokens=4000
+                **llm_kwargs
             )
             
             # Extract response text

--- a/gui/enhanced_prompt_dialog.py
+++ b/gui/enhanced_prompt_dialog.py
@@ -596,13 +596,14 @@ class EnhancedPromptDialog(QDialog, OperationGuardMixin):
         if is_gpt5:
             reasoning = self.reasoning_combo.currentText()
             verbosity = self.verbosity_combo.currentText()
-            temperature = 1.0  # GPT-5 only supports temperature=1
             max_tokens = 1000  # Default for GPT-5
         else:
             reasoning = "medium"
             verbosity = "medium"
-            temperature = self.temperature_spin.value()
             max_tokens = self.max_tokens_spin.value()
+        # Pass the user's temperature as-is; core.llm_params corrals it per
+        # model (e.g. drops it for models that only accept the default).
+        temperature = self.temperature_spin.value()
 
         self.worker = EnhanceWorker(
             prompt,

--- a/gui/layout/text_gen_dialog.py
+++ b/gui/layout/text_gen_dialog.py
@@ -15,6 +15,7 @@ from PySide6.QtCore import Qt, QThread, Signal, QSettings
 from core.config import ConfigManager
 from core.layout.models import TextBlock, DocumentSpec
 from core.llm_models import get_provider_models, get_provider_prefix
+from core.llm_params import validate_params
 from core.discord_rpc import discord_rpc, ActivityState
 from gui.llm_utils import DialogStatusConsole, LiteLLMHandler, LLMResponseParser
 from ..common.dialog_conventions import (
@@ -125,11 +126,17 @@ class TextGenerationWorker(QThread):
             self.progress.emit(f"Calling {model}...")
             messages = [{"role": "user", "content": prompt}]
 
-            # Handle temperature parameter compatibility
+            # Validate/corral params centrally (clamps ranges, drops
+            # temperature for models that reject it)
+            validated_params, _ = validate_params(
+                provider_id, model_name, {"temperature": self.temperature},
+                on_warning=self.progress.emit
+            )
+
             completion_kwargs = {
                 "model": model,
                 "messages": messages,
-                "temperature": self.temperature
+                **validated_params
             }
 
             # Only add API key if provided (for API key auth mode)

--- a/gui/prompt_generation_dialog.py
+++ b/gui/prompt_generation_dialog.py
@@ -22,6 +22,7 @@ from .common.dialog_conventions import (
 from .dialog_utils import OperationGuardMixin, guard_operation
 from .history_widget import DialogHistoryWidget
 from core.discord_rpc import discord_rpc, ActivityState
+from core.llm_params import validate_params
 
 logger = logging.getLogger(__name__)
 console = logging.getLogger("console")
@@ -114,6 +115,12 @@ class LLMWorker(QObject):
                 console.warning("LiteLLM not installed, falling back to direct SDK")
                 use_litellm = False
 
+            def _param_warn(msg: str) -> None:
+                # Surface param corrections in the status console alongside the
+                # file log (core.llm_params already logs via its own logger).
+                console.warning(f"LLM param: {msg}")
+                self.log_message.emit(f"LLM param: {msg}", "WARNING")
+
             # Create the prompt for the LLM
             system_prompt = """You are a creative prompt engineer for AI image generation.
                 Generate creative, detailed prompts based on the user's input.
@@ -129,18 +136,13 @@ class LLMWorker(QObject):
                 model_name = self.llm_model or "gpt-4"
 
                 if use_litellm:
-                    # Use litellm for better compatibility
-                    # Adjust parameters based on model
-                    if "gpt-5" in model_name.lower():
-                        # GPT-5 specific parameters
-                        temp = 1.0  # GPT-5 only supports temperature=1
-                        # Note: reasoning_effort and verbosity are not yet supported by the API
-                        logger.info(f"  Reasoning effort: {self.reasoning_effort} (UI only - not sent to API)")
-                        console.info(f"  Reasoning effort: {self.reasoning_effort} (UI only - not sent to API)")
-                        logger.info(f"  Verbosity: {self.verbosity} (UI only - not sent to API)")
-                        console.info(f"  Verbosity: {self.verbosity} (UI only - not sent to API)")
-                    else:
-                        temp = self.temperature
+                    # Use litellm for better compatibility.
+                    # core.llm_params owns per-model corralling (GPT-5
+                    # temperature lock, max_tokens -> max_completion_tokens).
+                    llm_kwargs, _ = validate_params(
+                        "openai", model_name,
+                        {"temperature": self.temperature, "max_tokens": self.max_tokens},
+                        on_warning=_param_warn)
 
                     request_data = {
                         "model": model_name,
@@ -148,9 +150,10 @@ class LLMWorker(QObject):
                             {"role": "system", "content": system_prompt},
                             {"role": "user", "content": user_prompt}
                         ],
-                        "temperature": temp,
-                        "max_tokens": self.max_tokens  # litellm will handle conversion
+                        **llm_kwargs
                     }
+
+                    token_value = llm_kwargs.get('max_tokens', llm_kwargs.get('max_completion_tokens'))
 
                     logger.info(f"LLM Request - Sending via LiteLLM to OpenAI:")
                     console.info(f"LLM Request - Sending via LiteLLM to OpenAI:")
@@ -158,11 +161,11 @@ class LLMWorker(QObject):
                     logger.info(f"  Model: {model_name}")
                     console.info(f"  Model: {model_name}")
 
-                    logger.info(f"  Temperature: {request_data['temperature']}")
-                    console.info(f"  Temperature: {request_data['temperature']}")
+                    logger.info(f"  Temperature: {request_data.get('temperature', 'default')}")
+                    console.info(f"  Temperature: {request_data.get('temperature', 'default')}")
 
-                    logger.info(f"  Max tokens: {request_data['max_tokens']}")
-                    console.info(f"  Max tokens: {request_data['max_tokens']}")
+                    logger.info(f"  Max tokens: {token_value}")
+                    console.info(f"  Max tokens: {token_value}")
 
                     # Clean up multi-line strings for logging
                     clean_system = system_prompt.replace('\n', ' ').strip()
@@ -180,11 +183,15 @@ class LLMWorker(QObject):
                     from openai import OpenAI
                     client = OpenAI(api_key=self.api_key)
 
-                    # Use max_completion_tokens for newer models (gpt-4, gpt-5, etc), max_tokens for gpt-3.5
-                    token_param = "max_completion_tokens" if "gpt-3.5" not in model_name.lower() else "max_tokens"
-
-                    # For gpt-5, use temperature=1 (the only supported value)
-                    temperature = 1.0 if "gpt-5" in model_name.lower() else self.temperature
+                    # core.llm_params picks the right token param name
+                    # (max_completion_tokens for reasoning models) and drops
+                    # temperature where the model rejects it (GPT-5 line).
+                    llm_kwargs, _ = validate_params(
+                        "openai", model_name,
+                        {"temperature": self.temperature, "max_tokens": self.max_tokens},
+                        on_warning=_param_warn)
+                    token_param = ("max_completion_tokens"
+                                   if "max_completion_tokens" in llm_kwargs else "max_tokens")
 
                     request_data = {
                         "model": model_name,
@@ -192,8 +199,7 @@ class LLMWorker(QObject):
                             {"role": "system", "content": system_prompt},
                             {"role": "user", "content": user_prompt}
                         ],
-                        "temperature": temperature,
-                        token_param: self.max_tokens
+                        **llm_kwargs
                     }
 
                     logger.info(f"LLM Request - Sending to OpenAI API:")
@@ -202,11 +208,11 @@ class LLMWorker(QObject):
                     logger.info(f"  Model: {request_data['model']}")
                     console.info(f"  Model: {request_data['model']}")
 
-                    logger.info(f"  Temperature: {request_data['temperature']}")
-                    console.info(f"  Temperature: {request_data['temperature']}")
+                    logger.info(f"  Temperature: {request_data.get('temperature', 'default')}")
+                    console.info(f"  Temperature: {request_data.get('temperature', 'default')}")
 
-                    logger.info(f"  Token limit ({token_param}): {request_data[token_param]}")
-                    console.info(f"  Token limit ({token_param}): {request_data[token_param]}")
+                    logger.info(f"  Token limit ({token_param}): {request_data.get(token_param)}")
+                    console.info(f"  Token limit ({token_param}): {request_data.get(token_param)}")
 
                     # Clean up multi-line strings for logging
                     clean_system = system_prompt.replace('\n', ' ').strip()
@@ -355,14 +361,18 @@ class LLMWorker(QObject):
                         else:
                             litellm_model = model_name
 
+                    llm_kwargs, _ = validate_params(
+                        "gemini", model_name,
+                        {"temperature": self.temperature, "max_tokens": self.max_tokens},
+                        on_warning=_param_warn)
+
                     request_data = {
                         "model": litellm_model,
                         "messages": [
                             {"role": "system", "content": system_prompt},
                             {"role": "user", "content": user_prompt}
                         ],
-                        "temperature": self.temperature,
-                        "max_tokens": self.max_tokens
+                        **llm_kwargs
                     }
 
                     # Only add API key if provided (for API key auth mode)
@@ -381,11 +391,11 @@ class LLMWorker(QObject):
                     logger.info(f"  Model: {request_data['model']}")
                     console.info(f"  Model: {request_data['model']}")
 
-                    logger.info(f"  Temperature: {request_data['temperature']}")
-                    console.info(f"  Temperature: {request_data['temperature']}")
+                    logger.info(f"  Temperature: {request_data.get('temperature', 'default')}")
+                    console.info(f"  Temperature: {request_data.get('temperature', 'default')}")
 
-                    logger.info(f"  Max tokens: {request_data['max_tokens']}")
-                    console.info(f"  Max tokens: {request_data['max_tokens']}")
+                    logger.info(f"  Max tokens: {request_data.get('max_tokens')}")
+                    console.info(f"  Max tokens: {request_data.get('max_tokens')}")
 
                     # Clean up multi-line strings for logging
                     clean_system = system_prompt.replace('\n', ' ').strip()
@@ -518,14 +528,19 @@ class LLMWorker(QObject):
                 if use_litellm:
                     # Use litellm with Anthropic provider - must prefix with "anthropic/"
                     litellm_model = f"anthropic/{model_name}"
+                    # core.llm_params drops sampling params the Claude 5-line
+                    # rejects and clamps temperature to 0..1 for older models.
+                    llm_kwargs, _ = validate_params(
+                        "anthropic", model_name,
+                        {"temperature": self.temperature, "max_tokens": self.max_tokens},
+                        on_warning=_param_warn)
                     request_data = {
                         "model": litellm_model,
                         "messages": [
                             {"role": "system", "content": system_prompt},
                             {"role": "user", "content": user_prompt}
                         ],
-                        "temperature": self.temperature,
-                        "max_tokens": self.max_tokens,
+                        **llm_kwargs,
                         "api_key": self.api_key  # Pass API key directly to LiteLLM
                     }
 
@@ -535,11 +550,11 @@ class LLMWorker(QObject):
                     logger.info(f"  Model: {litellm_model} (original: {model_name})")
                     console.info(f"  Model: {litellm_model} (original: {model_name})")
 
-                    logger.info(f"  Temperature: {request_data['temperature']}")
-                    console.info(f"  Temperature: {request_data['temperature']}")
+                    logger.info(f"  Temperature: {request_data.get('temperature', 'default')}")
+                    console.info(f"  Temperature: {request_data.get('temperature', 'default')}")
 
-                    logger.info(f"  Max tokens: {request_data['max_tokens']}")
-                    console.info(f"  Max tokens: {request_data['max_tokens']}")
+                    logger.info(f"  Max tokens: {request_data.get('max_tokens')}")
+                    console.info(f"  Max tokens: {request_data.get('max_tokens')}")
 
                     # Clean up multi-line strings for logging
                     clean_system = system_prompt.replace('\n', ' ').strip()
@@ -557,14 +572,24 @@ class LLMWorker(QObject):
                     from anthropic import Anthropic
                     client = Anthropic(api_key=self.api_key)
 
+                    # Validate through core.llm_params; the anthropic SDK takes
+                    # the same key names (temperature/max_tokens/top_p/top_k).
+                    llm_kwargs, _ = validate_params(
+                        "anthropic", model_name,
+                        {"temperature": self.temperature, "max_tokens": self.max_tokens},
+                        on_warning=_param_warn)
+                    sdk_params = {k: v for k, v in llm_kwargs.items()
+                                  if k in ("temperature", "max_tokens", "top_p", "top_k")}
+                    # The anthropic SDK requires max_tokens
+                    sdk_params.setdefault("max_tokens", self.max_tokens)
+
                     request_data = {
                         "model": model_name,
                         "messages": [
                             {"role": "user", "content": user_prompt}
                         ],
                         "system": system_prompt,
-                        "temperature": self.temperature,
-                        "max_tokens": self.max_tokens
+                        **sdk_params
                     }
 
                     logger.info(f"LLM Request - Sending to Claude API:")
@@ -573,11 +598,11 @@ class LLMWorker(QObject):
                     logger.info(f"  Model: {request_data['model']}")
                     console.info(f"  Model: {request_data['model']}")
 
-                    logger.info(f"  Temperature: {request_data['temperature']}")
-                    console.info(f"  Temperature: {request_data['temperature']}")
+                    logger.info(f"  Temperature: {request_data.get('temperature', 'default')}")
+                    console.info(f"  Temperature: {request_data.get('temperature', 'default')}")
 
-                    logger.info(f"  Max tokens: {request_data['max_tokens']}")
-                    console.info(f"  Max tokens: {request_data['max_tokens']}")
+                    logger.info(f"  Max tokens: {request_data.get('max_tokens')}")
+                    console.info(f"  Max tokens: {request_data.get('max_tokens')}")
 
                     # Clean up multi-line strings for logging
                     clean_system = system_prompt.replace('\n', ' ').strip()
@@ -1169,13 +1194,14 @@ class PromptGenerationDialog(DialogCleanupMixin, QDialog, OperationGuardMixin):
         if is_gpt5:
             reasoning = self.reasoning_combo.currentText()
             verbosity = self.verbosity_combo.currentText()
-            temperature = 1.0  # GPT-5 only supports temperature=1
             max_tokens = 1500  # Default for GPT-5
         else:
             reasoning = "medium"
             verbosity = "medium"
-            temperature = self.temperature_spin.value()
             max_tokens = self.max_tokens_spin.value()
+        # Pass the user's temperature as-is; core.llm_params corrals it per
+        # model (e.g. drops it for models that only accept the default).
+        temperature = self.temperature_spin.value()
 
         # Ensure sufficient tokens for the requested number of variations
         # Each detailed prompt needs ~150 tokens, plus overhead for JSON formatting

--- a/gui/prompt_question_dialog.py
+++ b/gui/prompt_question_dialog.py
@@ -123,14 +123,22 @@ class QuestionWorker(QObject):
             if self.llm_provider.lower() == "openai":
                 model_name = self.llm_model or "gpt-4"
 
+                # Validate/corral params centrally (drops temperature for
+                # models that reject it, e.g. gpt-5 reasoning models).
+                from core.llm_params import validate_params
+                # Don't specify max_tokens - let model decide
+                validated_params, _ = validate_params(
+                    "openai", model_name, {"temperature": self.temperature},
+                    on_warning=lambda msg: self.log_message.emit(msg, "WARNING")
+                )
+
                 if use_litellm:
                     import litellm
-                    # Don't specify max_tokens - let model decide
                     response = litellm.completion(
                         model=model_name,
                         messages=messages,
-                        temperature=self.temperature,
-                        api_key=self.api_key
+                        api_key=self.api_key,
+                        **validated_params
                     )
                     answer = response.choices[0].message.content
                 else:
@@ -139,7 +147,7 @@ class QuestionWorker(QObject):
                     response = client.chat.completions.create(
                         model=model_name,
                         messages=messages,
-                        temperature=self.temperature
+                        **validated_params
                     )
                     answer = response.choices[0].message.content
 

--- a/gui/video/start_prompt_dialog.py
+++ b/gui/video/start_prompt_dialog.py
@@ -168,18 +168,24 @@ Generate a detailed visual description suitable for AI image generation."""
         import litellm
         litellm.drop_params = True
 
+        from core.llm_params import build_completion_kwargs
+
         self.logger.info(f"Calling LLM with provider={self.provider}, model={self.model}")
         self.logger.info(f"User prompt: {user_prompt}")
 
-        response = litellm.completion(
-            model=f"{self.provider}/{self.model}",
-            messages=[
+        # Centralized param validation + route prefixing (normalizes provider
+        # display names like 'google'/'claude' to their LiteLLM routes).
+        completion_kwargs = build_completion_kwargs(
+            self.provider,
+            self.model,
+            [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}
             ],
-            temperature=0.7,
-            api_key=self.api_key
+            {"temperature": 0.7},
+            api_key=self.api_key,
         )
+        response = litellm.completion(**completion_kwargs)
 
         prompt = response.choices[0].message.content.strip()
         self.logger.info(f"Generated prompt: {prompt}")

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@
 # Qt event loop forever in headless runs), so a bare `pytest` that collected them
 # would hang. Run a demo explicitly by path if you ever need it.
 testpaths = tests
+markers =
+    live: hits real provider APIs (costs money); skipped unless IMAGEAI_LIVE_TESTS=1

--- a/tests/test_live_llm_params.py
+++ b/tests/test_live_llm_params.py
@@ -38,9 +38,10 @@ _TIMEOUT = 90
 @pytest.fixture(scope="module")
 def litellm_mod():
     litellm = pytest.importorskip("litellm")
+    saved = litellm.drop_params
     litellm.drop_params = False  # raw tests must NOT be silently rescued
     yield litellm
-    litellm.drop_params = True
+    litellm.drop_params = saved
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_live_llm_params.py
+++ b/tests/test_live_llm_params.py
@@ -1,0 +1,256 @@
+"""Live API boundary tests for core/llm_params.py.
+
+These hit real provider APIs and cost (a little) money. They are skipped
+unless ``IMAGEAI_LIVE_TESTS=1`` is set, and each provider's tests skip when
+its API key is not configured.
+
+Purpose: empirically verify the curated capability rules against provider
+documentation —
+  - Anthropic Claude 5-line rejects ``temperature`` (the style-dialog bug),
+  - older Claude accepts temperature only in [0, 1] and rejects
+    temperature+top_p together,
+  - OpenAI reasoning models (gpt-5.x) reject non-default temperature and
+    require ``max_completion_tokens``,
+  - classic OpenAI models accept temperature up to 2.0 and reject beyond,
+  - Gemini accepts temperature up to 2.0 and rejects beyond,
+and that the corralled request succeeds in every case where the raw one 400s.
+
+Run:  IMAGEAI_LIVE_TESTS=1 python3 -m pytest tests/test_live_llm_params.py -m live -v
+"""
+
+import os
+
+import pytest
+
+from core.llm_params import LLMParams, build_completion_kwargs, validate_params
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        os.environ.get("IMAGEAI_LIVE_TESTS") != "1",
+        reason="live API tests disabled (set IMAGEAI_LIVE_TESTS=1)"),
+]
+
+_MSGS = [{"role": "user", "content": "Reply with the single word: ok"}]
+_TIMEOUT = 90
+
+
+@pytest.fixture(scope="module")
+def litellm_mod():
+    litellm = pytest.importorskip("litellm")
+    litellm.drop_params = False  # raw tests must NOT be silently rescued
+    yield litellm
+    litellm.drop_params = True
+
+
+@pytest.fixture(scope="module")
+def keys():
+    from core.config import ConfigManager
+    config = ConfigManager()
+    return {
+        "anthropic": config.get_api_key("anthropic"),
+        "openai": config.get_api_key("openai"),
+        "google": config.get_api_key("google"),
+    }
+
+
+def _need(keys, provider):
+    if not keys.get(provider):
+        pytest.skip(f"no {provider} API key configured")
+    return keys[provider]
+
+
+def _raw_call(litellm_mod, **kwargs):
+    return litellm_mod.completion(timeout=_TIMEOUT, **kwargs)
+
+
+def _corralled_call(litellm_mod, provider, model, params, api_key):
+    kwargs = build_completion_kwargs(provider, model, _MSGS, params,
+                                     api_key=api_key)
+    kwargs.setdefault("timeout", _TIMEOUT)
+    return litellm_mod.completion(**kwargs)
+
+
+# --- Anthropic: Claude 5-line rejects sampling params ------------------------
+
+class TestAnthropicClaude5:
+    MODEL = "claude-sonnet-5"
+
+    def test_raw_temperature_rejected(self, litellm_mod, keys):
+        """Documents the bug from imageai_current.log: temperature -> 400."""
+        api_key = _need(keys, "anthropic")
+        with pytest.raises(litellm_mod.BadRequestError, match="temperature"):
+            _raw_call(litellm_mod, model=f"anthropic/{self.MODEL}",
+                      messages=_MSGS, temperature=0.7, max_tokens=32,
+                      api_key=api_key)
+
+    def test_raw_top_p_rejected(self, litellm_mod, keys):
+        api_key = _need(keys, "anthropic")
+        with pytest.raises(litellm_mod.BadRequestError, match="top_p"):
+            _raw_call(litellm_mod, model=f"anthropic/{self.MODEL}",
+                      messages=_MSGS, top_p=0.9, max_tokens=32,
+                      api_key=api_key)
+
+    def test_corralled_succeeds(self, litellm_mod, keys):
+        api_key = _need(keys, "anthropic")
+        response = _corralled_call(
+            litellm_mod, "anthropic", self.MODEL,
+            LLMParams(temperature=0.7, max_tokens=32), api_key)
+        assert response.choices[0].message.content
+
+
+# --- Anthropic: older Claude, temperature range 0..1 -------------------------
+
+class TestAnthropicHaiku:
+    MODEL = "claude-haiku-4-5-20251001"
+
+    def test_temperature_upper_bound_ok(self, litellm_mod, keys):
+        api_key = _need(keys, "anthropic")
+        response = _raw_call(litellm_mod, model=f"anthropic/{self.MODEL}",
+                             messages=_MSGS, temperature=1.0, max_tokens=32,
+                             api_key=api_key)
+        assert response.choices[0].message.content
+
+    def test_temperature_above_one_rejected_raw(self, litellm_mod, keys):
+        api_key = _need(keys, "anthropic")
+        with pytest.raises(litellm_mod.BadRequestError, match="temperature"):
+            _raw_call(litellm_mod, model=f"anthropic/{self.MODEL}",
+                      messages=_MSGS, temperature=1.5, max_tokens=32,
+                      api_key=api_key)
+
+    def test_temperature_above_one_corralled(self, litellm_mod, keys):
+        api_key = _need(keys, "anthropic")
+        params, warnings = validate_params(
+            "anthropic", self.MODEL, {"temperature": 1.5, "max_tokens": 32})
+        assert params["temperature"] == 1.0 and warnings
+        response = _corralled_call(
+            litellm_mod, "anthropic", self.MODEL,
+            LLMParams(temperature=1.5, max_tokens=32), api_key)
+        assert response.choices[0].message.content
+
+    def test_temp_and_top_p_together_rejected_raw(self, litellm_mod, keys):
+        api_key = _need(keys, "anthropic")
+        with pytest.raises(litellm_mod.BadRequestError):
+            _raw_call(litellm_mod, model=f"anthropic/{self.MODEL}",
+                      messages=_MSGS, temperature=0.5, top_p=0.9,
+                      max_tokens=32, api_key=api_key)
+
+    def test_temp_and_top_p_corralled(self, litellm_mod, keys):
+        api_key = _need(keys, "anthropic")
+        response = _corralled_call(
+            litellm_mod, "anthropic", self.MODEL,
+            LLMParams(temperature=0.5, top_p=0.9, max_tokens=32), api_key)
+        assert response.choices[0].message.content
+
+    def test_max_tokens_over_limit_corralled(self, litellm_mod, keys):
+        """Registry says 64000 output max; 100k request must be capped."""
+        api_key = _need(keys, "anthropic")
+        params, warnings = validate_params(
+            "anthropic", self.MODEL, {"max_tokens": 100_000})
+        assert params["max_tokens"] == 64000 and warnings
+        response = _corralled_call(
+            litellm_mod, "anthropic", self.MODEL,
+            LLMParams(temperature=0.0, max_tokens=100_000), api_key)
+        assert response.choices[0].message.content
+
+
+# --- OpenAI: reasoning models (gpt-5.x) --------------------------------------
+
+class TestOpenAIReasoning:
+    MODEL = "gpt-5.6-luna"  # nano tier — cheapest of the family
+
+    def test_raw_nondefault_temperature_rejected(self, litellm_mod, keys):
+        api_key = _need(keys, "openai")
+        with pytest.raises(litellm_mod.BadRequestError, match="temperature"):
+            _raw_call(litellm_mod, model=self.MODEL, messages=_MSGS,
+                      temperature=0.5, max_completion_tokens=32,
+                      api_key=api_key)
+
+    def test_corralled_succeeds_with_renamed_tokens(self, litellm_mod, keys):
+        api_key = _need(keys, "openai")
+        params, warnings = validate_params(
+            "openai", self.MODEL,
+            {"temperature": 0.5, "max_tokens": 256, "reasoning_effort": "low"})
+        assert "temperature" not in params
+        assert params["max_completion_tokens"] == 256
+        assert params["reasoning_effort"] == "low"
+        assert warnings
+        response = _corralled_call(
+            litellm_mod, "openai", self.MODEL,
+            LLMParams(temperature=0.5, max_tokens=256, reasoning_effort="low"),
+            api_key)
+        assert response.choices  # reasoning may consume tokens; call must succeed
+
+
+class TestOpenAIClassic:
+    MODEL = "gpt-4o-mini"
+
+    def test_temperature_upper_bound_ok(self, litellm_mod, keys):
+        api_key = _need(keys, "openai")
+        response = _raw_call(litellm_mod, model=self.MODEL, messages=_MSGS,
+                             temperature=2.0, max_tokens=32, api_key=api_key)
+        assert response.choices
+
+    def test_temperature_above_two_rejected_raw(self, litellm_mod, keys):
+        api_key = _need(keys, "openai")
+        with pytest.raises(litellm_mod.BadRequestError, match="temperature"):
+            _raw_call(litellm_mod, model=self.MODEL, messages=_MSGS,
+                      temperature=2.5, max_tokens=32, api_key=api_key)
+
+    def test_temperature_above_two_corralled(self, litellm_mod, keys):
+        api_key = _need(keys, "openai")
+        response = _corralled_call(
+            litellm_mod, "openai", self.MODEL,
+            LLMParams(temperature=2.5, max_tokens=32), api_key)
+        assert response.choices
+
+
+# --- Gemini ------------------------------------------------------------------
+
+class TestGemini:
+    MODEL = "gemini-2.5-flash-lite"
+
+    def test_temperature_upper_bound_ok(self, litellm_mod, keys):
+        api_key = _need(keys, "google")
+        response = _raw_call(litellm_mod, model=f"gemini/{self.MODEL}",
+                             messages=_MSGS, temperature=2.0, max_tokens=32,
+                             api_key=api_key)
+        assert response.choices
+
+    def test_temperature_above_two_rejected_raw(self, litellm_mod, keys):
+        api_key = _need(keys, "google")
+        with pytest.raises(litellm_mod.BadRequestError):
+            _raw_call(litellm_mod, model=f"gemini/{self.MODEL}",
+                      messages=_MSGS, temperature=2.5, max_tokens=32,
+                      api_key=api_key)
+
+    def test_temperature_above_two_corralled(self, litellm_mod, keys):
+        api_key = _need(keys, "google")
+        response = _corralled_call(
+            litellm_mod, "gemini", self.MODEL,
+            LLMParams(temperature=2.5, max_tokens=32), api_key)
+        assert response.choices
+
+
+# --- End-to-end regression: the style-analysis path --------------------------
+
+class TestStyleAnalyzerRegression:
+    """Replicates the exact failing path from imageai_current.log:
+    core/styles/analyzer.py -> UnifiedLLMProvider.analyze_image with a
+    Claude 5-line model and temperature=0.7 (previously a 400)."""
+
+    @pytest.mark.parametrize("model", ["anthropic/claude-opus-5",
+                                       "anthropic/claude-sonnet-5"])
+    def test_analyze_image_claude5(self, keys, model):
+        api_key = _need(keys, "anthropic")
+        from core.video.prompt_engine import UnifiedLLMProvider
+        provider = UnifiedLLMProvider({"anthropic_api_key": api_key})
+        result = provider.analyze_image(
+            messages=[{"role": "user",
+                       "content": "Answer with one word: what color is grass?"}],
+            model=model,
+            temperature=0.7,   # would have 400'd before the param layer
+            max_tokens=64,
+            max_retries=0,
+        )
+        assert isinstance(result, str) and result.strip()

--- a/tests/test_llm_params.py
+++ b/tests/test_llm_params.py
@@ -1,0 +1,225 @@
+"""Unit tests for core/llm_params.py — rules resolution, corralling, errors."""
+
+import pytest
+
+from core.llm_params import (
+    LLMParamError,
+    LLMParams,
+    build_completion_kwargs,
+    get_param_rules,
+    normalize_provider,
+    strip_route_prefix,
+    validate_params,
+)
+
+
+# --- provider/model normalization -------------------------------------------
+
+def test_normalize_provider_aliases():
+    assert normalize_provider("Google") == "gemini"
+    assert normalize_provider("claude") == "anthropic"
+    assert normalize_provider("LM Studio") == "lmstudio"
+    assert normalize_provider("OpenAI") == "openai"
+    assert normalize_provider("ollama") == "ollama"
+
+
+def test_strip_route_prefix():
+    assert strip_route_prefix("anthropic/claude-opus-5") == "claude-opus-5"
+    assert strip_route_prefix("vertex_ai/gemini-2.5-flash") == "gemini-2.5-flash"
+    assert strip_route_prefix("gpt-4o") == "gpt-4o"
+
+
+# --- rules resolution --------------------------------------------------------
+
+def test_claude5_family_rejects_sampling():
+    for model in ("claude-opus-5", "claude-sonnet-5", "claude-fable-5",
+                  "claude-opus-4-7", "claude-opus-4-8",
+                  "anthropic/claude-opus-5"):
+        rules = get_param_rules("anthropic", model)
+        assert rules.temperature_range is None, model
+        assert not rules.top_p_supported, model
+
+
+def test_older_claude_keeps_temperature_zero_to_one():
+    for model in ("claude-opus-4-5-20251101", "claude-sonnet-4-6",
+                  "claude-haiku-4-5-20251001", "claude-3-7-sonnet-20250219"):
+        rules = get_param_rules("anthropic", model)
+        assert rules.temperature_range == (0.0, 1.0), model
+        assert rules.temp_top_p_exclusive, model
+
+
+def test_openai_reasoning_models_fix_temperature():
+    for model in ("gpt-5.6-sol", "gpt-5.6-luna", "gpt-5.5-pro", "o4-mini",
+                  "o3", "o1-pro", "chat-latest"):
+        rules = get_param_rules("openai", model)
+        assert rules.temperature_fixed == 1.0, model
+        assert rules.tokens_param == "max_completion_tokens", model
+        assert rules.supports_reasoning_effort, model
+
+
+def test_openai_classic_models_allow_temperature():
+    rules = get_param_rules("openai", "gpt-4o")
+    assert rules.temperature_range == (0.0, 2.0)
+    assert rules.tokens_param == "max_tokens"
+
+
+def test_gemini_rules():
+    rules = get_param_rules("Google", "gemini-2.5-flash")
+    assert rules.temperature_range == (0.0, 2.0)
+    assert rules.top_k_supported
+
+
+def test_unknown_provider_is_permissive():
+    rules = get_param_rules("someprovider", "somemodel")
+    assert rules.temperature_range == (0.0, 2.0)
+
+
+def test_registry_supplies_max_output_tokens():
+    rules = get_param_rules("anthropic", "claude-haiku-4-5-20251001")
+    assert rules.max_output_tokens == 64000
+
+
+# --- corralling ---------------------------------------------------------------
+
+def test_temperature_dropped_on_claude5():
+    kwargs, warnings = validate_params(
+        "anthropic", "claude-opus-5", LLMParams(temperature=0.7, max_tokens=100))
+    assert "temperature" not in kwargs
+    assert kwargs["max_tokens"] == 100
+    assert warnings and "temperature" in warnings[0]
+
+
+def test_temperature_clamped_on_older_claude():
+    kwargs, warnings = validate_params(
+        "anthropic", "claude-haiku-4-5-20251001", LLMParams(temperature=1.5))
+    assert kwargs["temperature"] == 1.0
+    assert warnings
+
+
+def test_temperature_clamped_on_openai_classic():
+    kwargs, _ = validate_params("openai", "gpt-4o", LLMParams(temperature=2.5))
+    assert kwargs["temperature"] == 2.0
+    kwargs, _ = validate_params("openai", "gpt-4o", LLMParams(temperature=-0.5))
+    assert kwargs["temperature"] == 0.0
+
+
+def test_gpt5_temperature_dropped_unless_default():
+    kwargs, warnings = validate_params(
+        "openai", "gpt-5.6-luna", LLMParams(temperature=0.5))
+    assert "temperature" not in kwargs
+    assert warnings
+    # the only accepted value is omitted too (provider default applies)
+    kwargs, warnings = validate_params(
+        "openai", "gpt-5.6-luna", LLMParams(temperature=1.0))
+    assert "temperature" not in kwargs
+    assert not warnings
+
+
+def test_tokens_param_renamed_for_reasoning_models():
+    kwargs, _ = validate_params(
+        "openai", "gpt-5.6-luna", LLMParams(max_tokens=200))
+    assert kwargs == {"max_completion_tokens": 200}
+
+
+def test_max_tokens_capped_at_model_limit():
+    kwargs, warnings = validate_params(
+        "anthropic", "claude-haiku-4-5-20251001", LLMParams(max_tokens=100_000))
+    assert kwargs["max_tokens"] == 64000
+    assert warnings
+
+
+def test_temp_top_p_exclusive_on_older_claude():
+    kwargs, warnings = validate_params(
+        "anthropic", "claude-sonnet-4-6",
+        LLMParams(temperature=0.7, top_p=0.9))
+    assert kwargs["temperature"] == 0.7
+    assert "top_p" not in kwargs
+    assert warnings
+
+
+def test_reasoning_effort_dropped_where_unsupported():
+    kwargs, warnings = validate_params(
+        "anthropic", "claude-opus-5", LLMParams(reasoning_effort="low"))
+    assert "reasoning_effort" not in kwargs
+    assert warnings
+    kwargs, _ = validate_params(
+        "openai", "gpt-5.6-luna", LLMParams(reasoning_effort="low"))
+    assert kwargs["reasoning_effort"] == "low"
+
+
+def test_dict_params_accepted_and_unknown_keys_ignored():
+    kwargs, _ = validate_params(
+        "openai", "gpt-4o", {"temperature": 0.3, "not_a_param": 1})
+    assert kwargs == {"temperature": 0.3}
+
+
+def test_on_warning_callback_invoked():
+    seen = []
+    validate_params("anthropic", "claude-opus-5",
+                    LLMParams(temperature=0.7), on_warning=seen.append)
+    assert len(seen) == 1
+
+
+# --- errors -------------------------------------------------------------------
+
+def test_strict_mode_raises_instead_of_corralling():
+    with pytest.raises(LLMParamError):
+        validate_params("anthropic", "claude-opus-5",
+                        LLMParams(temperature=0.7), strict=True)
+    with pytest.raises(LLMParamError):
+        validate_params("openai", "gpt-4o",
+                        LLMParams(temperature=3.0), strict=True)
+
+
+def test_nonsense_values_raise():
+    with pytest.raises(LLMParamError):
+        validate_params("openai", "gpt-4o", LLMParams(max_tokens=-5))
+    with pytest.raises(LLMParamError):
+        validate_params("openai", "gpt-4o", LLMParams(max_tokens=0))
+    with pytest.raises(LLMParamError):
+        validate_params("openai", "gpt-4o", {"temperature": "hot"})
+    with pytest.raises(LLMParamError):
+        validate_params("openai", "gpt-5.6-luna",
+                        LLMParams(reasoning_effort="ultra"))
+    with pytest.raises(LLMParamError):
+        validate_params("openai", "gpt-4o", LLMParams(verbosity="loud"))
+
+
+# --- build_completion_kwargs --------------------------------------------------
+
+_MSGS = [{"role": "user", "content": "hi"}]
+
+
+def test_build_kwargs_anthropic_prefix():
+    kwargs = build_completion_kwargs(
+        "anthropic", "claude-opus-5", _MSGS,
+        LLMParams(temperature=0.7, max_tokens=64), api_key="k")
+    assert kwargs["model"] == "anthropic/claude-opus-5"
+    assert kwargs["api_key"] == "k"
+    assert "temperature" not in kwargs
+    assert kwargs["max_tokens"] == 64
+
+
+def test_build_kwargs_gemini_auth_modes():
+    with_key = build_completion_kwargs("Google", "gemini-2.5-flash", _MSGS,
+                                       api_key="k")
+    assert with_key["model"] == "gemini/gemini-2.5-flash"
+    without_key = build_completion_kwargs("Google", "gemini-2.5-flash", _MSGS)
+    assert without_key["model"] == "vertex_ai/gemini-2.5-flash"
+
+
+def test_build_kwargs_honors_existing_prefix():
+    kwargs = build_completion_kwargs(
+        "anthropic", "anthropic/claude-sonnet-5", _MSGS)
+    assert kwargs["model"] == "anthropic/claude-sonnet-5"
+
+
+def test_build_kwargs_lmstudio_uses_api_base():
+    kwargs = build_completion_kwargs("LM Studio", "local-model", _MSGS)
+    assert kwargs["model"] == "local-model"
+    assert kwargs["api_base"] == "http://localhost:1234/v1"
+
+
+def test_build_kwargs_requires_model():
+    with pytest.raises(LLMParamError):
+        build_completion_kwargs("openai", "", _MSGS)

--- a/tests/test_llm_params.py
+++ b/tests/test_llm_params.py
@@ -7,6 +7,7 @@ from core.llm_params import (
     LLMParams,
     build_completion_kwargs,
     get_param_rules,
+    infer_provider_from_model,
     normalize_provider,
     strip_route_prefix,
     validate_params,
@@ -223,3 +224,57 @@ def test_build_kwargs_lmstudio_uses_api_base():
 def test_build_kwargs_requires_model():
     with pytest.raises(LLMParamError):
         build_completion_kwargs("openai", "", _MSGS)
+
+
+def test_build_kwargs_lmstudio_slash_model_id():
+    # LM Studio ids often contain slashes that are NOT litellm route prefixes;
+    # api_base must still be wired (PR #40 review, suggestion 1).
+    kwargs = build_completion_kwargs(
+        "lmstudio", "lmstudio-community/Meta-Llama-3-8B-GGUF", _MSGS)
+    assert kwargs["model"] == "lmstudio-community/Meta-Llama-3-8B-GGUF"
+    assert kwargs["api_base"] == "http://localhost:1234/v1"
+
+
+def test_build_kwargs_gemini_auth_mode_overrides_key_presence():
+    # auth_mode wins over api_key presence (PR #40 review, suggestion 2)
+    env_key_route = build_completion_kwargs(
+        "Google", "gemini-2.5-flash", _MSGS, auth_mode="api-key")
+    assert env_key_route["model"] == "gemini/gemini-2.5-flash"
+    forced_vertex = build_completion_kwargs(
+        "Google", "gemini-2.5-flash", _MSGS, api_key="k", auth_mode="gcloud")
+    assert forced_vertex["model"] == "vertex_ai/gemini-2.5-flash"
+
+
+# --- infer_provider_from_model ------------------------------------------------
+
+def test_infer_provider_from_model():
+    assert infer_provider_from_model("anthropic/claude-opus-5") == "anthropic"
+    assert infer_provider_from_model("claude-sonnet-5") == "anthropic"
+    assert infer_provider_from_model("vertex_ai/gemini-2.5-flash") == "gemini"
+    assert infer_provider_from_model("gemini-2.0-flash") == "gemini"
+    assert infer_provider_from_model("gpt-4o") == "openai"
+    assert infer_provider_from_model("o4-mini") == "openai"
+    assert infer_provider_from_model("ollama/llama3.2:latest") == "ollama"
+    # bare local model names fall back to the default provider
+    assert infer_provider_from_model("local-model") == "openai"
+    assert infer_provider_from_model("local-model", default="lmstudio") == "lmstudio"
+
+
+# --- review follow-ups: seed + unknown keys ----------------------------------
+
+def test_seed_dropped_on_anthropic():
+    kwargs, warnings = validate_params(
+        "anthropic", "claude-sonnet-5", LLMParams(seed=42, max_tokens=32))
+    assert "seed" not in kwargs
+    assert warnings
+    kwargs, _ = validate_params("openai", "gpt-4o", LLMParams(seed=42))
+    assert kwargs["seed"] == 42
+
+
+def test_unknown_dict_keys_warn_but_do_not_crash(caplog):
+    import logging
+    with caplog.at_level(logging.WARNING, logger="core.llm_params"):
+        kwargs, _ = validate_params(
+            "openai", "gpt-4o", {"temperature": 0.3, "max_completion_tokens": 99})
+    assert kwargs == {"temperature": 0.3}
+    assert any("unknown LLM params" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Fixes the style-dialog Anthropic 400 (`"temperature is deprecated for this model"`) at the root and standardizes LLM parameter handling across the whole app.

**Root cause:** the Claude 5 family (and Opus 4.7/4.8) rejects `temperature`/`top_p`/`top_k`, and LiteLLM 1.89.0's capability table *wrongly claims support* on `claude-opus-5` — so the ubiquitous `litellm.drop_params=True` never protected us. The same class of per-model constraint was hand-patched at call sites (the GPT-5 `temperature=1.0` hack existed in 5+ places).

## Changes

- **`core/llm_params.py`** — single source of truth for chat params: curated per-family rules (authoritative over LiteLLM), registry-backed output-token caps, and a validate → corral (clamp/drop with logged warning) → error (`LLMParamError`) contract. `build_completion_kwargs()` owns route prefixing (`anthropic/`, `gemini/` vs `vertex_ai/` by auth mode, LM Studio `api_base`) and `max_tokens` → `max_completion_tokens` renaming for OpenAI reasoning models.
- **~30 call sites rewired** through the layer across `core/video/*`, `core/styles` path, `core/lyrics_to_prompts`, `core/layout/designer`, `core/prompt_enhancer_llm`, all GUI dialogs (including direct-SDK fallbacks), and the CLI. All scattered per-model hacks removed.
- **CLI validation:** `--lyrics-temperature` is validated against the chosen model — corralled values print a warning; un-corralable values exit 2.
- **Latent silent bugs fixed** (all previously swallowed by broad `except`):
  - nonexistent `PROVIDER_PREFIXES` attribute in `llm_sync.py`/`llm_sync_v2.py` — every LLM lyric sync silently degraded to timing estimation
  - `generate(system_prompt=…)` keyword mismatch in duration estimation (`generate()` takes `messages=`) — never called the LLM at all
  - missing `anthropic/` route prefix in `storyboard_v2.py`/`llm_sync_v2.py`

## Testing

- **26 unit tests** for the rules engine (`tests/test_llm_params.py`)
- **19 live boundary tests** (`tests/test_live_llm_params.py`, marker `live`, gated by `IMAGEAI_LIVE_TESTS=1`) — all passed against real Anthropic/OpenAI/Gemini APIs, verifying every documented limit: Claude 5-line sampling-param rejection, Anthropic 0–1 temperature range + temp/top_p exclusivity, output-token caps, gpt-5.x locked temperature + `max_completion_tokens` + `reasoning_effort`, Gemini/classic-OpenAI 0–2 range
- **Regression test** replays the exact failing style-analysis call on `claude-opus-5` and `claude-sonnet-5` — now succeeds
- Full suite: **683 passed, 19 skipped**

Plan doc: `Plans/LLM-Params-Standardization.md`. Release: v0.44.0 (bump + changelog via version tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174wW48PRraujRR5MLDqBuR