### PR TITLE
feat: sprite backgrounds and project workflow improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.0] - 2026-09-05
+
+### Added
+- Sprite background choices now include preserved source backgrounds, transparency, and a chosen solid GIF color. Solid exports reserve the exact background palette color and record the selection in metadata.
+- Sprite projects can be searched and opened by name, copied with their media using Save As, and restored when the Sprite tab is reopened. Managed project references follow changes to the image-storage root.
+
+### Fixed
+- Original-background exports now honor the same crop, padding, anchor, and exact HD/pixel canvas sizes as other modes, including profile palette and upscaling settings.
+- Background changes invalidate affected processing caches, and export refuses unavailable or stale profile output instead of silently using old frames.
+- Opening a lazy tab no longer triggers initialization of neighboring tabs. Malformed project listings and failed project copies are handled without losing existing projects.
+
+### Changed
+- Layout and Help initialize when first opened, with startup timing checkpoints recorded in the application log.
+
 ## [0.47.1] - 2026-09-04
 
 ### Fixed

--- a/Notes/2026-09-04-sprite-background-implementation.md
+++ b/Notes/2026-09-04-sprite-background-implementation.md
@@ -1,0 +1,46 @@
+# Sprite background modes
+
+Updated: 2026-09-05 08:24
+
+Implemented on `codex/sprite-background-modes`. The initial plan/diagnosis were committed under the standing plan rule; application code and tests remain uncommitted. No push, PR, version bump, provider calls, or modifications to the existing G: project assets were performed.
+
+## Using the feature
+
+In **Sprite > Processing > Background > Output**, choose:
+
+- **Keep original background**: skip background removal and its edge cleanup while retaining the source background within the configured crop. Crop, stabilization, padding, alpha/palette conversion, and upscaling settings still apply. Output profile dimensions specify the exact canvas size; fitting remains proportional. See `2026-09-05-rock-3-export-dimensions.md` for the geometry correction and current verification.
+- **Transparent**: use the existing chroma/ML/source-alpha workflow. This remains the default for existing projects.
+- **Solid color (GIF)**: remove the existing background using the chosen method, then composite onto the chosen color during GIF export. Enter `#RRGGBB` or use **Choose color**. Editable PNG frames retain alpha.
+
+After changing processing mode, select **Run pipeline**, then **Export** with Animated GIF selected. The Export dialog shows the project's chosen mode/color. Invalid colors and unavailable/stale profile preparation block export instead of silently using previous frames. Background changes are saved with the project and blocked while the affected workers run.
+
+If ImageAI is already running, restart it after saving work to load the updated code.
+
+## Generation and existing projects
+
+Original mode uses the character reference directly for new Omni/Veo generation and for image-sheet/edit-chain generation. It skips chroma plates, chroma prompt instructions, chroma turnaround references, and matte pairs. New imports in this mode retain their original canvas.
+
+A previously generated green-background clip remains green when keying is skipped. The feature cannot recover the original white background from that video. Previously normalized character imports may contain existing padding; reimport with Keep original background selected to preserve the source canvas. Generative providers can still change content, and GIF palette conversion can slightly change colors.
+
+The black guitar motion marks diagnosed in the earlier report are part of the reference artwork. This change deliberately does not erase foreground artwork or overwrite those project frames.
+
+## Implementation
+
+- `core/sprite/project.py`: validated, backward-compatible background settings; original-mode metadata uses actual fitted dimensions and no obsolete pixel palette.
+- `core/sprite/pipeline.py` and `pixelart.py`: original-mode bypass and cache invalidation; transparent/solid share keyed caches because the solid color is applied at export.
+- `core/sprite/generation/` and `source.py`: original reference generation and intake preservation.
+- `core/sprite/exporters/gif.py` and `engine_presets.py`: composite before palette conversion, retain an exact background palette entry, omit transparency for solid/opaque-original GIFs, preserve timing/disposal/repeat, and record mode/color in sidecars/logs.
+- `gui/sprite/`: Processing controls, disabled irrelevant controls, worker guards, project autosave, generation controls and export summary.
+
+## Verification
+
+- Full core Sprite suite plus hardcoded-path guard: **652 passed, 1 skipped**.
+- Isolated GUI suites: **159 passed** (Processing 30, workspace integration 29, export 45, Character 13, image route 26, Sprite smoke 16). Total core + GUI: **811 passed, 1 skipped**.
+- Application compilation with the repository `.venv` Python: `core`, `gui`, `cli`, `providers` passed.
+- Full project mypy checked 302 source files: **776 existing diagnostics in 149 files**, identical diagnostic multiset to HEAD using shadow files; no newly introduced diagnostics. This repository does not currently have a clean global typecheck.
+- Scoped Ruff comparison: no new diagnostics; pre-existing lint findings remain. Diff whitespace check passed.
+- Rendered the actual Processing widget offscreen with Segoe UI and inspected the new controls.
+- Independent agent review found and resolved metadata sizing, stale disabled-profile export, and original-sheet slicing issues.
+- Additional read-only Claude review was attempted with restricted tools, but authentication failed because its OAuth session expired. No Claude review is claimed.
+
+Tests use temporary files and mocked provider calls. Windows-only path assertions were made platform-neutral. Sprite GUI settings fixtures explicitly use temporary INI files because native Windows QSettings use the registry and cannot be redirected by setting an INI search path. Test discovery ignored pre-existing inaccessible `_Research`, `_screenshots`, `_transfer` junctions and used an in-memory local `tests` namespace to avoid an installed package of the same name. GUI files were run in separate processes to avoid the suite's known Qt teardown instability.

--- a/Notes/2026-09-04-sprite-gif-background-and-artifacts.md
+++ b/Notes/2026-09-04-sprite-gif-background-and-artifacts.md
@@ -1,0 +1,80 @@
+# Sprite GIF background proposal and rock_3 artifact diagnosis
+
+Investigated: 2026-09-04 18:05 (local environment clock).
+
+Scope: inspect current capability and propose implementation; diagnose saved artifacts. No application code, project settings, source images, frames, or exports changed. No generation API calls, commits, or pushes.
+
+## Solid background GIF
+
+The Sprite exporter currently always writes a transparent GIF. `core/sprite/exporters/gif.py:88` has no background argument; line 111 unconditionally sets transparency index 255. `gui/sprite/export_dialog.py:146` does not supply a background option. Both actual rock_3 GIFs decode with transparency index 255 (HD 256x256, pixel 64x64, nine frames each).
+
+Proposed implementation:
+
+1. Add **GIF background: Transparent / Solid color** to Export, with a color picker and validated hex field. Remember the choice; retain Transparent as the default.
+2. Pass optional RGB background through `ExportRequest`, `format_gif()`, and `export_gif()`. Also cover the separate `core/sprite/exporters/engine_presets.py` GIF writer.
+3. For solid output, alpha-composite source RGBA frames onto the chosen color **before** palette quantization. Reserve an exact palette entry for that background and omit the GIF transparency flag. Preserve aspect ratio, canvas size, timing, direction, repetition, and disposal behavior.
+4. Record mode/color in the JSON sidecar and export log. Leave the editable transparent source frames untouched.
+5. Extend existing exporter, GUI export, and engine-preset tests. Decode every exported frame to verify opacity, exact background color, soft-edge compositing within palette precision, timing, and absence of trails; preserve transparent-export regressions and test remembered settings/invalid colors.
+
+Relevant tests: `tests/sprite/test_exporters.py`, `tests/sprite/gui/test_export_dialog.py`, `tests/sprite/test_engine_presets.py`.
+
+## Latest project and visible artifacts
+
+Latest modified Sprite project under the configured G: sprite directory:
+
+`G:\ImageAI\Images\sprites\rock_3_20260903_100335\project.iasprite.json`
+
+Action: `rock_out`, ID `92f1f6989035454080287cc5e8383732`. Inspected its original character, generated plate, extracted video frames, keyed/cleanup/alpha/stabilized/profile PNGs, GIFs, sidecars, and `imageai_current.log`.
+
+### Detached black marks come from the source artwork
+
+The black strokes around the guitar are visible in `source/character.png`, before plate or video generation. They remain in `source/plate.png` and extracted frame `0001.png`. They are decorative motion marks in the supplied artwork, not marks invented by GIF encoding. They are particularly conspicuous in extracted frames 1 and 9; frame 7 lacks those large strokes. The video changes their appearance across poses, which makes them look like intermittent artifacts.
+
+Chroma removal retains those dark pixels as foreground. Saved cleanup settings are `despeckle_px=0`, `choke_px=0`, `feather_px=0`; keyed and cleanup masks retain the same detached-pixel counts. With 8-connected components at alpha >=128, excluding the largest component, frame 1 has 2,299 detached pixels and frame 9 has 777 before downscaling. These counts include both unwanted marks and potentially legitimate disconnected detail; they are not an automatic deletion mask.
+
+A deterministic, in-memory call to the actual `key_frame()` function on extracted frame 1 reproduced 1,193 visible pixels in the motion-mark region (x=748..847, y=140..254). An assertion that this region was empty failed as expected: `FAIL (expected): stray marks remain in keyed frame`.
+
+Best remedy for future generation: clean the motion marks out of the character reference before building the plate, and request no motion lines, floating symbols, particles, or detached strokes. Prompt wording alone cannot guarantee their absence. For existing frames, selective mask/retouch cleanup is more precise than aggressively eroding the whole character.
+
+### Edge processing amplifies colored flecks
+
+The plate generator returned muted green (`#77BB5F` measured in the plate sidecar) despite a requested `#00FF00`. Keying correctly auto-sampled the clip as `#75BA5D`, recorded in `stages/<action>/key/key.json`. Color drift alone therefore does not explain the black marks.
+
+Using a diagnostic magenta-like threshold of R > G+25, B > G+25, alpha >=128:
+
+| Frame | Extracted clip | Saved key stage | Saved alpha stage |
+| --- | ---: | ---: | ---: |
+| 1 | 305 | 305 | 598 |
+| 9 | 109 | 109 | 370 |
+
+`key_pass()` applies despill; `alpha_pass()` then unmixes the key color from partially transparent edges (`core/sprite/keying.py:370`). Controlled in-memory replay with current code produced 604 versus 305 magenta-like pixels in frame 1 with edge decontamination enabled versus disabled, and 375 versus 109 in frame 9. Thus some colored pixels already exist in the video, and edge decontamination adds more. The slight replay/saved difference also means the current implementation should not be described as a byte-identical reconstruction of the older output.
+
+Practical experiment in Processing: disable **Edge decontaminate**, use a small **despeckle** value, and select **Run pipeline** before reviewing/exporting again. In-memory despeckle values 1/2/3 reduced frame 1 detached pixels from 2,299 to 2,158/1,675/460, but did not eliminate all marks. Morphological opening can remove legitimate narrow detail, so inspect hair, fingers, and guitar strings. This experiment was not applied to the saved project.
+
+Potential implementation follow-up: review the ordering and assumptions of despill versus edge unmixing with real clip fixtures. Add an optional previewable detached-component cleanup with size/distance controls and selective protection, rather than unconditionally retaining only the largest component.
+
+### Stale processing is a separate issue
+
+The last logged GIF export at 11:59 warned for both profiles that **stabilize output is stale; run the pipeline from the Processing panel**. Export continued. Rerunning processing is necessary for current settings/code to reach the exported frames. This warning is not the origin of the motion marks: they are already in the original character image.
+
+A solid background will make transparency edges easier to judge and avoid binary-alpha cutout edges when composited before quantization. It will not remove foreground motion marks or colored foreground specks.
+
+## Verification and remaining work
+
+### Follow-up: preserve the input background
+
+The requested design now has three background choices:
+
+- **Keep original background:** bypass background removal, despill, edge decontamination, and alpha cleanup. Preserve the complete input frame/canvas and aspect ratio; resize only when requested. Avoid automatic border cropping, subject stabilization, and transparent profile padding. GIF palette conversion can still slightly change colors.
+- **Transparent:** retain input alpha when available; otherwise remove the background using chroma keying or ML matting.
+- **Replace with solid color:** obtain foreground alpha using existing input alpha or background removal, then composite onto the selected color before quantization. An opaque final GIF can therefore still need background removal when replacing an existing background.
+
+There is already a Processing method labeled `none (source has alpha)` (`gui/sprite/processing_panel.py:299`). Its implementation also accepts opaque inputs: a real `key_frame()` call with `KeySettings(method='none')` returned pixel-identical RGBA for extracted frame 1. However, this is only the keying stage: `stabilize_runner()` still applies solid-border auto-cropping to opaque frames, and output profiles use transparent canvas padding. The existing dropdown is not a complete preserve-input guarantee.
+
+For **new generation**, Keep original background must also bypass chroma-plate creation and the unconditional chroma prompt injection in both Omni and Veo paths (`core/sprite/generation/video_route.py`). Use the original character/reference background and request its preservation while retaining appropriate loop conditioning. Provider generation can still drift visually; pixel preservation is guaranteed only for the processing/export of already supplied frames, subject to requested resizing and GIF palette conversion.
+
+For the existing rock_3 clip, bypassing keying preserves the green background already baked into that clip, not the original character image's white background. Recovering the original white appearance requires a new generation from that reference or background replacement.
+
+Verified via direct image inspection, Pillow GIF decoding, connected-component measurements, source/sidecar/log inspection, and controlled calls to the real keyer. No fix or permanent regression test was implemented because the request was for a proposal and explanation.
+
+`Docs/CodeMap.md` reports last updated 2026-08-11 and predates these Sprite modules. A refresh would help subsequent implementation; references here were checked directly against current source.

--- a/Notes/2026-09-05-rock-3-export-dimensions.md
+++ b/Notes/2026-09-05-rock-3-export-dimensions.md
@@ -1,0 +1,38 @@
+# rock_3 background export geometry fix
+
+Updated: 2026-09-05 08:24 (local).
+
+## Result
+
+Keep original background now uses the same crop, padding, anchor, stabilization, and HD/pixel profile processing as the other background modes. Output cells use their exact configured size. Background removal and its edge cleanup remain bypassed in Original mode, while output alpha, palette, and upscaling settings apply normally. Background mode no longer overrides export canvas or palette metadata.
+
+The original diagnosis found rock_3 saved in Original mode with 16:9 generation and square 256 x 256 / 64 x 64 output profiles. Original mode previously bypassed stabilization and treated profile dimensions as bounds, yielding 256 x 144 / 64 x 36 GIFs. The user clarified that background selection must not override cropping or export geometry; this fix supersedes the earlier recommendation to change modes.
+
+## Changes
+
+- Removed the Original-only stabilization and profile runners; all modes use shared geometry code.
+- Kept crop and output-profile controls enabled, and corrected Processing help text.
+- Included stabilization, full profile settings, and pixel anchor in cache fingerprints. Bumped processing-stage cache versions so old rectangular outputs cannot be reused.
+- Removed Original-only export metadata overrides, including the obsolete palette suppression.
+- Added geometry/cache regressions and actual pipeline-to-export tests for all three background modes, square/rectangular profiles, upscaling on/off, PNG, GIF, sprite-sheet, and Aseprite JSON output.
+
+## Verification
+
+- The initial regression failed with 256 x 144 instead of 256 x 256 before the fix.
+- Final Sprite core suite: 675 passed, 1 skipped.
+- Processing panel and Export dialog suites: 87 passed.
+- Actual rock_3 extracted frames were copied into a temporary project and exported through the real pipeline: Original HD GIF 256 x 256, pixel GIF 64 x 64, each retaining all nine frames. PNG sequence dimensions also passed.
+- Scoped Ruff passed for production files and core/export tests. Processing-panel GUI tests have ten existing E741 diagnostics in untouched lines.
+- Compilation and git diff whitespace checks passed.
+- Project-wide mypy completed with 1319 errors across 170 files (304 source files checked); none reported in the changed sections. The repository-wide typecheck is not clean. No provider calls, model downloads, or GPU/AI upscaler execution were tested.
+- Independent review found obsolete palette metadata suppression; it was fixed. Final review found no further actionable issues.
+
+## Use
+
+Save any open work and reopen ImageAI to load the changed code. Keep Original selected, select rock_out, run the pipeline, then export. Existing rectangular exports are not rewritten until export runs again.
+
+The saved rock_3 project and its existing assets/exports were not modified. Changes remain in the existing codex/sprite-background-modes checkout alongside prior work; no commit, push, PR, or version release was requested.
+
+Automatic crop bounds may differ between keyed and opaque inputs because alpha cleanup changes the detected foreground; all modes now use the same crop rules and output settings. No image is stretched to force a square aspect.
+
+Docs/CodeMap.md is dated 2026-08-11 and was not regenerated during this fix; a separate refresh is recommended.

--- a/Notes/2026-09-05-sprite-projects-and-startup.md
+++ b/Notes/2026-09-05-sprite-projects-and-startup.md
@@ -1,0 +1,75 @@
+# Sprite projects and startup improvements
+
+Updated: 2026-09-05 06:50
+
+## Delivered
+
+- Sprite restores the last successfully selected project when its tab is first
+  constructed, after the workspace and panel signals are connected.
+- The remembered reference is relative to the Sprite library for managed
+  projects, so it follows a changed Images storage root. External projects use
+  an absolute reference. Failed automatic restoration logs a warning without
+  opening a blocking dialog and retains the reference for a later retry.
+- Open lists saved project names, with search and distinct labels for duplicate
+  names. An optional Browse button supports projects outside the library.
+  Invalid metadata is logged and skipped without hiding valid projects.
+- The project title and save confirmation show the project name. Save As asks
+  for a name and copies the project and its internal media into a managed
+  project directory. It remaps internal media paths and preserves the original.
+  Copying is blocked while workers or Export are active; failed copies clean
+  up only their newly created destination.
+- Layout and Help now load on first activation. Sprite and Video were already
+  lazy, but their placeholder replacement emitted transient tab-selection
+  events that could load neighboring tabs. Signal blocking fixes that cascade
+  for all four lazy tabs. Help initialization failures are logged and can retry.
+- Startup logs now include elapsed constructor time after the history scan,
+  initial tabs, session restoration, and application readiness.
+
+## Startup findings
+
+Settings is still constructed at startup because Image/provider/auth handlers
+share its controls. Templates is small and still constructed eagerly. History
+also remains eager; its disk scan, initial metadata reads, and cleanup are
+separate candidates for further measured work. Provider discovery/model-list
+population already constructs provider instances, so deleting the explicit
+preload call alone would not avoid provider initialization.
+
+An isolated offscreen measurement of the original Help implementation took
+0.740 seconds for QtWebEngine import/profile initialization and 0.303 seconds
+for synchronous Help construction: 1.043 seconds total. The measurement blocked
+external browser requests, used a stub config, and did not start the full app.
+This is one local sample of work now deferred until Help opens, not a measured
+end-to-end startup improvement. Layout's restoration/rendering cost and the
+avoided accidental Video load were not separately benchmarked.
+
+## Verification
+
+- Six initial regression tests failed on the original behavior, including the
+  unintended Video load when opening Sprite.
+- Final focused suite: **111 passed**, 9 warnings, in 20.42 seconds. Coverage
+  includes persistence, failed restores/opens, storage-root moves, named copies,
+  copy failure isolation, malformed project entries, filtering/cancel, lazy tab
+  activation/retry, existing Sprite integration, and the shared path rules.
+- Ruff passes for the Sprite UI changes, new modules, and new tests. Existing
+  modified modules introduce no additional lint findings versus HEAD after
+  normalizing line-number references in existing diagnostics.
+- The two new production modules pass mypy. A broad repository check reported
+  776 errors across 149 files; the repository is not type-clean. A separate
+  touched-module comparison reported 36 errors versus 37 with HEAD shadow
+  files; the apparent added diagnostic was the existing duplicate eventFilter
+  definition with its shifted line number.
+- Changed production files compile, and git diff whitespace checks pass.
+- Visually inspected the actual Open dialog in offscreen Qt with an explicitly
+  loaded system font: names, search, duplicate labels, Browse, Open and Cancel
+  fit without showing library paths.
+- Independent agent review identified malformed-list handling and transient
+  storage restore behavior; both findings were addressed.
+
+## Scope and remaining work
+
+Existing Sprite background work was preserved on the current
+`codex/sprite-background-modes` branch. The only overlapping production file
+edited was `core/sprite/project.py`, with additive validation in list_projects.
+No commit, push, package installation, live provider call, or restart of the
+user's application was performed. The full application was not benchmarked.
+CodeMap regeneration was explicitly deferred by the user.

--- a/Notes/2026-09-05-sprite-release.md
+++ b/Notes/2026-09-05-sprite-release.md
@@ -1,0 +1,27 @@
+# Sprite background and project workflow release
+
+Updated: 2026-09-05 09:26 (local).
+
+The user authorized committing and pushing all completed work in the existing `codex/sprite-background-modes` checkout, including project-library and startup improvements from the separate task.
+
+## Included
+
+- Original, transparent, and solid Sprite background modes, with exact configured export canvases and shared crop/profile settings.
+- Cache freshness and export guards, exact solid GIF background colors, and metadata.
+- Named/searchable project opening, last-project restoration, Save As with independent media copies, and malformed project handling.
+- Deferred Layout/Help startup and corrected lazy-tab selection behavior.
+
+## Checks
+
+- Sprite core: 675 passed, 1 skipped in the completed geometry verification; no subsequent core source changes.
+- Affected GUI files plus startup and shared-path tests: 171 passed in isolated processes. The combined GUI process hit a Windows native Qt heap exception during fixture garbage collection; isolated runs passed.
+- All application Python sources compiled. This repository is source-run and has no packaging/build configuration; no executable bundle or deployment was produced.
+- Ruff comparison across changed Python files: 93 diagnostics versus 94 at HEAD, with no added diagnostics after normalizing line references.
+- Project-wide mypy was compared against HEAD shadow files. Two new project-library diagnostics were corrected (saved-setting type validation and the typed QDialog enum). The repository remains non-type-clean; unrelated diagnostics were left in place.
+- Git whitespace checks passed. No provider requests, generated asset replacement, global configuration changes, or app restart occurred.
+
+## Release procedure
+
+Refresh origin and check branch history, commit the implementation, review the committed diff, then use the shared version manager for a minor release and changelog. Push the feature branch and its release tag. The user did not request a PR or merge into main.
+
+The version manager check/backfill found no missing tags or changelog sections to create. Historical date disagreements were reported and left unchanged. The existing plan commit is the only original commit ahead of origin/main; no unrelated local-main commits are being published.

--- a/Plans/2026-09-04-sprite-background-modes.md
+++ b/Plans/2026-09-04-sprite-background-modes.md
@@ -1,24 +1,31 @@
 # Sprite Background Modes Implementation Checklist
 
-**Last Updated:** 2026-09-04 18:52
-**Status:** In Progress
-**Progress:** 0/5 tasks complete
+**Last Updated:** 2026-09-05 08:24
+**Status:** Complete
+**Progress:** 5/5 tasks complete
 
 ## Overview
 
-Implement Keep original background, Transparent, and Solid color as persisted Sprite project choices. Original bypasses chroma generation and removal, cleanup, cropping, stabilization, and transparent profile padding. Solid GIFs composite keyed frames onto the selected color; existing projects retain transparent behavior by default.
+Implement Keep original background, Transparent, and Solid color as persisted Sprite project choices. Original bypasses chroma generation and removal plus background edge cleanup; every mode shares crop, stabilization, padding, and output-profile settings. Solid GIFs composite keyed frames onto the selected color; existing projects retain transparent behavior by default.
 
 ## Implementation Tasks
 
-- [~] Persist background settings and expose clear Processing controls with synchronized project state.
-- [~] Preserve whole input frames through processing and profile resizing; invalidate affected caches on mode changes.
-- [~] Bypass chroma generation for original-background video/image routes while preserving loop and reference behavior.
-- [~] Implement opaque solid GIF export, exact background palette color, metadata, and export controls.
-- [ ] Run scoped regressions, integration checks, final review, and document verified behavior and limitations.
+- [x] Persist background settings and expose clear Processing controls with synchronized project state.
+- [x] Preserve whole input frames through processing and profile resizing; invalidate affected caches on mode changes.
+- [x] Bypass chroma generation for original-background video/image routes while preserving loop and reference behavior.
+- [x] Implement opaque solid GIF export, exact background palette color, metadata, and export controls.
+- [x] Run scoped regressions, integration checks, final review, and document verified behavior and limitations.
 
 ## Notes
 
 - Based on `Notes/2026-09-04-sprite-gif-background-and-artifacts.md`.
-- Use proportional fitting with the original aspect ratio for original-mode output; profile cell dimensions act as bounds.
+- Use exact configured output cells in every mode, with proportional fitting, shared crop/padding/anchor rules, and the requested output profile. Background selection must not override geometry.
 - Existing project media on G: is diagnostic input only and must not be overwritten by tests.
 - No provider calls or package installation needed. No push/PR requested.
+
+- Core generation checks: 108 passed; Character controls: 13 passed; Image route dialog: 26 passed. Pipeline checks: 78 passed. Processing/settings and workspace/project checks passed in isolated runs.
+- Project-wide mypy has 776 diagnostics on the baseline; verified this feature adds none. No release/push is requested, so version/changelog remain unchanged.
+
+- Final validation: 652 core tests passed, 1 skipped; 159 GUI tests passed in isolated files. Application compilation passed. See `Notes/2026-09-04-sprite-background-implementation.md` for the full verification record and the expired-auth limitation on the attempted Claude review.
+
+- Geometry correction completed: 675 core tests passed, 1 skipped; 87 Processing/Export GUI tests passed. Real rock_3 Original exports verified at 256 x 256 and 64 x 64 using temporary copies. See `Notes/2026-09-05-rock-3-export-dimensions.md`.

--- a/Plans/2026-09-04-sprite-background-modes.md
+++ b/Plans/2026-09-04-sprite-background-modes.md
@@ -1,0 +1,24 @@
+# Sprite Background Modes Implementation Checklist
+
+**Last Updated:** 2026-09-04 18:52
+**Status:** In Progress
+**Progress:** 0/5 tasks complete
+
+## Overview
+
+Implement Keep original background, Transparent, and Solid color as persisted Sprite project choices. Original bypasses chroma generation and removal, cleanup, cropping, stabilization, and transparent profile padding. Solid GIFs composite keyed frames onto the selected color; existing projects retain transparent behavior by default.
+
+## Implementation Tasks
+
+- [~] Persist background settings and expose clear Processing controls with synchronized project state.
+- [~] Preserve whole input frames through processing and profile resizing; invalidate affected caches on mode changes.
+- [~] Bypass chroma generation for original-background video/image routes while preserving loop and reference behavior.
+- [~] Implement opaque solid GIF export, exact background palette color, metadata, and export controls.
+- [ ] Run scoped regressions, integration checks, final review, and document verified behavior and limitations.
+
+## Notes
+
+- Based on `Notes/2026-09-04-sprite-gif-background-and-artifacts.md`.
+- Use proportional fitting with the original aspect ratio for original-mode output; profile cell dimensions act as bounds.
+- Existing project media on G: is diagnostic input only and must not be overwritten by tests.
+- No provider calls or package installation needed. No push/PR requested.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### [ImageAI on GitHub](https://github.com/lelandg/ImageAI) Desktop + CLI for multi‑provider AI image and video generation with enterprise auth, prompt tools, and MIDI‑synced karaoke/video workflows.
 
-**Version 0.47.1**
+**Version 0.48.0**
 
 **See [LelandGreen.com](https://www.lelandgreen.com) for links to other code and free stuff**. _Under construction. Implementing social links soon._ 
 - **Chameleon Labs Discord - Support, AI Art & Community: [Chameleon Labs Discord](https://discord.gg/chameleonlabs)**

--- a/core/constants.py
+++ b/core/constants.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 # Application metadata
 APP_NAME = "ImageAI"
-VERSION = "0.47.1"
+VERSION = "0.48.0"
 __version__ = VERSION
 __author__ = "Leland Green"
 __email__ = "contact@lelandgreen.com"

--- a/core/sprite/exporters/engine_presets.py
+++ b/core/sprite/exporters/engine_presets.py
@@ -5,7 +5,7 @@ import copy
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 from core.sprite.exporters.aseprite_json import export_aseprite_json
 from core.sprite.exporters.gif import export_gif
@@ -170,12 +170,16 @@ def _write_png_sequence(meta: SheetMeta, out_dir: Path, title: str, preset: Engi
     return [p for png in pngs for p in (png, sidecar_path(png))]
 
 
-def _write_gif(meta: SheetMeta, out_dir: Path, title: str, preset: EnginePreset) -> List[Path]:
+def _write_gif(meta: SheetMeta, out_dir: Path, title: str, preset: EnginePreset, *,
+               background_color: Optional[str] = None,
+               background_mode: str = "transparent") -> List[Path]:
     paths: List[Path] = []
     for tag in meta.tags:
         # The title is sanitised by the caller; the tag name is user text and
         # must not carry a path separator into the file name (PR #45 review).
-        out = export_gif(meta, tag, out_dir / f"{title}_{sanitize_filename(tag.name)}.gif")
+        out = export_gif(meta, tag, out_dir / f"{title}_{sanitize_filename(tag.name)}.gif",
+                         loop=tag.repeat, background_color=background_color,
+                         background_mode=background_mode)
         # export_gif already wrote a sidecar with the correct unrolled frame
         # count plus durations_ms/loop/warnings/timestamp -- merge the preset
         # fields into it instead of overwriting, and derive "frames" the same
@@ -227,7 +231,9 @@ def _grid_output_paths(png: Path, scales: Tuple[int, ...]) -> List[Path]:
     return paths
 
 
-def export_with_preset(meta: SheetMeta, preset_id: str, out_dir: Path) -> List[Path]:
+def export_with_preset(meta: SheetMeta, preset_id: str, out_dir: Path, *,
+                       background_color: Optional[str] = None,
+                       background_mode: str = "transparent") -> List[Path]:
     """Run every exporter of ``preset_id`` into ``out_dir``; return the written paths."""
     preset = ENGINE_PRESETS.get(preset_id)
     if preset is None:
@@ -248,7 +254,12 @@ def export_with_preset(meta: SheetMeta, preset_id: str, out_dir: Path) -> List[P
         writer = FORMAT_WRITERS.get(fmt)
         if writer is None:
             raise ValueError(f"Preset {preset_id!r} names unknown format {fmt!r}")
-        written.extend(writer(laid, out_dir, title, preset))
+        if fmt == "gif":
+            written.extend(_write_gif(laid, out_dir, title, preset,
+                                  background_color=background_color,
+                                  background_mode=background_mode))
+        else:
+            written.extend(writer(laid, out_dir, title, preset))
     logger.info("Engine preset %s exported %d file(s) to %s", preset_id, len(written), out_dir)
     return written
 

--- a/core/sprite/exporters/gif.py
+++ b/core/sprite/exporters/gif.py
@@ -1,7 +1,7 @@
-"""Transparent GIF export with the safe Pillow recipe (design section 4.1).
+"""GIF export with preserved, transparent, or solid backgrounds.
 
 Recipe, regression-tested: every frame is quantized to 255 colours, index
-255 is reserved for transparency, ``disposal=2`` clears each frame before
+255 is reserved for transparency (or the exact solid background), ``disposal=2`` clears each frame before
 the next, ``optimize=False`` keeps Pillow from merging palettes, and every
 duration is clamped to at least 20 ms because browsers treat shorter delays
 as 100 ms.
@@ -11,11 +11,12 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-from PIL import Image
+from PIL import Image, ImageChops
 
 from core.utils import sidecar_path
 
@@ -85,9 +86,50 @@ def to_palette_frame(image: Image.Image) -> Image.Image:
     return quantized
 
 
+def normalize_background_color(color: str) -> str:
+    """Validate the portable RGB color accepted by the GIF export API."""
+    if not isinstance(color, str) or re.fullmatch(r"#[0-9a-fA-F]{6}", color) is None:
+        logger.error("Invalid GIF background color: %r", color)
+        raise ValueError("Background color must be a hex RGB color such as #FFFFFF")
+    return color.upper()
+
+
+def to_solid_palette_frame(image: Image.Image, color: str) -> Image.Image:
+    """Composite before quantization and reserve index 255 for the exact background."""
+    rgba = image.convert("RGBA")
+    background = Image.new("RGBA", rgba.size, color)
+    rgb = Image.alpha_composite(background, rgba).convert("RGB")
+    quantized = rgb.quantize(colors=255, method=Image.Quantize.MEDIANCUT,
+                             dither=Image.Dither.NONE)
+    palette = (quantized.getpalette() or [])[:255 * 3]
+    palette += [0] * (255 * 3 - len(palette)) + list(background.getpixel((0, 0))[:3])
+    quantized.putpalette(palette)
+    difference = ImageChops.difference(rgb, background.convert("RGB"))
+    red, green, blue = difference.split()
+    exact = ImageChops.lighter(ImageChops.lighter(red, green), blue).point(
+        lambda value: 255 if value == 0 else 0)
+    quantized.paste(255, mask=exact)
+    return quantized
+
+
 def export_gif(meta: SheetMeta, tag: TagMeta, out_gif: Path, *, loop: int = 0,
-               warnings: Optional[List[str]] = None) -> Path:
-    """Write one tag as a looping transparent GIF. Collects warnings when a list is given."""
+               warnings: Optional[List[str]] = None,
+               background_color: Optional[str] = None,
+               background_mode: str = "transparent") -> Path:
+    """Write one tag as GIF, optionally composited onto an exact solid RGB color.
+
+    Original mode preserves source alpha when present, and omits transparency
+    altogether for opaque inputs. Default calls retain the transparent recipe.
+    """
+    if background_mode not in ("transparent", "original", "solid"):
+        logger.error("Unknown GIF background mode: %r", background_mode)
+        raise ValueError(f"Unknown background mode: {background_mode!r}")
+    if background_color is not None:
+        background_color = normalize_background_color(background_color)
+        background_mode = "solid"
+    elif background_mode == "solid":
+        logger.error("Solid GIF background mode requires background_color")
+        raise ValueError("Solid background mode requires background_color")
     out_gif = Path(out_gif)
     out_gif.parent.mkdir(parents=True, exist_ok=True)
     frames = ordered_frames(meta, tag)
@@ -99,16 +141,22 @@ def export_gif(meta: SheetMeta, tag: TagMeta, out_gif: Path, *, loop: int = 0,
     if warnings is not None:
         warnings.extend(notes)
     palette_frames: List[Image.Image] = []
+    has_alpha = False
     for frame in frames:
         if frame.source_path is None or not Path(frame.source_path).exists():
             raise FileNotFoundError(f"Frame '{frame.name}' has no source PNG: {frame.source_path}")
         with Image.open(frame.source_path) as im:
-            palette_frames.append(to_palette_frame(im))
+            has_alpha = has_alpha or im.convert("RGBA").getchannel("A").getextrema()[0] < ALPHA_CUTOFF
+            palette_frames.append(to_solid_palette_frame(im, background_color)
+                                  if background_color else to_palette_frame(im))
     first, rest = palette_frames[0], palette_frames[1:]
+    options = {"background": 255} if background_color else {}
+    if background_mode == "transparent" or (background_mode == "original" and has_alpha):
+        options["transparency"] = TRANSPARENT_INDEX
     first.save(
         out_gif, format="GIF", save_all=True, append_images=rest,
         duration=durations, loop=loop, disposal=2, optimize=False,
-        transparency=TRANSPARENT_INDEX,
+        **options,
     )
     sidecar_path(out_gif).write_text(json.dumps({
         "type": "sprite_gif",
@@ -118,10 +166,13 @@ def export_gif(meta: SheetMeta, tag: TagMeta, out_gif: Path, *, loop: int = 0,
         "frames": len(frames),
         "durations_ms": durations,
         "loop": loop,
+        "background_mode": background_mode,
+        "background_color": background_color,
         "warnings": notes,
         "app": meta.app,
         "version": meta.version,
         "timestamp": datetime.now().isoformat(timespec="seconds"),
     }, indent=2), encoding="utf-8")
-    logger.info(f"Wrote GIF {out_gif} ({len(frames)} frames, tag '{tag.name}')")
+    logger.info("Wrote GIF %s (%d frames, tag '%s', background=%s, color=%s)",
+                out_gif, len(frames), tag.name, background_mode, background_color)
     return out_gif

--- a/core/sprite/generation/image_route.py
+++ b/core/sprite/generation/image_route.py
@@ -17,7 +17,7 @@ from PIL import Image
 from core.sprite.generation._common import emit
 from core.sprite.generation.errors import ProviderError, classify_provider_error
 from core.sprite.generation.pose_steps import generate_pose_instructions  # noqa: F401 — re-export (design §4.6)
-from core.sprite.generation.prompts import inject_chroma
+from core.sprite.generation.prompts import background_prompt
 from core.sprite.models import Size
 from core.sprite.pipeline import CancelToken
 from core.sprite.project import ActionCard
@@ -148,7 +148,8 @@ def openai_edit_size(model: str, size: Size) -> str:
 
 # --------------------------------------------------------------------------- sheet route
 
-def sheet_prompt(action: ActionCard, frames: int, plate_color: str) -> str:
+def sheet_prompt(action: ActionCard, frames: int, plate_color: str, *,
+                 background_mode: str = "transparent") -> str:
     """Prompt for one horizontal strip; chroma suffix and loop hint come from inject_chroma."""
     label = action.name.replace("_", " ")
     base = (
@@ -158,7 +159,7 @@ def sheet_prompt(action: ActionCard, frames: int, plate_color: str) -> str:
         "No labels, no numbers, no cell borders, no text. "
         f"{action.prompt.strip()}"
     )
-    return inject_chroma(base, plate_color, loop=action.loop)
+    return background_prompt(base, plate_color, loop=action.loop, background_mode=background_mode)
 
 
 def generate_sheet(
@@ -169,6 +170,7 @@ def generate_sheet(
     *,
     frames: int,
     plate_color: str,
+    background_mode: str = "transparent",
     model: Optional[str] = None,
     log: LogFn = logger.info,
     token: Optional[CancelToken] = None,
@@ -183,7 +185,7 @@ def generate_sheet(
         raise FileNotFoundError(character)
     kind = provider_kind(provider)
     model = model or provider.get_default_model()
-    prompt = sheet_prompt(action, frames, plate_color)
+    prompt = sheet_prompt(action, frames, plate_color, background_mode=background_mode)
     if kind == "openai":
         size = openai_sheet_size(model)
         params: Dict = {"size": size, "n": 1}
@@ -201,6 +203,7 @@ def generate_sheet(
         "prompt": prompt, "provider": kind, "model": model, "timestamp": _timestamp(),
         "route": "image_sheet", "action": action.name, "action_id": action.id,
         "frames": frames, "plate_color": plate_color, "params": params,
+        "background_mode": background_mode,
         "reference_images": [str(character)],
     })
     emit(logger, log, f"[image route] sheet saved: {out}")
@@ -214,23 +217,29 @@ def slice_generated_sheet(
     plate_color: str,
     *,
     log: LogFn = logger.info,
+    background_mode: str = "transparent",
 ) -> List[Path]:
     """Cut a generated sheet into ``frames`` PNGs (guess the grid; fall back to one row)."""
     sheet_png = Path(sheet_png)
-    with Image.open(sheet_png) as img:
-        guess = guess_grid(img.convert("RGBA"), key_color=plate_color)
     columns, rows = frames, 1
-    if guess.confidence >= MIN_GRID_CONFIDENCE and guess.columns * guess.rows == frames:
-        columns, rows = guess.columns, guess.rows
-        emit(logger, log, f"[image route] grid detected: {columns}x{rows} (confidence {guess.confidence:.2f})")
+    if background_mode != "original":
+        with Image.open(sheet_png) as img:
+            guess = guess_grid(img.convert("RGBA"), key_color=plate_color)
+        if guess.confidence >= MIN_GRID_CONFIDENCE and guess.columns * guess.rows == frames:
+            columns, rows = guess.columns, guess.rows
+            emit(logger, log, f"[image route] grid detected: {columns}x{rows} (confidence {guess.confidence:.2f})")
+        else:
+            emit(logger, log, f"[image route] grid guess {guess.columns}x{guess.rows} "
+                              f"(confidence {guess.confidence:.2f}) rejected; slicing {frames}x1")
     else:
-        emit(logger, log, f"[image route] grid guess {guess.columns}x{guess.rows} "
-                          f"(confidence {guess.confidence:.2f}) rejected; slicing {frames}x1")
+        # Scenery can contain the key color and must not be mistaken for cell gutters.
+        emit(logger, log, f"[image route] preserving backgrounds in the requested {frames}x1 layout")
     paths = list(slice_sheet(sheet_png, Path(out_dir), columns, rows))
     for index, path in enumerate(paths, start=1):
         write_image_sidecar(path, {
             "route": "image_sheet", "source_sheet": str(sheet_png), "cell_index": index,
             "columns": columns, "rows": rows, "timestamp": _timestamp(),
+            "background_mode": background_mode,
         })
     return paths
 
@@ -249,6 +258,7 @@ def edit_chain(
     frames: int,
     pose_instructions: Sequence[str],
     plate_color: str,
+    background_mode: str = "transparent",
     model: Optional[str] = None,
     log: LogFn = logger.info,
     token: Optional[CancelToken] = None,
@@ -261,6 +271,8 @@ def edit_chain(
     ``*.png`` in the stage directory and must see the frames alone. Each plate keeps its
     own ``.json`` sidecar, and the composed frame's sidecar lists both plate paths.
     """
+    if background_mode == "original":
+        matte_pairs = False
     if frames < 1:
         raise ValueError("frames must be >= 1")
     if len(pose_instructions) != frames:
@@ -299,9 +311,10 @@ def edit_chain(
                 # buys the black one (same convention as retouch_frame).
                 if token is not None:
                     token.raise_if_cancelled()
-                prompt = inject_chroma(STEP_PROMPT.format(instruction=instruction.strip()), color, loop=False)
+                prompt = background_prompt(STEP_PROMPT.format(instruction=instruction.strip()), color,
+                                           loop=False, background_mode=background_mode)
                 prompts[color] = prompt
-                params: Dict = {"step": k, "plate": color}
+                params: Dict = {"step": k, "plate": color, "background_mode": background_mode}
                 refs = [character_bytes, prev_bytes]
                 if kind == "openai":
                     size = openai_edit_size(model, char_size)
@@ -346,6 +359,7 @@ def edit_chain(
                 "timestamp": _timestamp(), "route": "image_edit_chain",
                 "action": action.name, "action_id": action.id, "step": k, "of": frames,
                 "pose": instruction, "plate_color": plate_color, "matte_pairs": matte_pairs,
+                "background_mode": background_mode,
                 "plates": plate_paths,
                 "reference_images": [str(character), str(prev_reference_path)],
             })

--- a/core/sprite/generation/prompts.py
+++ b/core/sprite/generation/prompts.py
@@ -80,3 +80,16 @@ def inject_chroma(prompt: str, plate_color: str, *, loop: bool) -> str:
     if loop:
         parts.append(LOOP_SUFFIX)
     return ", ".join(parts)
+
+
+def background_prompt(prompt: str, plate_color: str, *, loop: bool,
+                      background_mode: str = "transparent") -> str:
+    """Keep source scenery when requested; otherwise prepare a removable plate."""
+    if background_mode != "original":
+        return inject_chroma(prompt, plate_color, loop=loop)
+    parts = [strip_render_terms(prompt),
+             "Preserve the original reference image background, including its colors and scenery. "
+             "Keep the camera fixed and the framing unchanged"]
+    if loop:
+        parts.append(LOOP_SUFFIX)
+    return ", ".join(part for part in parts if part)

--- a/core/sprite/generation/queue.py
+++ b/core/sprite/generation/queue.py
@@ -94,16 +94,21 @@ class ActionQueue:
         return Path(self.project.project_dir) / "clips" / f"{action.id}.mp4"
 
     def build_request(self, action: ActionCard) -> RenderRequest:
-        plate = self.project.plate_path
+        background_mode = self.project.background.mode
+        plate = (self.project.character_source if background_mode == "original"
+                 else self.project.plate_path)
         if not plate or not Path(plate).exists():
+            if background_mode == "original":
+                raise ProviderError("Import a character image before rendering (Character panel).")
             raise ProviderError("Make the chroma plate before rendering (Character panel > Make chroma plate).")
         settings = self.project.generation
         refs: List[Path] = []
-        if settings.use_turnaround_refs:
+        if settings.use_turnaround_refs and background_mode != "original":
             refs = [Path(self.project.turnaround[view]) for view in VIEWS
                     if view in self.project.turnaround]
         return RenderRequest(action=action, plate=Path(plate), refs=refs,
-                             settings=settings, out_mp4=self.clip_path(action))
+                             settings=settings, out_mp4=self.clip_path(action),
+                             background_mode=background_mode)
 
     # -- queue operations ----------------------------------------------------
 

--- a/core/sprite/generation/video_route.py
+++ b/core/sprite/generation/video_route.py
@@ -26,14 +26,14 @@ from core.sprite.extract import extract_frames
 from core.sprite.generation._common import emit, now_iso
 from core.sprite.generation.cost import estimate_action, price_per_second
 from core.sprite.generation.errors import ProviderError, classify_provider_error
-from core.sprite.generation.prompts import inject_chroma, strip_render_terms
+from core.sprite.generation.prompts import background_prompt, strip_render_terms
 from core.sprite.pipeline import CancelToken, Cancelled, ProgressFn, no_progress
 from core.sprite.project import ActionCard, ClipRecord, ExtractionSettings, GenerationSettings
 from core.sprite.timing import legal_aspect_ratios, snap_duration
 
 if TYPE_CHECKING:
     from core.video.omni_client import OmniClient, OmniGenerationConfig
-    from core.video.veo_client import VeoClient, VeoGenerationConfig, VeoModel
+    from core.video.veo_client import VeoClient, VeoGenerationConfig
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +47,7 @@ class RenderRequest:
     refs: List[Path]
     settings: GenerationSettings
     out_mp4: Path
+    background_mode: str = "transparent"
 
 
 def validate_generation_settings(settings: GenerationSettings) -> Optional[str]:
@@ -70,7 +71,8 @@ def validate_generation_settings(settings: GenerationSettings) -> Optional[str]:
 
 def omni_prompt(req: RenderRequest, duration_s: int) -> str:
     """Chroma-injected prompt with a plain-language duration hint (Omni has no duration field)."""
-    base = inject_chroma(req.action.prompt, req.settings.plate_color, loop=req.action.loop)
+    base = background_prompt(req.action.prompt, req.settings.plate_color, loop=req.action.loop,
+                             background_mode=req.background_mode)
     return f"{base}, about {duration_s} seconds long"
 
 
@@ -82,7 +84,7 @@ def build_omni_config(req: RenderRequest, *,
     if duration != req.action.duration_s:
         emit(logger, log, f"Omni: duration {req.action.duration_s}s snapped to {duration}s "
                           f"(legal range {OmniClient.MODEL_CONSTRAINTS['duration_range']})")
-    refs = [Path(req.plate)] + [Path(p) for p in req.refs]
+    refs = [Path(req.plate)] + ([Path(p) for p in req.refs] if req.background_mode != "original" else [])
     refs = refs[:MAX_REFERENCE_IMAGES]
     if len(req.refs) + 1 > MAX_REFERENCE_IMAGES:
         emit(logger, log, f"Omni: {len(req.refs)} reference image(s) plus the plate exceed "
@@ -130,8 +132,10 @@ def build_veo_config(req: RenderRequest, *,
                           f"using {allowed[0]}")
         resolution = allowed[0]
 
-    refs = [Path(p) for p in req.refs][:MAX_REFERENCE_IMAGES]
-    prompt = inject_chroma(req.action.prompt, req.settings.plate_color, loop=req.action.loop)
+    refs = ([Path(p) for p in req.refs][:MAX_REFERENCE_IMAGES]
+            if req.background_mode != "original" else [])
+    prompt = background_prompt(req.action.prompt, req.settings.plate_color, loop=req.action.loop,
+                               background_mode=req.background_mode)
     try:
         return VeoGenerationConfig(
             model=model,
@@ -141,7 +145,7 @@ def build_veo_config(req: RenderRequest, *,
             duration=duration,
             fps=req.settings.fps,
             include_audio=bool(req.settings.include_audio),
-            image=Path(req.plate) if loop_conditioning else None,
+            image=Path(req.plate) if loop_conditioning or req.background_mode == "original" else None,
             last_frame=Path(req.plate) if loop_conditioning else None,
             reference_images=refs or None,
         )
@@ -253,6 +257,7 @@ def render_action(req: RenderRequest, *, api_key: Optional[str], auth_mode: str 
     else:
         raise ProviderError(f"Unknown sprite video provider {provider!r}. Use 'omni' or 'veo'.")
 
+    params["background_mode"] = req.background_mode
     _log_request(log, provider, model_id, params, cfg.prompt, action)
     progress("render", 0, 0, f"{provider}: rendering '{action.name}'")
 

--- a/core/sprite/pipeline.py
+++ b/core/sprite/pipeline.py
@@ -277,7 +277,20 @@ def stage_settings(project: SpriteProject, action: ActionCard, stage: str) -> Di
     """The registered settings for a stage (empty dict when none is registered)."""
     if stage not in STAGES:
         raise ValueError(f"Unknown stage: {stage!r}")
+    if stage != "extract" and keeps_original_background(project):
+        # Only settings actually applied belong in the original-frame cache.
+        # Solid and transparent modes deliberately share the existing keyed
+        # cache: the solid color is applied by the exporter, not these stages.
+        settings: Dict[str, Any] = {"background": "original"}
+        if stage == "stabilize" or stage in PROFILE_STAGES:
+            settings.update(STAGE_SETTINGS.get(stage, _no_settings)(project, action))
+        return settings
     return STAGE_SETTINGS.get(stage, _no_settings)(project, action)
+
+
+def keeps_original_background(project: SpriteProject) -> bool:
+    """Whether background removal and its edge cleanup are bypassed."""
+    return project.background.mode == "original"
 
 
 def stage_fingerprint(project: SpriteProject, action: ActionCard, stage: str) -> str:
@@ -379,6 +392,8 @@ def key_runner(project: SpriteProject, action: ActionCard, input_frames: List[Pa
     choice is written to ``out_dir/key.json`` so the alpha stage
     decontaminates against the same color.
     """
+    if keeps_original_background(project):
+        return identity_runner(project, action, input_frames, out_dir, progress, token)
     settings = _effective_key_settings(project)
     _reset_dir(out_dir)
     outputs: List[Path] = []
@@ -480,6 +495,8 @@ def key_self_check(image: Image.Image, alpha: Any, key_rgb: Sequence[int]) -> Op
 def cleanup_runner(project: SpriteProject, action: ActionCard, input_frames: List[Path],
                    out_dir: Path, progress: ProgressFn, token: Optional[CancelToken]) -> List[Path]:
     """Choke/feather/despeckle the alpha the ``key`` stage produced."""
+    if keeps_original_background(project):
+        return identity_runner(project, action, input_frames, out_dir, progress, token)
     _reset_dir(out_dir)
     outputs: List[Path] = []
     total = len(input_frames)
@@ -497,6 +514,8 @@ def cleanup_runner(project: SpriteProject, action: ActionCard, input_frames: Lis
 def alpha_runner(project: SpriteProject, action: ActionCard, input_frames: List[Path],
                  out_dir: Path, progress: ProgressFn, token: Optional[CancelToken]) -> List[Path]:
     """Decontaminate spill on the keyed edges (chroma only) and finalize the RGBA."""
+    if keeps_original_background(project):
+        return identity_runner(project, action, input_frames, out_dir, progress, token)
     settings = _effective_key_settings(project)
     if settings.method == "chroma" and not settings.key_color:
         recorded = read_key_color(project, action)
@@ -584,8 +603,8 @@ register_stage("key", key_runner, key_stage_settings, code_version=4)
 register_stage("cleanup", cleanup_runner, cleanup_stage_settings, code_version=2)
 register_stage("alpha", alpha_runner, alpha_stage_settings, code_version=3)
 # stabilize 3: dejitter limits every shift so no subject pixel leaves the canvas.
-register_stage("stabilize", stabilize_runner, stabilize_stage_settings, code_version=3)
-register_stage("hd", hd_runner, hd_stage_settings, code_version=2)
+register_stage("stabilize", stabilize_runner, stabilize_stage_settings, code_version=4)
+register_stage("hd", hd_runner, hd_stage_settings, code_version=3)
 register_stage("pixel", identity_runner, pixel_stage_settings)
 
 

--- a/core/sprite/pixelart.py
+++ b/core/sprite/pixelart.py
@@ -344,7 +344,7 @@ def pixel_stage_settings(project: Any, action: Any) -> Dict[str, Any]:
     profile = project.profile("pixel")
     if profile is None or not profile.enabled:
         return {}
-    return asdict(profile)
+    return {**asdict(profile), "anchor": project.stabilize.anchor}
 
 
 def _validate_pixel_profile(profile: Any) -> None:
@@ -458,6 +458,5 @@ def run_pixel_stage(project: Any, action: Any, input_frames: List[Path], out_dir
 
 # Importing this module registers the stage. core/sprite/__init__.py imports it
 # after .pipeline, so this call replaces sub-project 1's identity runner.
-# code_version=2: the identity runner is version 1, and a real runner at the
-# same version with the same settings would reuse a stale identity output.
-register_stage("pixel", run_pixel_stage, settings_fn=pixel_stage_settings, code_version=2)
+# Version 3 applies the configured canvas and profile in every background mode.
+register_stage("pixel", run_pixel_stage, settings_fn=pixel_stage_settings, code_version=3)

--- a/core/sprite/project.py
+++ b/core/sprite/project.py
@@ -78,6 +78,35 @@ def _reanchored(path: Optional[Path], project_dir: Optional[Path]) -> Optional[P
 # --- settings dataclasses ---------------------------------------------------
 
 
+BACKGROUND_MODES = ("transparent", "original", "solid")
+
+
+@dataclass
+class BackgroundSettings:
+    """Project-wide background intent; solid compositing happens at GIF export."""
+
+    mode: str = "transparent"
+    color: str = "#FFFFFF"
+
+    def __post_init__(self) -> None:
+        if self.mode not in BACKGROUND_MODES:
+            message = f"Unknown sprite background mode: {self.mode!r}"
+            logger.error(message)
+            raise ValueError(message)
+        if not isinstance(self.color, str) or re.fullmatch(r"#[0-9a-fA-F]{6}", self.color) is None:
+            message = f"Sprite background color must be #RRGGBB: {self.color!r}"
+            logger.error(message)
+            raise ValueError(message)
+        self.color = self.color.upper()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "BackgroundSettings":
+        return cls(**{k: v for k, v in (data or {}).items() if k in cls.__dataclass_fields__})
+
+
 @dataclass
 class GenerationSettings:
     provider: str = "omni"
@@ -376,6 +405,7 @@ class SpriteProject:
     cost_ledger: List[CostEntry] = field(default_factory=list)
     created: str = field(default_factory=_now)
     modified: str = field(default_factory=_now)
+    background: BackgroundSettings = field(default_factory=BackgroundSettings)
 
     # -- lookups ---------------------------------------------------------
 
@@ -410,6 +440,7 @@ class SpriteProject:
             "genre_preset": self.genre_preset,
             "actions": [a.to_dict() for a in self.actions],
             "generation": self.generation.to_dict(),
+            "background": self.background.to_dict(),
             "extraction": self.extraction.to_dict(),
             "key": self.key.to_dict(),
             "stabilize": self.stabilize.to_dict(),
@@ -434,6 +465,7 @@ class SpriteProject:
             genre_preset=str(data.get("genre_preset", "sidescroller")),
             actions=[ActionCard.from_dict(a) for a in data.get("actions", [])],
             generation=GenerationSettings.from_dict(data.get("generation") or {}),
+            background=BackgroundSettings.from_dict(data.get("background") or {}),
             extraction=ExtractionSettings.from_dict(data.get("extraction") or {}),
             key=KeySettings.from_dict(data.get("key") or {}),
             stabilize=StabilizeSettings.from_dict(data.get("stabilize") or {}),
@@ -586,12 +618,14 @@ class SpriteProject:
                 repeat=0 if action.loop else 1,
                 fps_hint=action.fps,
             ))
+        cell_size = prof.cell_size
+        palette = list(prof.locked_palette) if prof.locked_palette and prof.palette_size else None
         return SheetMeta(
             title=self.slug,
             frames=frames,
             tags=tags,
-            cell_size=prof.cell_size,
-            palette=list(prof.locked_palette) if prof.locked_palette and prof.palette_size else None,
+            cell_size=cell_size,
+            palette=palette,
             profile=profile,
         )
 
@@ -661,15 +695,21 @@ class SpriteProjectManager:
                 continue
             try:
                 data = json.loads(project_file.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError) as exc:
+                if not isinstance(data, dict):
+                    raise ValueError("project metadata must be an object")
+                if not isinstance(data.get("name", "Untitled"), str):
+                    raise ValueError("project name must be text")
+                if not isinstance(data.get("actions", []), list):
+                    raise ValueError("project actions must be a list")
+            except (OSError, ValueError) as exc:
                 logger.warning(f"Failed to read sprite project {project_file}: {exc}")
                 continue
             projects.append({
                 "name": data.get("name", "Untitled"),
                 "slug": project_dir.name,
                 "path": project_file,
-                "created": data.get("created"),
-                "modified": data.get("modified"),
+                "created": data.get("created") if isinstance(data.get("created"), str) else None,
+                "modified": data.get("modified") if isinstance(data.get("modified"), str) else None,
                 "actions": len(data.get("actions", [])),
             })
         projects.sort(key=lambda p: p.get("modified") or "", reverse=True)

--- a/core/sprite/project_copy.py
+++ b/core/sprite/project_copy.py
@@ -1,0 +1,64 @@
+"""Create an independent, named copy of a Sprite project and its media."""
+import copy
+import logging
+import shutil
+from dataclasses import fields, is_dataclass
+from pathlib import Path
+
+from .project import SpriteProject, SpriteProjectManager
+
+logger = logging.getLogger(__name__)
+
+
+def copy_project(project: SpriteProject, name: str,
+                 manager: SpriteProjectManager) -> SpriteProject:
+    """Keep internal media references inside the copy; retain external references."""
+    if project.project_dir is None:
+        raise ValueError("Save the original project before making a copy.")
+    source = project.project_dir.resolve()
+    created = manager.create_project(name)
+    assert created.project_dir is not None
+    destination = created.project_dir.resolve()
+    try:
+        if destination.is_relative_to(source):
+            raise ValueError("The project library cannot be inside the source project.")
+        for item in source.iterdir():
+            if item.name == project.project_file().name:
+                continue
+            target = destination / item.name
+            if item.is_dir():
+                shutil.copytree(item, target, dirs_exist_ok=True)
+            else:
+                shutil.copy2(item, target)
+
+        def relocate(value):
+            if isinstance(value, Path):
+                try:
+                    return destination / value.resolve().relative_to(source)
+                except ValueError:
+                    return value
+            if is_dataclass(value) and not isinstance(value, type):
+                for field in fields(value):
+                    setattr(value, field.name, relocate(getattr(value, field.name)))
+            elif isinstance(value, list):
+                return [relocate(item) for item in value]
+            elif isinstance(value, dict):
+                return {key: relocate(item) for key, item in value.items()}
+            elif isinstance(value, tuple):
+                return tuple(relocate(item) for item in value)
+            return value
+
+        result = relocate(copy.deepcopy(project))
+        result.name = name
+        result.project_dir = destination
+        result.created = created.created
+        manager.save_project(result)
+        return result
+    except Exception:
+        logger.exception("Could not copy Sprite project %r", project.name)
+        # This directory was uniquely created above; the original is untouched.
+        try:
+            shutil.rmtree(destination)
+        except OSError:
+            logger.exception("Could not remove incomplete Sprite project copy")
+        raise

--- a/core/sprite/source.py
+++ b/core/sprite/source.py
@@ -66,8 +66,9 @@ def analyze_source(image: Path) -> SourceAnalysis:
                           border_uniform=uniform, size=(width, height))
 
 
-def normalize_source(image: Path, out_png: Path, aspect_ratio: str = "16:9") -> Path:
-    """Pad the character onto a transparent canvas of ``aspect_ratio``.
+def normalize_source(image: Path, out_png: Path, aspect_ratio: str = "16:9", *,
+                     preserve_background: bool = False) -> Path:
+    """Pad to ``aspect_ratio``, or keep the complete original canvas and background.
 
     Writes an RGBA PNG to ``out_png`` plus a ``.json`` sidecar. Raises
     ``FileNotFoundError`` when ``image`` is missing.
@@ -79,7 +80,8 @@ def normalize_source(image: Path, out_png: Path, aspect_ratio: str = "16:9") -> 
         raise FileNotFoundError(f"Character image not found: {image}")
     out_png = Path(out_png)
     raw = image.read_bytes()
-    fixed = apply_transparent_canvas_fix(raw, aspect_ratio, logger_instance=logger)
+    fixed = raw if preserve_background else apply_transparent_canvas_fix(
+        raw, aspect_ratio, logger_instance=logger)
 
     with Image.open(io.BytesIO(fixed)) as img:
         rgba = img.convert("RGBA")
@@ -93,6 +95,7 @@ def normalize_source(image: Path, out_png: Path, aspect_ratio: str = "16:9") -> 
         "source": str(image),
         "aspect_ratio": aspect_ratio,
         "padded": fixed is not raw,
+        "preserve_background": preserve_background,
         "size": [width, height],
         "source_has_alpha": analysis.has_alpha,
         "source_border_color": analysis.border_color,

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -143,6 +143,8 @@ class MainWindow(QMainWindow):
 
     def __init__(self):
         super().__init__()
+        from time import perf_counter
+        startup_started = perf_counter()
         import logging
         self.logger = logging.getLogger(__name__)
         self.config = ConfigManager()
@@ -184,6 +186,7 @@ class MainWindow(QMainWindow):
         print("Scanning image history...")
         self.history_paths: List[Path] = scan_disk_history(project_only=True)
         print(f"Found {len(self.history_paths)} images in history")
+        self.logger.info("Startup: history scan complete at %.3fs", perf_counter() - startup_started)
 
         self.history = []  # Initialize empty history list
         self.history_loaded_count = 0  # Track how many items are loaded
@@ -215,6 +218,7 @@ class MainWindow(QMainWindow):
         # Create UI first so we have status bar
         print("Creating user interface...")
         self._init_ui()
+        self.logger.info("Startup: initial tabs ready at %.3fs", perf_counter() - startup_started)
         self.status_bar.showMessage("Initializing application...")
         QApplication.processEvents()
 
@@ -253,6 +257,7 @@ class MainWindow(QMainWindow):
         QApplication.processEvents()
         self._restore_geometry()
         self._restore_ui_state()
+        self.logger.info("Startup: session restored at %.3fs", perf_counter() - startup_started)
 
         # Initialize Midjourney watcher if enabled
         self._init_midjourney_watcher()
@@ -280,6 +285,7 @@ class MainWindow(QMainWindow):
         self._start_config_health_timer()
 
         print("Application ready!")
+        self.logger.info("Startup: application ready at %.3fs", perf_counter() - startup_started)
         self.status_bar.showMessage("Ready")
         QApplication.processEvents()
 
@@ -690,24 +696,16 @@ class MainWindow(QMainWindow):
         self.tab_sprite = QWidget()
         self._sprite_tab_loaded = False
 
-        # Create layout tab
-        try:
-            from gui.layout import LayoutTab
-            self.tab_layout = LayoutTab(config=self.config)
-            logger.info("Layout tab created successfully")
-        except Exception as e:
-            logger.error(f"Failed to create layout tab: {e}", exc_info=True)
-            self.tab_layout = QWidget()  # Fallback placeholder
+        # Layout restores and renders its document only when first opened.
+        self.tab_layout = QWidget()
+        self._layout_tab_loaded = False
+        self._help_tab_loaded = False
 
         # Phase 5b: cross-tab handoff. The Layout tab asks us to open the Image
         # tab pre-configured for a region; we route the generated image back into
         # that region by id (see _on_layout_send_to_image / _maybe_place_image_in_layout).
         self._pending_layout_region_id = None
         self._layout_fill_plan = None  # FillPlan driving layout-complete mode
-        if hasattr(self.tab_layout, "sendToImageRequested"):
-            self.tab_layout.sendToImageRequested.connect(self._on_layout_send_to_image)
-        if hasattr(self.tab_layout, "fillAllRequested"):
-            self.tab_layout.fillAllRequested.connect(self._on_layout_fill_all)
 
         # Add tabs
         self.tabs.addTab(self.tab_generate, "🎨 Image")
@@ -722,7 +720,6 @@ class MainWindow(QMainWindow):
         self._init_generate_tab()
         self._init_templates_tab()
         self._init_settings_tab()
-        self._init_help_tab()
         self._init_history_tab()  # Always init history tab
         
         # Connect tab change signal to handle help tab rendering
@@ -8202,9 +8199,15 @@ For more detailed information, please refer to the full documentation.
             self.logger.info("Triggering sprite tab lazy load...")
             self._load_sprite_tab()
 
+        if current_widget == self.tab_layout and not self._layout_tab_loaded:
+            self._load_layout_tab()
+
         # If switching to help tab, trigger a minimal scroll to fix rendering
         if current_widget == self.tab_help:
-            self._trigger_help_render()
+            if not self._help_tab_loaded:
+                self._load_help_tab()
+            if self._help_tab_loaded:
+                self._trigger_help_render()
 
         # If switching to history tab, check for new images not created by us
         if current_widget == self.tab_history:
@@ -8218,6 +8221,8 @@ For more detailed information, please refer to the full documentation.
 
     def _load_video_tab(self):
         """Lazy load the video tab when first accessed."""
+        if self._video_tab_loaded:
+            return
         self.logger.info("=== _LOAD_VIDEO_TAB CALLED ===")
         self.logger.info(f"Thread ID: {__import__('threading').current_thread().ident}")
         self.logger.info(f"Current platform: {__import__('sys').platform}")
@@ -8270,11 +8275,15 @@ For more detailed information, please refer to the full documentation.
             # Step 6: Replace placeholder tab
             self.logger.info("STEP 6: Replacing placeholder tab...")
             self.logger.info(f"STEP 6a: Removing placeholder tab at index {video_index}")
-            self.tabs.removeTab(video_index)
-            self.logger.info(f"STEP 6b: Inserting real video tab at index {video_index}")
-            self.tabs.insertTab(video_index, real_video_tab, "🎬 Video")
-            self.logger.info(f"STEP 6c: Setting current index to {video_index}")
-            self.tabs.setCurrentIndex(video_index)
+            from PySide6.QtCore import QSignalBlocker
+            placeholder = self.tab_video
+            with QSignalBlocker(self.tabs):
+                self.tabs.removeTab(video_index)
+                self.tabs.insertTab(video_index, real_video_tab, "🎬 Video")
+                self.tab_video = real_video_tab
+                self._video_tab_loaded = True
+                self.tabs.setCurrentIndex(video_index)
+            placeholder.deleteLater()
             self.logger.info("STEP 6: Tab replacement complete")
 
             # Step 7: Update references
@@ -8322,17 +8331,74 @@ For more detailed information, please refer to the full documentation.
             real_tab = SpriteTab(config=self.config)
             real_tab.addToHistoryRequested.connect(self.add_to_history)
             index = self.tabs.indexOf(self.tab_sprite)
-            self.tabs.removeTab(index)
-            self.tabs.insertTab(index, real_tab, "🎮 Sprite")
-            self.tabs.setCurrentIndex(index)
-            self.tab_sprite = real_tab
-            self._sprite_tab_loaded = True
+            from PySide6.QtCore import QSignalBlocker
+            placeholder = self.tab_sprite
+            with QSignalBlocker(self.tabs):
+                self.tabs.removeTab(index)
+                self.tabs.insertTab(index, real_tab, "🎮 Sprite")
+                self.tab_sprite = real_tab
+                self._sprite_tab_loaded = True
+                self.tabs.setCurrentIndex(index)
+            placeholder.deleteLater()
             self.logger.info("Sprite tab loaded")
         except Exception as e:
             import traceback
             error_msg = f"Failed to load sprite tab: {str(e)}\n\n{traceback.format_exc()}"
             self.logger.error(f"SPRITE TAB LOAD ERROR:\n{error_msg}")
             QMessageBox.warning(self, "Sprite Tab Error", error_msg)
+
+    def _load_help_tab(self):
+        """Build the documentation browser on demand; allow retry after failure."""
+        if self._help_tab_loaded:
+            return
+        from PySide6.QtCore import QSignalBlocker
+
+        placeholder = self.tab_help
+        real_tab = QWidget()
+        self.tab_help = real_tab
+        try:
+            self._init_help_tab()
+        except Exception as exc:
+            self.tab_help = placeholder
+            real_tab.deleteLater()
+            self.logger.exception("Failed to load Help tab")
+            QMessageBox.warning(self, "Help Tab Error", f"Could not open Help: {exc}")
+            return
+        index = self.tabs.indexOf(placeholder)
+        with QSignalBlocker(self.tabs):
+            self.tabs.removeTab(index)
+            self.tabs.insertTab(index, real_tab, "❓ Help")
+            self._help_tab_loaded = True
+            self.tabs.setCurrentIndex(index)
+        placeholder.deleteLater()
+        self.logger.info("Help tab loaded")
+
+    def _load_layout_tab(self):
+        """Restore Layout on demand, keeping placeholder swaps invisible to tabs."""
+        if self._layout_tab_loaded:
+            return
+        try:
+            from PySide6.QtCore import QSignalBlocker
+            from gui.layout import LayoutTab
+
+            real_tab = LayoutTab(config=self.config)
+            if hasattr(real_tab, "sendToImageRequested"):
+                real_tab.sendToImageRequested.connect(self._on_layout_send_to_image)
+            if hasattr(real_tab, "fillAllRequested"):
+                real_tab.fillAllRequested.connect(self._on_layout_fill_all)
+            placeholder = self.tab_layout
+            index = self.tabs.indexOf(placeholder)
+            with QSignalBlocker(self.tabs):
+                self.tabs.removeTab(index)
+                self.tabs.insertTab(index, real_tab, "📖 Layout")
+                self.tab_layout = real_tab
+                self._layout_tab_loaded = True
+                self.tabs.setCurrentIndex(index)
+            placeholder.deleteLater()
+            self.logger.info("Layout tab loaded")
+        except Exception as exc:
+            self.logger.exception("Failed to load Layout tab")
+            QMessageBox.warning(self, "Layout Tab Error", f"Could not open Layout: {exc}")
 
     def _on_send_to_sprite(self, path):
         """Route an image path into the Sprite tab as its character source."""

--- a/gui/sprite/character_panel.py
+++ b/gui/sprite/character_panel.py
@@ -111,8 +111,13 @@ class CharacterPanel(WorkerHost, QGroupBox):
         has_project = self.project is not None
         has_source = has_project and bool(getattr(self.project, "character_source", None))
         self.browse_btn.setEnabled(has_project and not busy)
-        self.plate_btn.setEnabled(has_source and not busy)
-        self.turnaround_btn.setEnabled(has_source and not busy)
+        original = has_project and self.project.background.mode == "original"
+        self.plate_btn.setEnabled(has_source and not busy and not original)
+        self.plate_color_btn.setEnabled(not busy and not original)
+        self.turnaround_btn.setEnabled(has_source and not busy and not original)
+        self.plate_btn.setToolTip("Not needed when keeping the original background." if original else "")
+        self.turnaround_btn.setToolTip(
+            "Original background mode uses the character image directly." if original else "")
         self.cancel_btn.setEnabled(busy)
         self.setAcceptDrops(has_project and not busy)
 
@@ -175,11 +180,15 @@ class CharacterPanel(WorkerHost, QGroupBox):
             return
         out_png = Path(self.project.project_dir) / "source" / "character.png"
         aspect = getattr(self.project.generation, "aspect_ratio", "16:9")
+        preserve_background = self.project.background.mode == "original"
 
         def job(progress, token):
             progress("source", 0, 0, f"Normalizing {path.name}")
             out_png.parent.mkdir(parents=True, exist_ok=True)
-            out = normalize_source(path, out_png, aspect_ratio=aspect)
+            if preserve_background:
+                out = normalize_source(path, out_png, aspect_ratio=aspect, preserve_background=True)
+            else:
+                out = normalize_source(path, out_png, aspect_ratio=aspect)
             token.raise_if_cancelled()
             return Path(out), analyze_source(Path(out))
 
@@ -187,6 +196,9 @@ class CharacterPanel(WorkerHost, QGroupBox):
         self._begin("normalize", job, self._on_source_done)
 
     def make_plate(self) -> None:
+        if self.project is not None and self.project.background.mode == "original":
+            self.logMessage.emit("Keeping the original background; no chroma plate is needed.", "INFO")
+            return
         if not self._ready_for_provider("chroma plate"):
             return
         character = Path(self.project.character_source)
@@ -208,6 +220,9 @@ class CharacterPanel(WorkerHost, QGroupBox):
         self._begin("plate", job, self._on_plate_done)
 
     def generate_turnaround(self) -> None:
+        if self.project is not None and self.project.background.mode == "original":
+            self.logMessage.emit("Original background mode uses the character image directly.", "INFO")
+            return
         if not self._ready_for_provider("turnaround"):
             return
         character = Path(self.project.character_source)

--- a/gui/sprite/export_dialog.py
+++ b/gui/sprite/export_dialog.py
@@ -31,7 +31,7 @@ from core.sprite.exporters.png_sequence import export_png_sequence
 from core.sprite.exporters.texturepacker_json import export_texturepacker_json
 from core.sprite.models import SheetMeta
 from core.sprite.pipeline import CancelToken, ProgressFn, ensure_profile_stages
-from core.sprite.project import SpriteProject
+from core.sprite.project import BackgroundSettings, SpriteProject
 from core.utils import sidecar_path
 from gui.common.dialog_conventions import (DialogCleanupMixin, bind_primary_action,
                                            persist_splitter, restore_splitter,
@@ -143,14 +143,17 @@ def format_png_sequence(meta: SheetMeta, out_dir: Path, template: str = DEFAULT_
     return files
 
 
-def format_gif(meta: SheetMeta, out_dir: Path) -> List[Path]:
+def format_gif(meta: SheetMeta, out_dir: Path, *, background_color: Optional[str] = None,
+               background_mode: str = "transparent") -> List[Path]:
     if not meta.tags:
         logger.warning("GIF export (%s): the sheet has no tags; nothing written", meta.profile)
         return []
     files: List[Path] = []
     for tag in meta.tags:
         out = Path(out_dir) / f"{meta.title}_{tag.name}.gif"
-        gif_path = Path(export_gif(meta, tag, out, loop=tag.repeat))
+        gif_path = Path(export_gif(meta, tag, out, loop=tag.repeat,
+                                   background_color=background_color,
+                                   background_mode=background_mode))
         files.append(gif_path)
         sidecar = sidecar_path(gif_path)
         if sidecar.exists():
@@ -257,9 +260,9 @@ def _ensure_profile_outputs(project: SpriteProject, profile: str, *, log: LogFn,
                             progress: ProgressFn, token: CancelToken) -> None:
     """Run the missing profile stage for every action with frames, then save (T3).
 
-    A reason the helper returns is logged and shown; the export still runs
-    with whatever ``sheet_meta`` finds. The project is saved only when a
-    stage ran (the fingerprints changed). A save error is logged, never raised.
+    Any unavailable stage blocks export rather than falling back to old
+    background processing, including disabled or failed profiles. The
+    project is saved only when a stage ran (the fingerprints changed).
     """
     if project.project_dir is None:
         return
@@ -274,6 +277,9 @@ def _ensure_profile_outputs(project: SpriteProject, profile: str, *, log: LogFn,
             message = f"Profile '{name}', action '{action.name}': {reason}"
             _log_at(log, message, "WARNING")
             logger.warning(message)
+            raise ValueError(f"Cannot export profile '{name}' for '{action.name}': {reason}. "
+                             "Enable the profile and Run the pipeline from the Processing panel, "
+                             "then export again.")
     if _fingerprint_snapshot(project) == before:
         return
     try:
@@ -291,6 +297,9 @@ def run_export(request: ExportRequest, formats: Sequence[ExportFormat], *,
     written: List[Path] = []
     total = len(request.profiles)
     needs_sheet = any(fmt.needs_sheet for fmt in formats)
+    background = BackgroundSettings(**request.project.background.to_dict())
+    background_color = background.color if background.mode == "solid" else None
+    log(f"Background: {background.mode}" + (f" ({background_color}); GIF only" if background_color else ""))
 
     def record(path: Path) -> None:
         path = Path(path)
@@ -320,7 +329,10 @@ def run_export(request: ExportRequest, formats: Sequence[ExportFormat], *,
         for fmt in formats:
             token.raise_if_cancelled()
             progress("export", index, total, f"{profile}: {fmt.label}")
-            if fmt.takes_template:
+            if fmt.id == "gif":
+                files = format_gif(meta, out_dir, background_color=background_color,
+                               background_mode=background.mode)
+            elif fmt.takes_template:
                 files = fmt.fn(meta, out_dir, template=request.template)
             else:
                 files = fmt.fn(meta, out_dir)
@@ -391,6 +403,15 @@ class ExportDialog(WorkerHost, DialogCleanupMixin, QDialog):
         self.notes_label.setWordWrap(True)
         self.notes_label.setStyleSheet("color: #888;")
         self.options_layout.addWidget(self.notes_label)
+
+        background = self.project.background
+        background_names = {"transparent": "Transparent", "original": "Keep original background",
+                            "solid": f"Solid color {background.color} (GIF only)"}
+        self.background_label = QLabel(
+            f"Background: {background_names[background.mode]}. "
+            "Change this in Processing. After switching original/background removal, run the pipeline again.")
+        self.background_label.setWordWrap(True)
+        self.options_layout.addWidget(self.background_label)
 
         output_box = QGroupBox("Output")
         output_form = QFormLayout(output_box)

--- a/gui/sprite/frames_workspace.py
+++ b/gui/sprite/frames_workspace.py
@@ -68,6 +68,7 @@ class FramesWorkspace(QObject):
         # The render queue runs run_pipeline on its own thread; the panel's Run
         # must not start a second run on the same action meanwhile.
         self.panel.set_busy_guard(lambda: "render queue" if tab.queue_panel.is_busy() else None)
+        self.panel.set_background_busy_guard(self._background_job)
         tab.undo_controller = self.undo_controller
         tab.undo_stack = SnapshotStack()          # replaced per action in _set_action
         tab.refresh_frames = self.refresh_frames  # sub-project 6 calls tab.refresh_frames()
@@ -94,11 +95,26 @@ class FramesWorkspace(QObject):
         self.panel.pipelineFinished.connect(self._on_pipeline_finished)
         self.panel.logMessage.connect(tab.log)
         self.panel.exportRequested.connect(self.open_export_dialog)
+        self.panel.backgroundChanged.connect(self._on_background_changed)
         app = QApplication.instance()
         if app is not None:
             app.aboutToQuit.connect(self.shutdown)
 
     # ----- tab events -------------------------------------------------
+    def _background_job(self) -> Optional[str]:
+        if self.tab.queue_panel.is_busy():
+            return "render queue"
+        if self.tab.character_panel.is_busy():
+            return "character generation"
+        if self._export_dialog is not None:
+            return "export dialog"
+        return None
+
+    def _on_background_changed(self) -> None:
+        self.tab.character_panel._sync_enabled()
+        self.tab._autosave()
+        self.tab.projectChanged.emit()
+
     def current_action(self) -> Optional[ActionCard]:
         return self._action
 
@@ -343,6 +359,8 @@ class FramesWorkspace(QObject):
         if open_dialog is not None:
             logger.info("Export dialog is already open")
             return open_dialog
+        if not self.panel.validate_background():
+            return None
         dialog = self.export_dialog_factory(project, self.tab)
         self._export_dialog = dialog
         dialog.logMessage.connect(self.tab.log)

--- a/gui/sprite/image_route_dialog.py
+++ b/gui/sprite/image_route_dialog.py
@@ -164,7 +164,10 @@ class ImageRouteDialog(WorkerHost, DialogCleanupMixin, QDialog):
 
     def _on_mode_changed(self, _index: int) -> None:
         chain = self.mode_combo.currentData() == "edit_chain"
-        self.matte_check.setEnabled(chain)
+        self.matte_check.setEnabled(chain and self.project.background.mode != "original")
+        if self.project.background.mode == "original":
+            self.matte_check.setChecked(False)
+            self.matte_check.setToolTip("Keeping the original background skips matte removal.")
         self.steps_edit.setEnabled(chain)
         self.steps_btn.setEnabled(chain and not self.is_busy())
 
@@ -203,13 +206,16 @@ class ImageRouteDialog(WorkerHost, DialogCleanupMixin, QDialog):
         provider_id = self.provider_combo.currentData()
         model = self.model_edit.text().strip() or None
         frames = self.frames_spin.value()
-        matte = self.matte_check.isChecked() and mode == "edit_chain"
+        background_mode = self.project.background.mode
+        matte = (self.matte_check.isChecked() and mode == "edit_chain"
+                 and background_mode != "original")
         typed_steps = self._typed_steps()
         project, action = self.project, self.action
         factory, pose_fn, log = self._provider_factory, self._pose_fn, self.logLine.emit
 
         def job(progress: ProgressFn, token: CancelToken) -> List[Path]:
-            character = project.plate_path or project.character_source
+            character = (project.character_source if background_mode == "original"
+                         else project.plate_path or project.character_source)
             if character is None or not Path(character).exists():
                 raise ProviderError("Import a character image first (Character panel).")
             provider = factory(provider_id)
@@ -232,10 +238,12 @@ class ImageRouteDialog(WorkerHost, DialogCleanupMixin, QDialog):
                     progress("image_route", 0, 3, "Generating sheet")
                     sheet_png = Path(project.project_dir) / "clips" / f"{action.id}_sheet.png"
                     sheet = generate_sheet(provider, Path(character), action, sheet_png, frames=frames,
-                                           plate_color=project.plate_color, model=model, log=log, token=token)
+                                           plate_color=project.plate_color, background_mode=background_mode,
+                                           model=model, log=log, token=token)
                     sheet_done = True
                     progress("image_route", 1, 3, "Slicing sheet")
-                    paths = slice_generated_sheet(sheet, extract_dir, frames, project.plate_color, log=log)
+                    paths = slice_generated_sheet(sheet, extract_dir, frames, project.plate_color, log=log,
+                                                  background_mode=background_mode)
                 else:
                     steps = typed_steps
                     if len(steps) != frames:
@@ -244,7 +252,7 @@ class ImageRouteDialog(WorkerHost, DialogCleanupMixin, QDialog):
                     progress("image_route", 1, 3, f"Edit chain: {frames} steps")
                     paths = edit_chain(provider, Path(character), action, extract_dir, frames=frames,
                                        pose_instructions=steps, plate_color=project.plate_color, model=model,
-                                       log=log, token=token, matte_pairs=matte)
+                                       log=log, token=token, matte_pairs=matte, background_mode=background_mode)
                 progress("image_route", 2, 3, "Running pipeline to stabilize")
                 duration_ms = round(1000 / max(1, action.fps))
                 action.frames = [

--- a/gui/sprite/processing_panel.py
+++ b/gui/sprite/processing_panel.py
@@ -16,8 +16,8 @@ from typing import Any, Callable, Dict, Optional
 
 from PIL import Image
 from PySide6.QtCore import Qt, QUrl, Signal
-from PySide6.QtGui import QDesktopServices
-from PySide6.QtWidgets import (QCheckBox, QComboBox, QDoubleSpinBox, QFormLayout, QGroupBox,
+from PySide6.QtGui import QColor, QDesktopServices
+from PySide6.QtWidgets import (QCheckBox, QColorDialog, QComboBox, QDoubleSpinBox, QFormLayout, QGroupBox,
                                QHBoxLayout, QLabel, QLineEdit, QMessageBox, QProgressBar,
                                QPushButton, QScrollArea, QSlider, QSpinBox, QVBoxLayout,
                                QWidget)
@@ -207,6 +207,7 @@ class ProcessingPanel(WorkerHost, QWidget):
 
     pipelineFinished = Signal(str)
     settingsChanged = Signal()
+    backgroundChanged = Signal()
     logMessage = Signal(str, str)
     exportRequested = Signal()
 
@@ -235,16 +236,116 @@ class ProcessingPanel(WorkerHost, QWidget):
         scroll.setWidgetResizable(True)
         body = QWidget()
         self._body_layout = QVBoxLayout(body)
+        self._body_layout.addWidget(self._build_background())
         self._body_layout.addWidget(self._build_extraction())
-        self._body_layout.addWidget(self._build_key())
+        self.key_box = self._build_key()
+        self._body_layout.addWidget(self.key_box)
         self.profiles_box = QGroupBox("Output profiles")
         self.profiles_layout = QVBoxLayout(self.profiles_box)
         self._body_layout.addWidget(self.profiles_box)
-        self._body_layout.addWidget(self._build_stabilize())
+        self.stabilize_box = self._build_stabilize()
+        self._body_layout.addWidget(self.stabilize_box)
         self._body_layout.addStretch()
         scroll.setWidget(body)
         outer.addWidget(scroll, 1)
         outer.addWidget(self._build_actions())
+
+    def _build_background(self) -> QGroupBox:
+        self.background_box = QGroupBox("Background")
+        form = QFormLayout(self.background_box)
+        self.background_mode = _combo(("transparent", "original", "solid"), {
+            "transparent": "Transparent", "original": "Keep original background",
+            "solid": "Solid color (GIF)",
+        })
+        form.addRow("Output:", self.background_mode)
+        self.background_color = QLineEdit("#FFFFFF")
+        self.background_color.setPlaceholderText("#RRGGBB")
+        self.background_color.setMaxLength(7)
+        self.background_pick_btn = QPushButton("Choose color…")
+        self.background_pick_btn.setAutoDefault(False)
+        row = QHBoxLayout()
+        row.addWidget(self.background_color)
+        row.addWidget(self.background_pick_btn)
+        form.addRow("GIF color:", row)
+        self.background_help = QLabel()
+        self.background_help.setWordWrap(True)
+        form.addRow(self.background_help)
+        self.background_mode.currentIndexChanged.connect(self._on_background_changed)
+        self.background_color.editingFinished.connect(self._on_background_changed)
+        self.background_pick_btn.clicked.connect(self._pick_background_color)
+        return self.background_box
+
+    def _pick_background_color(self) -> None:
+        color = QColorDialog.getColor(QColor(self.background_color.text()), self, "GIF background color")
+        if color.isValid():
+            self.background_color.setText(color.name().upper())
+            self._on_background_changed()
+
+    def _on_background_changed(self, *_args) -> None:
+        project = self._project
+        if self._loading or project is None:
+            return
+        mode = self.background_mode.currentData()
+        text = self.background_color.text().strip()
+        if mode == project.background.mode and text.upper() == project.background.color:
+            return
+        busy = self._background_busy_guard() if self._background_busy_guard else self._external_job()
+        if self.is_busy() or busy:
+            with _blocked(self.background_mode, self.background_color):
+                self.background_mode.setCurrentIndex(self.background_mode.findData(project.background.mode))
+                self.background_color.setText(project.background.color)
+            self._warn("Background", f"Wait for the {busy or 'processing job'} to finish before changing the background.")
+            return
+        if mode == "solid" and not HEX_RE.fullmatch(text):
+            self.background_color.setStyleSheet("border: 1px solid #c44;")
+            self._warn("Background color", f"{text!r} is not #RRGGBB")
+            return
+        old_mode = project.background.mode
+        project.background.mode = mode
+        if HEX_RE.fullmatch(text):
+            project.background.color = text.upper()
+        self.background_color.setStyleSheet("")
+        self._sync_background_controls()
+        self.settingsChanged.emit()
+        self.backgroundChanged.emit()
+        if old_mode != mode:
+            message = f"Background: {self.background_mode.currentText()}. Run pipeline to refresh existing frames."
+            logger.info(message)
+            self.logMessage.emit(message, "INFO")
+
+    def validate_background(self) -> bool:
+        """Commit pending color input before processing/export; reject invalid values."""
+        if self._project is None:
+            return False
+        mode = self.background_mode.currentData()
+        text = self.background_color.text().strip()
+        if mode == "solid" and not HEX_RE.fullmatch(text):
+            self._warn("Background color", f"{text!r} is not #RRGGBB")
+            return False
+        self._on_background_changed()
+        return self._project.background.mode == mode
+
+    def _sync_background_controls(self) -> None:
+        mode = self._project.background.mode if self._project is not None else "transparent"
+        original = mode == "original"
+        self.background_color.setEnabled(mode == "solid")
+        self.background_pick_btn.setEnabled(mode == "solid")
+        self.key_box.setEnabled(not original)
+        self.stabilize_box.setEnabled(True)
+        self.background_help.setText({
+            "original": "Keeps the source background and skips background removal. Crop, padding, "
+                        "anchor, and output profiles still apply, including the exact canvas size. "
+                        "Existing green clips stay green.",
+            "transparent": "Removes the background using the method below, or keeps existing source alpha.",
+            "solid": "Removes the old background, then fills it with this color in GIF exports. "
+                     "Editable PNG frames retain transparency.",
+        }[mode])
+        for editor in self.profile_editors.values():
+            for control in (editor.binary_alpha, editor.threshold, editor.defringe,
+                            editor.palette_size, editor.dither, editor.palette_lock, editor.rebuild_btn):
+                control.setEnabled(True)
+        self.preview_btn.setEnabled(self._project is not None and self._action is not None
+                                    and not self.is_busy() and not original)
 
     def _build_extraction(self) -> QGroupBox:
         box = QGroupBox("Extraction")
@@ -297,7 +398,7 @@ class ProcessingPanel(WorkerHost, QWidget):
         box = QGroupBox("Key / matte")
         form = QFormLayout(box)
         self.key_method = _combo(KEY_METHODS, {"chroma": "chroma key", "ml": "ML matte",
-                                               "none": "none (source has alpha)"})
+                                               "none": "none (use existing pixels / alpha)"})
         form.addRow("Method:", self.key_method)
         self.key_color_edit = QLineEdit()
         self.key_color_edit.setPlaceholderText("auto (sampled from the clip)")
@@ -489,6 +590,9 @@ class ProcessingPanel(WorkerHost, QWidget):
             return
         self._loading = True
         try:
+            with _blocked(self.background_mode, self.background_color):
+                self.background_mode.setCurrentIndex(self.background_mode.findData(project.background.mode))
+                self.background_color.setText(project.background.color)
             ex = project.extraction
             with _blocked(self.extract_mode, self.every_n, self.target_fps, self.exact_n,
                           self.trim_start, self.trim_end, self.cull, self.cull_threshold):
@@ -533,6 +637,7 @@ class ProcessingPanel(WorkerHost, QWidget):
                 self.profile_editors[profile.name] = editor
         finally:
             self._loading = False
+        self._sync_background_controls()
         self._update_estimate()
 
     def _key_color_value(self) -> Optional[str]:
@@ -552,6 +657,8 @@ class ProcessingPanel(WorkerHost, QWidget):
         log-only warning per keystroke; this re-reads the live field text so the two
         commit points show and log the refusal instead of running against the plate.
         """
+        if self._project is not None and self._project.background.mode == "original":
+            return True
         text = self.key_color_edit.text().strip()
         if text and not HEX_RE.match(text):
             self._warn("Key color", f"{text!r} is not #RRGGBB")
@@ -635,6 +742,8 @@ class ProcessingPanel(WorkerHost, QWidget):
         primary = getattr(self, "_primary", None)
         if primary is not None:
             primary.set_enabled(ready)
+        self.background_box.setEnabled(self._project is not None and not self.is_busy())
+        self._sync_background_controls()
 
     def _on_worker_idle(self) -> None:
         """A worker orphaned by a timed-out ``shutdown()`` finally stopped.
@@ -674,6 +783,10 @@ class ProcessingPanel(WorkerHost, QWidget):
     # the same stage directories leave action.status/frames last-writer-wins).
     # The workspace installs it; None means no guard (PR #45 review).
     _busy_guard: Optional[Callable[[], Optional[str]]] = None
+    _background_busy_guard: Optional[Callable[[], Optional[str]]] = None
+
+    def set_background_busy_guard(self, guard: Callable[[], Optional[str]]) -> None:
+        self._background_busy_guard = guard
 
     def set_busy_guard(self, guard: Optional[Callable[[], Optional[str]]]) -> None:
         self._busy_guard = guard
@@ -695,6 +808,8 @@ class ProcessingPanel(WorkerHost, QWidget):
             return
         self._write_back()
         if not self._check_key_color_field():
+            return
+        if not self.validate_background():
             return
         force = self.force_check.isChecked()
 
@@ -758,6 +873,9 @@ class ProcessingPanel(WorkerHost, QWidget):
 
     def preview_key_on_clip(self) -> None:
         project, action = self._project, self._action
+        if project is not None and project.background.mode == "original":
+            self.logMessage.emit("Keep original background skips chroma preview. Run pipeline to preview the preserved frames.", "INFO")
+            return
         if project is None or action is None:
             self._warn("Preview key", "Select an action card first.")
             return
@@ -804,6 +922,8 @@ class ProcessingPanel(WorkerHost, QWidget):
         # from the fitted binary-alpha frames — the same frames the quantizer uses.
         profile.locked_palette = None
         self.logMessage.emit(f"Palette lock cleared for '{profile.name}'; re-running the pipeline", "INFO")
+        if not self.validate_background():
+            return
         force = self.force_check.isChecked()
 
         def job(progress, token):

--- a/gui/sprite/project_dialog.py
+++ b/gui/sprite/project_dialog.py
@@ -1,0 +1,82 @@
+"""Open a Sprite project by its saved name, without browsing storage folders."""
+from collections import Counter
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog, QDialogButtonBox, QFileDialog, QLabel, QLineEdit,
+    QListWidget, QListWidgetItem, QPushButton, QVBoxLayout,
+)
+
+
+class SpriteProjectDialog(QDialog):
+    def __init__(self, manager, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Open sprite project")
+        self.resize(520, 400)
+        self._external_path = None
+        self._manager = manager
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Choose a project:"))
+        self.search = QLineEdit()
+        self.search.setPlaceholderText("Search projects…")
+        layout.addWidget(self.search)
+        self.project_list = QListWidget()
+        layout.addWidget(self.project_list)
+        projects = manager.list_projects()
+        counts = Counter(str(info["name"]) for info in projects)
+        occurrences = Counter()
+        for info in projects:
+            name = str(info["name"])
+            occurrences[name] += 1
+            label = name
+            if counts[name] > 1:
+                # Distinguish even copies made in the same second, without paths.
+                label += f" — copy {occurrences[name]} of {counts[name]}"
+            item = QListWidgetItem(label)
+            item.setData(Qt.UserRole, str(info["path"]))
+            self.project_list.addItem(item)
+        self.empty_label = QLabel("No saved projects yet." if not projects else "")
+        layout.addWidget(self.empty_label)
+        browse = QPushButton("Browse for another project…")
+        browse.clicked.connect(self._browse)
+        layout.addWidget(browse)
+        self.buttons = QDialogButtonBox(QDialogButtonBox.Open | QDialogButtonBox.Cancel)
+        self.buttons.button(QDialogButtonBox.Open).setDefault(True)
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+        layout.addWidget(self.buttons)
+        self.project_list.currentItemChanged.connect(self._update_open)
+        self.project_list.itemDoubleClicked.connect(lambda _item: self.accept())
+        self.search.textChanged.connect(self._filter)
+        self.project_list.setCurrentRow(0)
+        self._update_open()
+
+    def _update_open(self, *_args):
+        item = self.project_list.currentItem()
+        self.buttons.button(QDialogButtonBox.Open).setEnabled(
+            item is not None and not item.isHidden())
+
+    def _filter(self, text):
+        first = None
+        for index in range(self.project_list.count()):
+            item = self.project_list.item(index)
+            item.setHidden(text.casefold() not in item.text().casefold())
+            if not item.isHidden() and first is None:
+                first = item
+        self.project_list.setCurrentItem(first)
+        self._update_open()
+
+    def _browse(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Open sprite project", str(self._manager.base_dir),
+            "Sprite projects (*.iasprite.json)")
+        if path:
+            self._external_path = Path(path)
+            self.accept()
+
+    def selected_path(self):
+        if self._external_path is not None:
+            return self._external_path
+        item = self.project_list.currentItem()
+        return Path(item.data(Qt.UserRole)) if item and not item.isHidden() else None

--- a/gui/sprite/sprite_tab.py
+++ b/gui/sprite/sprite_tab.py
@@ -14,10 +14,9 @@ from typing import Optional
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
-    QDialog, QFileDialog, QHBoxLayout, QInputDialog, QLabel, QPushButton, QVBoxLayout, QWidget,
+    QDialog, QHBoxLayout, QInputDialog, QLabel, QPushButton, QVBoxLayout, QWidget,
 )
 
-from core.paths import get_data_paths
 from core.sprite.configs import NamedConfigStore
 from core.sprite.project import ActionCard, SpriteProject, SpriteProjectManager
 from gui.common.dialog_conventions import persist_splitter, restore_splitter, standard_splitter
@@ -34,7 +33,6 @@ from providers import get_provider
 
 logger = logging.getLogger(__name__)
 
-PROJECT_FILTER = "Sprite projects (*.iasprite.json)"
 SPLITTER_KEYS = {
     "main": "sprite/splitter_main",
     "left": "sprite/splitter_left",
@@ -73,6 +71,8 @@ class SpriteTab(QWidget):
         install_retouch(self)
         # Sub-project 6: "Render (image)" button on every action card row.
         install_image_route(self)
+        # Restore only when this lazy tab is constructed, after all panels listen.
+        self._restore_last_project()
 
     # -- build -------------------------------------------------------------
 
@@ -96,6 +96,7 @@ class SpriteTab(QWidget):
             toolbar.addWidget(button)
         toolbar.addStretch(1)
         self.title_label = QLabel()
+        self.title_label.setTextFormat(Qt.TextFormat.PlainText)
         toolbar.addWidget(self.title_label)
         root.addLayout(toolbar)
 
@@ -301,20 +302,55 @@ class SpriteTab(QWidget):
                 self.log(f"The {label} job is still finishing; it cannot start again "
                          "until it stops.", "WARNING")
 
-    def _apply_project(self, project: SpriteProject) -> None:
+    def _apply_project(self, project: SpriteProject, path=None) -> None:
         self._shutdown_panel_workers()
         self._project = project
         self.character_panel.set_project(project)
         self.action_cards_panel.set_project(project)
         self.queue_panel.set_project(project)
         self._sync_title()
-        self.log(f"Project: {project.name} ({project.project_dir})", "INFO")
+        self.log(f"Project: {project.name}", "INFO")
         self.projectChanged.emit()
+        self._remember_project(path or project.project_file())
+
+    def _remember_project(self, path) -> None:
+        path = Path(path)
+        if path.is_dir():
+            if self._project is None:
+                return
+            path = self._project.project_file()
+        # Relative references survive changes to the Images storage root.
+        try:
+            path = path.relative_to(self.project_manager.base_dir)
+        except ValueError:
+            pass
+        settings = sprite_settings()
+        settings.setValue("sprite/last_project", str(path))
+        settings.sync()
+
+    def _restore_last_project(self) -> None:
+        settings = sprite_settings()
+        saved = settings.value("sprite/last_project", "")
+        if not saved:
+            return
+        try:
+            if not isinstance(saved, str):
+                raise ValueError("Saved Sprite project reference must be text")
+            path = Path(saved)
+            if not path.is_absolute():
+                path = self.project_manager.base_dir / path
+            project = self.project_manager.load_project(path)
+            self._apply_project(project, path)
+        except Exception:
+            logger.exception("Could not restore last Sprite project: %s", saved)
+            self.log("Could not restore the last project. Choose Open… to select a project.", "WARNING")
+            # Keep the reference: a removable/network storage root may return.
+            # A successful New/Open/Save replaces it naturally.
 
     def _sync_title(self) -> None:
         has_project = self._project is not None
         if has_project:
-            self.title_label.setText(f"{self._project.name} — {self._project.project_dir}")
+            self.title_label.setText(self._project.name)
         else:
             self.title_label.setText(NO_PROJECT_TEXT)
         for button in (self.save_btn, self.save_as_btn, self.settings_btn):
@@ -324,7 +360,8 @@ class SpriteTab(QWidget):
         if self._project is None:
             return
         try:
-            self.project_manager.save_project(self._project)
+            saved = self.project_manager.save_project(self._project)
+            self._remember_project(saved)
         except Exception as exc:  # noqa: BLE001 - reported, never raised out of a slot
             self._report_error("save project", exc)
 
@@ -352,10 +389,14 @@ class SpriteTab(QWidget):
         return project
 
     def open_project(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(
-            self, "Open sprite project", str(get_data_paths().sprite_projects()), PROJECT_FILTER)
-        if path:
-            self.open_project_from(path)
+        from .project_dialog import SpriteProjectDialog
+
+        try:
+            dialog = SpriteProjectDialog(self.project_manager, self)
+            if dialog.exec() == QDialog.DialogCode.Accepted and dialog.selected_path():
+                self.open_project_from(dialog.selected_path())
+        except Exception as exc:
+            self._report_error("list projects", exc)
 
     def open_project_from(self, path) -> Optional[SpriteProject]:
         try:
@@ -363,7 +404,7 @@ class SpriteTab(QWidget):
         except Exception as exc:  # noqa: BLE001
             self._report_error("open project", exc)
             return None
-        self._apply_project(project)
+        self._apply_project(project, path)
         return project
 
     def save_project(self) -> Optional[Path]:
@@ -375,7 +416,8 @@ class SpriteTab(QWidget):
         except Exception as exc:  # noqa: BLE001
             self._report_error("save project", exc)
             return None
-        self.log(f"Saved → {saved}", "SUCCESS")
+        self._remember_project(saved)
+        self.log(f"Saved {self._project.name}", "SUCCESS")
         self._sync_title()
         return Path(saved)
 
@@ -383,10 +425,28 @@ class SpriteTab(QWidget):
         if self._project is None:
             show_warning(self, "Sprite", "There is no project to save.")
             return
-        start = str(self._project.project_dir or get_data_paths().sprite_projects())
-        path, _ = QFileDialog.getSaveFileName(self, "Save sprite project as", start, PROJECT_FILTER)
-        if path:
-            self.save_project_to(path)
+        name, ok = QInputDialog.getText(
+            self, "Save sprite project as", "Project name:",
+            text=f"{self._project.name} copy")
+        if ok and name.strip():
+            self.save_project_as_named(name.strip())
+
+    def save_project_as_named(self, name: str) -> Optional[SpriteProject]:
+        if self._project is None:
+            return None
+        if any(panel.is_busy() for panel in self._worker_panels()) or self.frames_workspace._export_dialog:
+            self.log("Wait for running jobs and close Export before copying the project.", "WARNING")
+            return None
+        try:
+            from core.sprite.project_copy import copy_project
+
+            project = copy_project(self._project, name, self.project_manager)
+            self._apply_project(project)
+            self.log(f"Saved {project.name}", "SUCCESS")
+            return project
+        except Exception as exc:
+            self._report_error("copy project", exc)
+            return None
 
     def save_project_to(self, path) -> Optional[Path]:
         if self._project is None:
@@ -396,7 +456,7 @@ class SpriteTab(QWidget):
         except Exception as exc:  # noqa: BLE001
             self._report_error("save project", exc)
             return None
-        self.log(f"Saved → {saved}", "SUCCESS")
+        self.log(f"Saved {self._project.name}", "SUCCESS")
         self._sync_title()
         return Path(saved)
 

--- a/tests/gui/test_startup_lazy_tabs.py
+++ b/tests/gui/test_startup_lazy_tabs.py
@@ -1,0 +1,122 @@
+"""Exercise startup/tab activation without providers, history, or user sessions."""
+import logging
+import time
+
+from PySide6.QtWidgets import QMainWindow, QWidget
+
+
+def make_window(monkeypatch):
+    from gui.main_window import MainWindow
+    import gui.layout
+
+    calls = []
+
+    class Layout(QWidget):
+        def __init__(self, config=None):
+            super().__init__()
+            calls.append("layout")
+
+    monkeypatch.setattr(gui.layout, "LayoutTab", Layout)
+
+    class Window(MainWindow):
+        def __init__(self):
+            QMainWindow.__init__(self)
+            self.config = type("Config", (), {"get": lambda self, key, default=None: default})()
+            self.logger = logging.getLogger(__name__)
+
+        def _init_generate_tab(self):
+            calls.append("image")
+
+        def _init_settings_tab(self):
+            calls.append("settings")
+
+        def _init_history_tab(self):
+            calls.append("history")
+
+        def _init_help_tab(self):
+            calls.append("help")
+
+        def _init_templates_tab(self):
+            calls.append("templates")
+
+        def _trigger_help_render(self):
+            pass
+
+    return Window(), calls
+
+
+def test_startup_defers_unopened_tabs(qapp, monkeypatch):
+    window, calls = make_window(monkeypatch)
+    started = time.perf_counter()
+    window._init_ui()
+    print(f"UI orchestration: {time.perf_counter() - started:.4f}s; constructors: {calls}")
+    assert calls == ["image", "templates", "settings", "history"]
+    window.tabs.setCurrentWidget(window.tab_help)
+    window.tabs.setCurrentWidget(window.tab_generate)
+    window.tabs.setCurrentWidget(window.tab_help)
+    assert calls.count("help") == 1
+    window.tabs.setCurrentWidget(window.tab_layout)
+    assert calls.count("layout") == 1
+
+
+def test_sprite_swap_does_not_activate_neighbor(qapp, monkeypatch):
+    from PySide6.QtCore import Signal
+    import gui.sprite
+
+    class Sprite(QWidget):
+        addToHistoryRequested = Signal(dict)
+
+        def __init__(self, config=None):
+            super().__init__()
+
+    monkeypatch.setattr(gui.sprite, "SpriteTab", Sprite)
+    window, calls = make_window(monkeypatch)
+    window._init_ui()
+    neighbors = []
+    window._load_video_tab = lambda: neighbors.append("video")
+    window.tabs.setCurrentWidget(window.tab_sprite)
+    assert not neighbors
+    assert window.tabs.currentWidget() is window.tab_sprite
+
+
+def test_video_swap_does_not_load_layout(qapp, monkeypatch):
+    import gui.main_window
+    import gui.video.video_project_tab
+    import core.llm_models
+
+    class Video(QWidget):
+        def __init__(self, config, providers):
+            super().__init__()
+
+    monkeypatch.setattr(gui.video.video_project_tab, "VideoProjectTab", Video)
+    monkeypatch.setattr(gui.main_window, "list_providers", lambda: [])
+    monkeypatch.setattr(core.llm_models, "update_ollama_models", lambda: False)
+    window, calls = make_window(monkeypatch)
+    window.current_provider = "google"
+    window._init_ui()
+    window.tabs.setCurrentWidget(window.tab_video)
+    assert "layout" not in calls
+    assert window._video_tab_loaded
+    assert window.tabs.currentWidget() is window.tab_video
+
+
+def test_help_failure_is_logged_and_can_retry(qapp, monkeypatch, caplog):
+    import gui.main_window
+
+    window, calls = make_window(monkeypatch)
+    window._init_ui()
+    original = window.tab_help
+    shown = []
+    monkeypatch.setattr(gui.main_window.QMessageBox, "warning", lambda *args: shown.append(args))
+    def fail():
+        raise RuntimeError("browser unavailable")
+    window._init_help_tab = fail
+    window.tabs.setCurrentWidget(window.tab_help)
+    assert not window._help_tab_loaded
+    assert window.tab_help is original
+    assert shown and "Failed to load Help tab" in caplog.text
+    window._init_help_tab = lambda: calls.append("help")
+    window.tabs.setCurrentWidget(window.tab_generate)
+    window.tabs.setCurrentWidget(window.tab_help)
+    assert window._help_tab_loaded
+    assert window.tabs.count() == 8

--- a/tests/sprite/generation/test_gen_queue.py
+++ b/tests/sprite/generation/test_gen_queue.py
@@ -386,3 +386,25 @@ def test_cancel_during_a_re_render_requeues_the_card(harness):
     assert q.pending == ["a1"]
     assert walk.clip is old_clip                      # the previous clip is kept
     assert isinstance(results["a1"], ProviderError) and results["a1"].retryable is True
+
+
+
+def test_original_background_queue_needs_source_not_plate(harness, png_file):
+    project, queue = harness["build"](plate=False, turnaround=True)
+    project.background.mode = "original"
+    project.character_source = png_file("original.png", color=(255, 255, 255, 255))
+    request = queue.build_request(project.actions[0])
+    assert request.background_mode == "original"
+    assert request.plate == project.character_source
+    assert request.refs == []
+    queue.enqueue([project.actions[0].id])
+    queue.run()
+    assert len(harness["renders"]) == 1
+
+
+def test_original_background_requires_source_even_with_old_plate(harness):
+    project, queue = harness["build"]()
+    project.background.mode = "original"
+    project.character_source = None
+    with pytest.raises(ProviderError, match="Import a character"):
+        queue.build_request(project.actions[0])

--- a/tests/sprite/generation/test_gen_video_route.py
+++ b/tests/sprite/generation/test_gen_video_route.py
@@ -391,3 +391,30 @@ def test_veo_loop_conditioning_is_skipped_for_a_non_looping_action(request_for, 
     cfg = build_veo_config(req)
     assert cfg.image is None and cfg.last_frame is None
     assert cfg.duration == 6
+
+
+@pytest.mark.parametrize("provider", ["omni", "veo"])
+@pytest.mark.parametrize("loop", [False, True])
+def test_original_background_uses_source_without_chroma_refs(request_for, make_action, provider, loop):
+    req = request_for(provider, refs=2)
+    req.background_mode = "original"
+    req.action = make_action(loop=loop)
+    cfg = build_omni_config(req) if provider == "omni" else build_veo_config(req)
+    assert "Preserve the original reference image background" in cfg.prompt
+    assert "chroma" not in cfg.prompt and "#00FF00" not in cfg.prompt
+    assert (LOOP_SUFFIX in cfg.prompt) == loop
+    if provider == "omni":
+        assert cfg.reference_images == [req.plate]
+    else:
+        assert cfg.image == req.plate
+        assert cfg.last_frame == (req.plate if loop else None)
+        assert cfg.reference_images is None
+
+
+def test_original_background_is_recorded_in_render_sidecar(request_for, monkeypatch):
+    _omni_client(monkeypatch)
+    req = request_for("omni")
+    req.background_mode = "original"
+    record = render_action(req, api_key="test")
+    assert record.params["background_mode"] == "original"
+    assert json.loads(req.out_mp4.with_suffix(".json").read_text())["params"]["background_mode"] == "original"

--- a/tests/sprite/gui/conftest.py
+++ b/tests/sprite/gui/conftest.py
@@ -6,7 +6,7 @@ import types
 import pytest
 from PySide6.QtWidgets import QApplication
 
-from core.sprite.project import ActionCard, GenerationSettings
+from core.sprite.project import BackgroundSettings, ActionCard, GenerationSettings
 
 
 class FakeConfig:
@@ -61,6 +61,7 @@ def fake_project(tmp_path):
             ActionCard(id="a2", name="walk", prompt="walk cycle", target_frames=8, fps=12),
         ],
         generation=GenerationSettings(),
+        background=BackgroundSettings(),
         cost_ledger=[],
         stage_fingerprints={},
     )
@@ -109,3 +110,22 @@ def _collect_dead_qt_objects_between_tests(qapp):
     for _ in range(3):
         qapp.processEvents()
     gc.collect()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_sprite_preferences(tmp_path, monkeypatch):
+    """Use an explicit INI store: NativeFormat is the Windows registry, not a path."""
+    import sys
+    from PySide6.QtCore import QSettings
+    from gui.sprite import prefs
+
+    original = prefs.sprite_settings
+    settings_file = str(tmp_path / "sprite-preferences.ini")
+
+    def temporary_settings():
+        return QSettings(settings_file, QSettings.Format.IniFormat)
+
+    # Cover modules that import the helper directly, including smoke-test aliases.
+    for module in list(sys.modules.values()):
+        if isinstance(module, types.ModuleType) and vars(module).get("sprite_settings") is original:
+            monkeypatch.setattr(module, "sprite_settings", temporary_settings)

--- a/tests/sprite/gui/test_character_panel.py
+++ b/tests/sprite/gui/test_character_panel.py
@@ -239,3 +239,19 @@ def test_paths_from_mime_filters_images(qapp, tmp_path):
     mime.setUrls([QUrl.fromLocalFile(str(tmp_path / "a.png")),
                   QUrl.fromLocalFile(str(tmp_path / "b.txt"))])
     assert paths_from_mime(mime) == [tmp_path / "a.png"]
+
+
+
+def test_original_background_disables_plate_generation(qapp, fake_config, fake_project, png, monkeypatch):
+    fake_project.background.mode = "original"
+    fake_project.character_source = png
+    panel = CharacterPanel(fake_config)
+    panel.set_project(fake_project)
+    assert not panel.plate_btn.isEnabled()
+    assert not panel.plate_color_btn.isEnabled()
+    assert not panel.turnaround_btn.isEnabled()
+    calls = []
+    monkeypatch.setattr(panel, "_ready_for_provider", lambda what: calls.append(what))
+    panel.make_plate()
+    panel.generate_turnaround()
+    assert calls == []

--- a/tests/sprite/gui/test_export_dialog.py
+++ b/tests/sprite/gui/test_export_dialog.py
@@ -1,14 +1,16 @@
 import gc
+import json
 import threading
 import time
 from pathlib import Path
 
 import pytest
 from PySide6.QtTest import QTest
+from PySide6.QtCore import QSettings
 
 import gui.sprite.export_dialog as ed
 from core.sprite.exporters.grid import GridOptions
-from core.sprite.pipeline import CancelToken, no_progress
+from core.sprite.pipeline import STALE_STABILIZE_REASON, CancelToken, no_progress
 from core.sprite.project import SpriteProject
 from gui.sprite.export_dialog import (BUILTIN_FORMATS, DEFAULT_TEMPLATE, ExportDialog,
                                       ExportRequest, parse_scales, run_export, sheet_png_path)
@@ -39,7 +41,7 @@ def _wait_idle(dialog, timeout_s=10.0):
 
 
 @pytest.fixture(autouse=True)
-def _isolated_export_settings():
+def _isolated_export_settings(tmp_path, monkeypatch):
     """Important 7: tests must not see another test's persisted sprite/export/* keys.
 
     `tests/conftest.py` sandboxes QSettings into one session-scoped ini file with no
@@ -52,6 +54,11 @@ def _isolated_export_settings():
     same clean slate. `test_settings_round_trip` is unaffected: it exercises persistence
     across two `ExportDialog`s constructed within itself.
     """
+    # NativeFormat is the Windows registry: setPath cannot redirect it.
+    # Use an explicit INI file to exercise persistence without touching user preferences.
+    settings_file = str(tmp_path / "sprite-settings.ini")
+    monkeypatch.setattr(ed.prefs, "sprite_settings",
+                        lambda: QSettings(settings_file, QSettings.Format.IniFormat))
     settings = ed.prefs.sprite_settings()
     settings.remove(ed.SETTINGS_PREFIX.rstrip("/"))
     settings.sync()
@@ -63,6 +70,9 @@ def project(tmp_path, monkeypatch):
     project, _action = make_project(tmp_path)
     monkeypatch.setattr(SpriteProject, "sheet_meta",
                         lambda self, profile, warn=True: sheet_from_action(self.actions[0], profile))
+    # Unit tests provide their own sheet metadata; pipeline integration tests
+    # below use real stages or replace this helper with a recorder.
+    monkeypatch.setattr(ed, "ensure_profile_stages", lambda *args, **kwargs: {})
     monkeypatch.setattr(ed.prefs, "purge_after_export_enabled", lambda: False)
     monkeypatch.setattr(ed.prefs, "set_purge_after_export", lambda value: None)
     monkeypatch.setattr(ed.prefs, "confirm_purge", lambda parent: True)
@@ -191,6 +201,37 @@ def test_run_export_gif_per_tag(project, tmp_path):
                        progress=no_progress, token=CancelToken())
     assert [Path(p).name for p in files] == ["walk_walk.gif", "walk_walk.gif.json"]
     assert sorted(Path(p).name for p in files) == _on_disk(tmp_path / "out" / "pixel")
+
+
+@pytest.mark.parametrize("mode", ["solid", "original"])
+def test_run_export_gif_background_metadata_and_pixels(project, tmp_path, mode):
+    import json
+
+    project.background.mode = mode
+    project.background.color = "#123456"
+    for index, frame in enumerate(project.actions[0].frames):
+        source = Image.new("RGBA", (8, 8), (0, 255, 0, 255 if mode == "original" else 0))
+        source.putpixel((index + 2, 5), (240, 80, 20, 255))
+        source.save(frame.source_path)
+    request = _request(project, tmp_path, ["pixel"], ["gif"])
+    files = run_export(request, _formats("gif"), log=lambda m: None,
+                       progress=no_progress, token=CancelToken())
+    with Image.open(files[0]) as gif:
+        assert "transparency" not in gif.info
+        assert gif.convert("RGB").getpixel((0, 0)) == ((18, 52, 86) if mode == "solid" else (0, 255, 0))
+    metadata = json.loads(Path(files[1]).read_text())
+    assert metadata["background_mode"] == mode
+    assert metadata["background_color"] == ("#123456" if mode == "solid" else None)
+
+
+def test_export_dialog_displays_project_background(qapp, project):
+    project.background.mode = "solid"
+    project.background.color = "#123456"
+    dialog = ExportDialog(project)
+    assert "#123456" in dialog.background_label.text()
+    assert "GIF only" in dialog.background_label.text()
+    assert "Processing" in dialog.background_label.text()
+    _close(dialog)
 
 
 def test_run_export_applies_pivot_and_passes_filled_meta_to_plugins(project, tmp_path):
@@ -609,15 +650,16 @@ def test_run_export_ensures_profile_stages_per_action_before_sheet_meta(project,
                       ("ensure", "act1", ["pixel"]), ("sheet_meta", "pixel")]
 
 
-def test_run_export_logs_every_ensure_reason_and_still_writes(project, tmp_path, monkeypatch, caplog):
+def test_run_export_blocks_stale_processing_before_writing(project, tmp_path, monkeypatch, caplog):
     events = []
-    _install_recorder(monkeypatch, events, reasons={"hd": "stabilize output is stale"})
+    _install_recorder(monkeypatch, events, reasons={"hd": STALE_STABILIZE_REASON})
     logs = []
     req = _request(project, tmp_path, ["hd"], ["png_sequence"])
     with caplog.at_level("WARNING", logger="gui.sprite.export_dialog"):
-        files = run_export(req, _formats("png_sequence"), log=logs.append,
-                           progress=no_progress, token=CancelToken())
-    assert len(files) == 8
+        with pytest.raises(ValueError, match="Run the pipeline"):
+            run_export(req, _formats("png_sequence"), log=logs.append,
+                       progress=no_progress, token=CancelToken())
+    assert not req.out_dir.exists()
     assert any("stabilize output is stale" in line and "walk" in line for line in logs)
     assert any("stabilize output is stale" in r.message for r in caplog.records)
 
@@ -625,14 +667,15 @@ def test_run_export_logs_every_ensure_reason_and_still_writes(project, tmp_path,
 def test_run_export_sends_reasons_at_warning_level(project, tmp_path, monkeypatch):
     """A two-argument log callback (the dialog's) gets WARNING for a reason; the
     ordinary lines stay INFO."""
-    _install_recorder(monkeypatch, [], reasons={"hd": "stabilize output is stale"})
+    _install_recorder(monkeypatch, [], reasons={"hd": "profile is disabled"})
     logs = []
     req = _request(project, tmp_path, ["hd"], ["png_sequence"])
-    run_export(req, _formats("png_sequence"), log=lambda m, level="INFO": logs.append((level, m)),
-               progress=no_progress, token=CancelToken())
-    levels = {level for level, line in logs if "stabilize output is stale" in line}
+    with pytest.raises(ValueError, match="profile is disabled"):
+        run_export(req, _formats("png_sequence"), log=lambda m, level="INFO": logs.append((level, m)),
+                   progress=no_progress, token=CancelToken())
+    levels = {level for level, line in logs if "profile is disabled" in line}
     assert levels == {"WARNING"}
-    assert any(level == "INFO" and line.startswith("Wrote ") for level, line in logs)
+    assert not any(line.startswith("Wrote ") for _level, line in logs)
 
 
 def test_run_export_saves_the_project_after_the_helper(project, tmp_path, monkeypatch):
@@ -710,3 +753,97 @@ def test_run_export_end_to_end_writes_hd_cell_sized_frames(tmp_path, alpha_frame
         with Image.open(png) as im:
             assert im.size == (256, 256), png.name
     assert (project.project_dir / "project.iasprite.json").exists()
+
+
+def test_export_rejects_disabled_profile_with_old_background_outputs(tmp_path, alpha_frames):
+    project = SpriteProject(name="background")
+    project.project_dir = tmp_path / "project"
+    project.project_dir.mkdir()
+    action = ActionCard(id="a1", name="walk", prompt="walk")
+    project.actions = [action]
+    import_png_sequence(alpha_frames, stage_dir(project, action, "extract"))
+    register_external_frames(project, action)
+    run_pipeline(project, action, upto="hd")
+    assert list(stage_dir(project, action, "hd").glob("*.png"))
+    project.profile("hd").enabled = False
+    project.background.mode = "original"
+    run_pipeline(project, action, upto="stabilize")
+    request = _request(project, tmp_path, ["hd"], ["gif"])
+    with pytest.raises(ValueError, match="disabled"):
+        run_export(request, _formats("gif"), log=lambda m: None,
+                   progress=no_progress, token=CancelToken())
+    assert not request.out_dir.exists()
+
+
+def test_export_validates_mutated_background_settings(project, tmp_path, caplog):
+    project.background.mode = "solid"
+    project.background.color = "not a color"
+    request = _request(project, tmp_path, ["hd"], ["gif"])
+    with pytest.raises(ValueError, match="#RRGGBB"):
+        run_export(request, _formats("gif"), log=lambda m: None,
+                   progress=no_progress, token=CancelToken())
+    assert "not a color" in caplog.text
+    assert not request.out_dir.exists()
+
+
+@pytest.mark.parametrize("background_mode", ["transparent", "original", "solid"])
+@pytest.mark.parametrize("upscale_small", [False, True])
+@pytest.mark.parametrize("cells", [((256, 256), (64, 64)), ((120, 80), (48, 72))])
+def test_background_modes_export_exact_profile_canvases(
+        tmp_path, background_mode, upscale_small, cells):
+    """Background choice must not turn profile dimensions into resize bounds."""
+    project = SpriteProject(name="background_geometry", project_dir=tmp_path / "project")
+    project.background.mode = background_mode
+    project.background.color = "#123456"
+    project.key.method = "chroma"
+    project.key.key_color = "#00FF00"
+    project.stabilize.pad_px = 4
+    project.stabilize.anchor = "center"
+    action = ActionCard(id="a1", name="walk", prompt="walk")
+    project.actions = [action]
+    extracted = stage_dir(project, action, "extract")
+    extracted.mkdir(parents=True)
+    for index in range(2):
+        image = Image.new("RGBA", (160, 90), "#00FF00")
+        image.paste((220, 30 + index * 50, 40, 255), (30 + index, 20, 120 + index, 70))
+        image.save(extracted / f"{index + 1:04d}.png")
+    register_external_frames(project, action)
+    for name, cell in zip(("hd", "pixel"), cells):
+        profile = project.profile(name)
+        profile.cell_size = cell
+        profile.upscale_small = upscale_small
+        profile.upscale_method = "lanczos"
+
+    # Export must build both profile stages from current stabilization output.
+    run_pipeline(project, action, upto="stabilize")
+    formats = ["grid", "png_sequence", "gif"]
+    request = _request(project, tmp_path, ["hd", "pixel"], formats,
+                       grid=GridOptions(columns=2, shape_px=0))
+    files = run_export(request, _formats(*formats), log=lambda message: None,
+                       progress=no_progress, token=CancelToken())
+
+    for name, cell in zip(("hd", "pixel"), cells):
+        profile_dir = request.out_dir / name
+        meta = project.sheet_meta(name)
+        sheet_path = sheet_png_path(meta, profile_dir)
+        png_frames = [path for path in files
+                      if path.parent == profile_dir / "frames" and path.suffix == ".png"]
+        gifs = [path for path in files if path.parent == profile_dir and path.suffix == ".gif"]
+        assert len(png_frames) == 2
+        assert len(gifs) == 1
+        for path in png_frames + gifs:
+            with Image.open(path) as image:
+                assert image.size == cell, (background_mode, name, path.name)
+                if path.suffix == ".gif":
+                    assert image.n_frames == 2
+                    for frame_index in range(image.n_frames):
+                        image.seek(frame_index)
+                        assert image.size == cell
+        with Image.open(sheet_path) as sheet:
+            assert sheet.size == (2 * cell[0], cell[1])
+        sheet_json = json.loads(sheet_path.with_suffix(".json").read_text(encoding="utf-8"))
+        assert sheet_json["meta"]["size"] == {"w": 2 * cell[0], "h": cell[1]}
+        assert len(sheet_json["frames"]) == 2
+        for frame in sheet_json["frames"].values():
+            assert frame["sourceSize"] == {"w": cell[0], "h": cell[1]}
+            assert (frame["frame"]["w"], frame["frame"]["h"]) == cell

--- a/tests/sprite/gui/test_image_route_dialog.py
+++ b/tests/sprite/gui/test_image_route_dialog.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import QWidget
 from core.sprite.generation.errors import ProviderError
 from core.sprite.models import FrameMeta
 from core.sprite.pipeline import Cancelled, CancelToken, no_progress
-from core.sprite.project import ActionCard, SpriteProject
+from core.sprite.project import ActionCard, BackgroundSettings, SpriteProject
 from gui.sprite import image_route_dialog as ird
 from gui.sprite.image_route_dialog import (
     ImageRouteDialog, archive_existing_frames, billed_units, install_image_route,
@@ -35,6 +35,7 @@ def _project(tmp_path):
     project.plate_path = None
     project.character_source = _png(tmp_path / "character.png")
     project.plate_color = "#00FF00"
+    project.background = BackgroundSettings()
     return project
 
 
@@ -558,3 +559,28 @@ def test_image_route_is_refused_while_the_render_queue_runs(qapp, tmp_path):
     assert ("Wait for the render queue to finish before rendering", "WARNING") in tab.log_calls
     tab.queue_panel = SimpleNamespace(is_busy=lambda: False)
     assert ird.open_image_route_dialog(tab, action, exec_dialog=False) is not None
+
+
+
+@pytest.mark.parametrize("route", ["sheet", "edit_chain"])
+def test_original_background_job_ignores_old_plate_and_matte(qapp, tmp_path, monkeypatch, route):
+    produced = [_png(tmp_path / "0001.png"), _png(tmp_path / "0002.png")]
+    _patch_core(monkeypatch, tmp_path, produced)
+    requests = []
+
+    def generator(provider, character, *args, **kwargs):
+        # Keep plain request data, not Qt-bound log callbacks, through teardown.
+        requests.append((character, kwargs["background_mode"], kwargs.get("matte_pairs")))
+        return tmp_path / "sheet.png" if route == "sheet" else produced
+
+    monkeypatch.setattr(ird, "generate_sheet" if route == "sheet" else "edit_chain", generator)
+    dialog = _dialog(tmp_path)
+    dialog.project.background.mode = "original"
+    dialog.project.plate_path = _png(tmp_path / "old-green-plate.png")
+    dialog.mode_combo.setCurrentIndex(0 if route == "sheet" else 1)
+    dialog._on_mode_changed(0)
+    assert not dialog.matte_check.isEnabled()
+    dialog.matte_check.setChecked(True)  # Build-job guard must also prevent matte work.
+    dialog.build_job()(no_progress, CancelToken())
+    assert requests == [(dialog.project.character_source, "original", False if route == "edit_chain" else None)]
+    dialog.close()

--- a/tests/sprite/gui/test_processing_panel.py
+++ b/tests/sprite/gui/test_processing_panel.py
@@ -529,3 +529,64 @@ def test_run_pipeline_is_refused_while_an_external_job_runs(panel, monkeypatch):
     widget.set_busy_guard(lambda: None)
     widget.run_pipeline()
     assert started == ["Pipeline"]
+
+
+
+def test_original_background_disables_cleanup_and_preserves_preferences(panel):
+    widget, project, _ = panel
+    widget.tolerance.setValue(33)
+    widget.dejitter.setChecked(True)
+    changes = []
+    widget.backgroundChanged.connect(lambda: changes.append(project.background.mode))
+    widget.background_mode.setCurrentIndex(widget.background_mode.findData("original"))
+    assert project.background.mode == "original"
+    assert not widget.key_box.isEnabled()
+    assert widget.stabilize_box.isEnabled()
+    assert not widget.preview_btn.isEnabled()
+    assert widget.profile_editors["pixel"].palette_size.isEnabled()
+    assert "exact canvas size" in widget.background_help.text()
+    assert project.key.tolerance == 0.33 and project.stabilize.dejitter
+    widget.background_mode.setCurrentIndex(widget.background_mode.findData("transparent"))
+    assert widget.key_box.isEnabled() and widget.stabilize_box.isEnabled()
+    assert widget.profile_editors["pixel"].palette_size.isEnabled()
+    assert project.key.tolerance == 0.33 and project.stabilize.dejitter
+    assert changes == ["original", "transparent"]
+
+
+def test_solid_color_commits_validated_hex_and_reloads(panel, monkeypatch):
+    widget, project, _ = panel
+    widget.background_mode.setCurrentIndex(widget.background_mode.findData("solid"))
+    widget.background_color.setText("#a1B2c3")
+    assert widget.validate_background()
+    assert project.background.color == "#A1B2C3"
+    widget.set_project(project)
+    assert widget.background_mode.currentData() == "solid"
+    assert widget.background_color.text() == "#A1B2C3"
+    shown = []
+    monkeypatch.setattr(pp.QMessageBox, "warning", staticmethod(lambda *a, **k: shown.append(a)))
+    widget.background_color.setText("bad")
+    assert not widget.validate_background()
+    assert project.background.color == "#A1B2C3"
+    assert shown
+
+
+def test_background_change_blocked_while_external_job_uses_project(panel, monkeypatch):
+    widget, project, _ = panel
+    widget.set_background_busy_guard(lambda: "render queue")
+    shown = []
+    monkeypatch.setattr(pp.QMessageBox, "warning", staticmethod(lambda *a, **k: shown.append(a)))
+    widget.background_mode.setCurrentIndex(widget.background_mode.findData("original"))
+    assert project.background.mode == "transparent"
+    assert widget.background_mode.currentData() == "transparent"
+    assert shown
+
+
+def test_original_background_ignores_unused_invalid_key_and_skips_preview(panel, monkeypatch):
+    widget, project, _ = panel
+    widget.background_mode.setCurrentIndex(widget.background_mode.findData("original"))
+    widget.key_color_edit.setText("invalid")
+    assert widget._check_key_color_field()
+    called = []
+    monkeypatch.setattr(pp, "ffmpeg_chromakey_preview", lambda *a, **k: called.append(1))
+    widget.preview_key_on_clip()
+    assert not called and not widget.is_busy()

--- a/tests/sprite/gui/test_project_library.py
+++ b/tests/sprite/gui/test_project_library.py
@@ -1,0 +1,126 @@
+"""Project-name UI and last-project restoration, with real temporary projects."""
+from pathlib import Path
+
+from gui.sprite import SpriteTab
+from gui.sprite.prefs import sprite_settings
+
+
+def test_last_project_restored_after_workspace_is_wired(qapp, fake_config):
+    first = SpriteTab(fake_config)
+    project = first.new_project_named("Space Ranger")
+    first.shutdown()
+    second = SpriteTab(fake_config)
+    assert second.current_project is not None
+    assert second.current_project.project_dir == project.project_dir
+    assert second.frames_workspace.panel.project() is second.current_project
+    assert second.title_label.text() == "Space Ranger"
+    second.shutdown()
+
+
+def test_missing_last_project_is_logged_without_blocking(qapp, fake_config, tmp_path):
+    sprite_settings().setValue("sprite/last_project", str(tmp_path / "gone.iasprite.json"))
+    tab = SpriteTab(fake_config)
+    assert tab.current_project is None
+    assert "Could not restore" in tab.console.console.toPlainText()
+    assert sprite_settings().contains("sprite/last_project")
+
+
+def test_title_and_save_confirmation_only_show_project_name(qapp, fake_config):
+    tab = SpriteTab(fake_config)
+    project = tab.new_project_named("Space Ranger")
+    tab.save_project()
+    assert tab.title_label.text() == "Space Ranger"
+    assert str(project.project_dir) not in tab.console.console.toPlainText()
+
+
+def test_picker_uses_names_and_distinguishes_duplicate_projects(qapp, tmp_path):
+    from core.sprite.project import SpriteProjectManager
+    from gui.sprite.project_dialog import SpriteProjectDialog
+
+    manager = SpriteProjectManager(tmp_path)
+    first = manager.create_project("Space Ranger")
+    second = manager.create_project("Space Ranger")
+    dialog = SpriteProjectDialog(manager)
+    assert dialog.project_list.count() == 2
+    labels = [dialog.project_list.item(i).text() for i in range(2)]
+    assert all("Space Ranger" in label for label in labels)
+    assert labels[0] != labels[1]
+    assert all(str(tmp_path) not in label for label in labels)
+    selected = set()
+    for index in range(2):
+        dialog.project_list.setCurrentRow(index)
+        selected.add(Path(dialog.selected_path()))
+    assert selected == {first.project_file(), second.project_file()}
+
+
+def test_named_save_as_copies_media_and_remembers_copy(qapp, fake_config, png):
+    tab = SpriteTab(fake_config)
+    original = tab.new_project_named("Original")
+    source = original.project_dir / "source" / "character.png"
+    source.write_bytes(png.read_bytes())
+    original.character_source = source
+    copied = tab.save_project_as_named("Second version")
+    assert copied is tab.current_project
+    assert copied.name == "Second version"
+    assert copied.project_dir != original.project_dir
+    assert copied.character_source.read_bytes() == png.read_bytes()
+    assert source.exists()
+    assert not Path(sprite_settings().value("sprite/last_project")).is_absolute()
+    second = SpriteTab(fake_config)
+    assert second.current_project.project_dir == copied.project_dir
+
+
+def test_failed_manual_open_keeps_last_successful_project(qapp, fake_config, monkeypatch, tmp_path):
+    tab = SpriteTab(fake_config)
+    original = tab.new_project_named("Good project")
+    saved = sprite_settings().value("sprite/last_project")
+    monkeypatch.setattr(tab, "_report_error", lambda *args: None)
+    assert tab.open_project_from(tmp_path / "missing.json") is None
+    assert tab.current_project is original
+    assert sprite_settings().value("sprite/last_project") == saved
+
+
+def test_relative_last_project_follows_new_library_root(qapp, fake_config, tmp_path, monkeypatch):
+    import shutil
+    from core.sprite.project import SpriteProjectManager
+
+    tab = SpriteTab(fake_config)
+    original = tab.new_project_named("Moving project")
+    moved_library = tmp_path / "moved"
+    shutil.copytree(original.project_dir, moved_library / original.project_dir.name)
+    monkeypatch.setattr("gui.sprite.sprite_tab.SpriteProjectManager",
+                        lambda: SpriteProjectManager(moved_library))
+    second = SpriteTab(fake_config)
+    assert second.current_project.project_dir == moved_library / original.project_dir.name
+
+
+def test_picker_skips_invalid_metadata_and_keeps_valid_projects(qapp, tmp_path, caplog):
+    from core.sprite.project import SpriteProjectManager
+    from gui.sprite.project_dialog import SpriteProjectDialog
+
+    manager = SpriteProjectManager(tmp_path)
+    good = manager.create_project("Good project")
+    for index, content in enumerate(('[]', '{"actions": null}', '{"name": []}', '{broken')):
+        broken = manager.create_project(f"Broken {index}")
+        broken.project_file().write_text(content, encoding="utf-8")
+    dialog = SpriteProjectDialog(manager)
+    assert dialog.project_list.count() == 1
+    assert dialog.selected_path() == good.project_file()
+    assert "Failed to read sprite project" in caplog.text
+
+
+def test_picker_search_and_cancel_do_not_open_a_project(qapp, tmp_path):
+    from PySide6.QtWidgets import QDialog, QDialogButtonBox
+    from core.sprite.project import SpriteProjectManager
+    from gui.sprite.project_dialog import SpriteProjectDialog
+
+    manager = SpriteProjectManager(tmp_path)
+    good = manager.create_project("Space Ranger")
+    dialog = SpriteProjectDialog(manager)
+    dialog.search.setText("missing")
+    assert dialog.selected_path() is None
+    assert not dialog.buttons.button(QDialogButtonBox.Open).isEnabled()
+    dialog.search.setText("ranger")
+    assert dialog.selected_path() == good.project_file()
+    dialog.reject()
+    assert dialog.result() == QDialog.DialogCode.Rejected

--- a/tests/sprite/gui/test_sprite_tab_integration.py
+++ b/tests/sprite/gui/test_sprite_tab_integration.py
@@ -16,6 +16,13 @@ class _StubQueue(QObject):
         return False
 
 
+class _StubCharacter(_StubQueue):
+    sync_count = 0
+
+    def _sync_enabled(self):
+        self.sync_count += 1
+
+
 class _StubTab(QWidget):
     """Implements the 5a SpriteTab contract that FramesWorkspace consumes."""
 
@@ -27,12 +34,16 @@ class _StubTab(QWidget):
         self._project = project
         self.console = DialogStatusConsole("Console")
         self.queue_panel = _StubQueue(self)
+        self.character_panel = _StubCharacter(self)
         self.placed = {}
         self.toolbar_buttons = []
         self.log_calls = []
         self.saved = []
         self._layout = QVBoxLayout(self)
         self._layout.addWidget(self.console)
+
+    def _autosave(self):
+        self.save_current_project()
 
     def save_current_project(self):
         self.saved.append(self._project)
@@ -668,3 +679,13 @@ def test_real_sprite_tab_shutdown_autosaves(qapp, monkeypatch):
     Path(saved).unlink()
     assert tab.shutdown() is True
     assert Path(saved).exists()                      # written again on close
+
+
+
+def test_background_change_updates_generation_controls_and_autosaves(qapp, tmp_path, monkeypatch):
+    tab, workspace, project, action = _workspace(qapp, tmp_path, monkeypatch)
+    workspace.panel.background_mode.setCurrentIndex(workspace.panel.background_mode.findData("original"))
+    assert project.background.mode == "original"
+    assert tab.character_panel.sync_count == 1
+    assert tab.saved == [project]
+    workspace.shutdown()

--- a/tests/sprite/test_background_geometry.py
+++ b/tests/sprite/test_background_geometry.py
@@ -1,0 +1,69 @@
+"""Background selection must not bypass configured output geometry."""
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from core.sprite.pipeline import (
+    hd_runner, stage_fingerprint, stabilize_runner,
+)
+from core.sprite.pixelart import run_pixel_stage
+from core.sprite.project import ActionCard, OutputProfile, SpriteProject
+
+
+@pytest.mark.parametrize("mode", ["original", "transparent", "solid"])
+@pytest.mark.parametrize("profile_name,runner", [("hd", hd_runner), ("pixel", run_pixel_stage)])
+@pytest.mark.parametrize("cell", [(256, 256), (64, 64), (96, 48)])
+def test_every_background_honors_exact_profile_canvas(tmp_path, mode, profile_name, runner, cell):
+    project = SpriteProject(name="geometry", project_dir=tmp_path)
+    project.background.mode = mode
+    project.profiles = [OutputProfile(name=profile_name, cell_size=cell, palette_size=None)]
+    frame = tmp_path / "wide.png"
+    Image.new("RGBA", (1280, 720), (80, 120, 160, 255)).save(frame)
+    result = runner(project, ActionCard(id="a1", name="walk", prompt="walk"), [frame], tmp_path / "out",
+                    lambda *args: None, None)
+    with Image.open(result[0]) as image:
+        assert image.size == cell
+
+
+def test_original_uses_same_crop_padding_and_anchor_as_other_modes(tmp_path):
+    project = SpriteProject(name="geometry", project_dir=tmp_path)
+    project.stabilize.pad_px = 3
+    project.stabilize.anchor = "top_left"
+    project.stabilize.dejitter = False
+    action = ActionCard(id="a1", name="walk", prompt="walk")
+    frame = tmp_path / "border.png"
+    pixels = np.full((30, 50, 4), (50, 100, 150, 255), dtype=np.uint8)
+    pixels[8:20, 10:35] = (200, 80, 60, 255)
+    Image.fromarray(pixels).save(frame)
+    outputs = []
+    for mode in ("transparent", "solid", "original"):
+        project.background.mode = mode
+        result = stabilize_runner(project, action, [frame], tmp_path / mode,
+                                  lambda *args: None, None)
+        with Image.open(result[0]) as image:
+            outputs.append(np.asarray(image))
+    for output in outputs[1:]:
+        np.testing.assert_array_equal(output, outputs[0])
+
+
+@pytest.mark.parametrize("setting,value", [("upscale_method", "nearest"), ("palette_size", 4)])
+def test_original_profile_cache_tracks_output_settings(tmp_path, setting, value):
+    project = SpriteProject(name="geometry", project_dir=tmp_path)
+    project.background.mode = "original"
+    action = ActionCard(id="a1", name="walk", prompt="walk")
+    before = stage_fingerprint(project, action, "pixel")
+    setattr(project.profile("pixel"), setting, value)
+    assert stage_fingerprint(project, action, "pixel") != before
+
+
+def test_original_cache_tracks_anchor_and_padding(tmp_path):
+    project = SpriteProject(name="geometry", project_dir=tmp_path)
+    project.background.mode = "original"
+    action = ActionCard(id="a1", name="walk", prompt="walk")
+    before = stage_fingerprint(project, action, "stabilize")
+    project.stabilize.pad_px += 5
+    assert stage_fingerprint(project, action, "stabilize") != before
+    before = stage_fingerprint(project, action, "hd")
+    project.stabilize.anchor = "top_left"
+    assert stage_fingerprint(project, action, "hd") != before

--- a/tests/sprite/test_engine_presets.py
+++ b/tests/sprite/test_engine_presets.py
@@ -81,6 +81,22 @@ def test_unknown_preset_raises():
         export_with_preset(SheetMeta(title="x", frames=[], tags=[]), "gamemaker", Path("."))
 
 
+def test_web_preview_solid_color_only_changes_gif(tmp_path):
+    meta = _meta(tmp_path)
+    meta.tags[0].repeat = 4
+    written = export_with_preset(meta, "web_preview", tmp_path / "out", background_color="#123456")
+    with Image.open(tmp_path / "out" / "hero_walk.gif") as gif:
+        assert gif.info["loop"] == 4
+        assert "transparency" not in gif.info
+        assert gif.convert("RGB").getpixel((0, 0)) == (18, 52, 86)
+    png = next(p for p in written if p.suffix == ".png")
+    with Image.open(png) as image:
+        assert image.convert("RGBA").getpixel((0, 0))[3] == 0
+    details = json.loads((tmp_path / "out" / "hero_walk.gif.json").read_text())
+    assert details["background_mode"] == "solid"
+    assert details["background_color"] == "#123456"
+
+
 def test_atlas_formats_subset():
     assert ATLAS_FORMATS <= set(FORMAT_IDS)
 
@@ -134,8 +150,8 @@ def test_manifest_matches_every_file_on_disk_for_web_preview_preset(tmp_path):
     reported = sorted(str(p.relative_to(out)) for p in written)
     assert reported == _on_disk_recursive(out)
     # every frame PNG's sidecar is reported, not just the PNG itself
-    assert "frames/hero_walk_01.png.json" in reported
-    assert "frames/hero_idle_02.png.json" in reported
+    assert str(Path("frames/hero_walk_01.png.json")) in reported
+    assert str(Path("frames/hero_idle_02.png.json")) in reported
 
 
 def test_gif_sidecar_frame_count_reflects_pingpong_unrolling(tmp_path):

--- a/tests/sprite/test_exporters.py
+++ b/tests/sprite/test_exporters.py
@@ -267,3 +267,87 @@ def test_export_gif_pingpong_and_reverse(tmp_path):
         assert gif.n_frames == 3 and gif.info["loop"] == 3
     with pytest.raises(ValueError):
         export_gif(meta, TagMeta(name="x", from_index=5, to_index=4), tmp_path / "x.gif")
+
+
+def test_solid_gif_blends_alpha_and_clears_moving_frames(tmp_path):
+    meta = _meta(tmp_path)
+    color = "#13579B"
+    for index, frame in enumerate(meta.frames[:3]):
+        source = Image.new("RGBA", (16, 16), (255, 0, 255, 0))
+        source.putpixel((index + 2, 5), (240, 80, 20, 255))
+        source.putpixel((index + 2, 6), (240, 80, 20, 128))
+        source.save(frame.source_path)
+    out = export_gif(meta, meta.tags[0], tmp_path / "solid.gif", loop=3, background_color=color)
+    with Image.open(out) as gif:
+        assert "transparency" not in gif.info
+        assert gif.info["loop"] == 3
+        assert gif.n_frames == 3
+        for index in range(3):
+            gif.seek(index)
+            assert gif.disposal_method == 2
+            assert gif.info["duration"] == 80
+            frame = gif.convert("RGBA")
+            expected = Image.new("RGBA", (16, 16), color)
+            with Image.open(meta.frames[index].source_path) as source:
+                expected = Image.alpha_composite(expected, source)
+            assert frame.tobytes() == expected.tobytes()
+    details = json.loads(out.with_suffix(".gif.json").read_text())
+    assert details["background_mode"] == "solid"
+    assert details["background_color"] == color
+    with Image.open(meta.frames[0].source_path) as source:
+        assert source.getpixel((0, 0))[3] == 0
+
+
+def test_solid_gif_keeps_exact_background_with_busy_palette(tmp_path):
+    meta = _meta(tmp_path, cell=32)
+    for frame in meta.frames[:3]:
+        source = Image.new("RGBA", (32, 32))
+        for y in range(31):
+            for x in range(31):
+                source.putpixel((x, y), (x * 8, y * 8, (x + y) * 4, 255))
+        source.save(frame.source_path)
+    with Image.open(export_gif(meta, meta.tags[0], tmp_path / "busy.gif",
+                               background_color="#13579B")) as gif:
+        assert gif.convert("RGB").getpixel((31, 31)) == (19, 87, 155)
+
+
+def test_original_opaque_gif_has_no_transparency(tmp_path):
+    meta = _meta(tmp_path)
+    for index, frame in enumerate(meta.frames[:3]):
+        source = Image.new("RGB", (16, 16), (0, 255, 0))
+        source.putpixel((index + 2, 5), (240, 80, 20))
+        source.save(frame.source_path)
+    with Image.open(export_gif(meta, meta.tags[0], tmp_path / "original.gif",
+                               background_mode="original")) as gif:
+        assert "transparency" not in gif.info
+        for index in range(3):
+            gif.seek(index)
+            assert gif.convert("RGBA").getpixel((0, 0)) == (0, 255, 0, 255)
+            with Image.open(meta.frames[index].source_path) as source:
+                assert gif.convert("RGB").tobytes() == source.tobytes()
+
+
+def test_original_gif_preserves_existing_alpha_threshold(tmp_path):
+    meta = _meta(tmp_path)
+    for index, frame in enumerate(meta.frames[:3]):
+        source = Image.new("RGBA", (16, 16), (0, 255, 0, 0))
+        source.putpixel((index + 2, 5), (240, 80, 20, 200))
+        source.putpixel((index + 2, 6), (240, 80, 20, 100))
+        source.save(frame.source_path)
+    with Image.open(export_gif(meta, meta.tags[0], tmp_path / "alpha.gif",
+                               background_mode="original")) as gif:
+        assert gif.info["transparency"] == 255
+        for index in range(3):
+            gif.seek(index)
+            frame = gif.convert("RGBA")
+            assert frame.getpixel((index + 2, 5)) == (240, 80, 20, 255)
+            assert frame.getpixel((index + 2, 6))[3] == 0
+            assert frame.getpixel((0, 0))[3] == 0
+
+
+@pytest.mark.parametrize("color", ["red", "#fff", "#11223344", "#xyzxyz", "112233"])
+def test_gif_rejects_invalid_background_color(tmp_path, color):
+    meta = _meta(tmp_path)
+    with pytest.raises(ValueError, match="hex RGB"):
+        export_gif(meta, meta.tags[0], tmp_path / "bad.gif", background_color=color)
+    assert not (tmp_path / "bad.gif").exists()

--- a/tests/sprite/test_image_route.py
+++ b/tests/sprite/test_image_route.py
@@ -382,3 +382,44 @@ def test_edit_chain_session_failure_survives_raising_log_sink(tmp_path):
                      pose_instructions=["a"], plate_color="#00FF00", log=flaky_log)
     assert len(out) == 1
     provider.reset_edit_session.assert_not_called()
+
+
+
+def test_original_background_sheet_keeps_source_background_instruction(tmp_path):
+    provider = _google()
+    out = generate_sheet(provider, _character(tmp_path), _action(), tmp_path / "sheet.png",
+                         frames=3, plate_color="#00FF00", background_mode="original")
+    prompt = provider.edit_image.call_args.args[1]
+    assert "Preserve the original reference image background" in prompt
+    assert "#00FF00" not in prompt and "chroma" not in prompt
+    assert "seamless loop" in prompt
+    meta = json.loads(out.with_suffix(".png.json").read_text())
+    assert meta["background_mode"] == "original"
+
+
+def test_original_background_edit_chain_skips_matte_pairs(tmp_path):
+    provider = _google()
+    paths = image_route.edit_chain(provider, _character(tmp_path), _action(), tmp_path / "frames",
+                                  frames=2, pose_instructions=["raise hand", "lower hand"],
+                                  plate_color="#00FF00", matte_pairs=True, background_mode="original")
+    assert len(paths) == provider.edit_image.call_count == 2
+    for call in provider.edit_image.call_args_list:
+        assert "Preserve the original reference image background" in call.args[1]
+        assert "chroma" not in call.args[1]
+    meta = json.loads(paths[0].with_suffix(".png.json").read_text())
+    assert meta["background_mode"] == "original" and meta["matte_pairs"] is False
+    assert meta["plates"] == []
+
+
+
+def test_original_background_sheet_slicing_ignores_chroma_grid(tmp_path, monkeypatch):
+    sheet = tmp_path / "scenery.png"
+    sheet.write_bytes(png_bytes())
+    monkeypatch.setattr(image_route, "guess_grid", MagicMock(side_effect=AssertionError("chroma grid used")))
+    paths = slice_generated_sheet(sheet, tmp_path / "frames", 3, "#00FF00", background_mode="original")
+    assert len(paths) == 3
+    with Image.open(sheet) as source:
+        for index, path in enumerate(paths):
+            with Image.open(path) as cell:
+                assert cell.size == (16, 16)
+                assert cell.tobytes() == source.crop((index * 16, 0, (index + 1) * 16, 16)).tobytes()

--- a/tests/sprite/test_models.py
+++ b/tests/sprite/test_models.py
@@ -40,7 +40,7 @@ def test_to_dict_uses_plain_json_types():
     import json
     data = _sheet().to_dict()
     json.dumps(data)
-    assert data["frames"][0]["source_path"] == "/x/0.png"
+    assert data["frames"][0]["source_path"] == str(Path("/x/0.png"))
     assert data["frames"][0]["frame"] == [0, 0, 16, 16]
     assert data["tags"][0]["direction"] == "pingpong"
 

--- a/tests/sprite/test_pipeline_background.py
+++ b/tests/sprite/test_pipeline_background.py
@@ -1,0 +1,130 @@
+"""Original background skips removal but shares geometry and output profiles."""
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from core.sprite import keying
+from core.sprite.pipeline import (
+    STAGES, ensure_profile_stages, is_stage_current, register_external_frames,
+    run_pipeline, stage_dir, stage_fingerprint,
+)
+from core.sprite.project import ActionCard, BackgroundSettings, OutputProfile, SpriteProject
+
+
+def make_project(tmp_path, *, alpha=False, cell=(80, 80), upscale=False):
+    project = SpriteProject(name="background", project_dir=tmp_path / "project")
+    project.background = BackgroundSettings(mode="original")
+    project.profiles = [
+        OutputProfile(name=name, enabled=True, cell_size=cell, binary_alpha=True,
+                      palette_size=2, locked_palette=["#000000", "#FFFFFF"],
+                      upscale_small=upscale)
+        for name in ("hd", "pixel")
+    ]
+    project.key.method = "chroma"
+    project.key.key_color = "#00FF00"
+    project.key.choke_px = 3
+    project.key.feather_px = 2
+    project.key.despeckle_px = 20
+    project.key.edge_decontaminate = True
+    project.stabilize.pad_px = 8
+    project.stabilize.dejitter = True
+    action = ActionCard(id="a1", name="walk", prompt="walk")
+    project.actions = [action]
+    directory = stage_dir(project, action, "extract")
+    directory.mkdir(parents=True)
+    arrays = []
+    for index in range(2):
+        pixels = np.full((24, 40, 4), (0, 255, 0, 255), dtype=np.uint8)
+        y, x = np.indices((12, 20))
+        pixels[6:18, 10 + index:30 + index, :3] = np.stack(
+            ((x * 11) % 255, (y * 19) % 255, (x + y) * 7), axis=-1)
+        if alpha:
+            pixels[..., 3] = np.arange(40, dtype=np.uint8)[None, :] * 6
+        Image.fromarray(pixels).save(directory / f"{index + 1:04d}.png")
+        arrays.append(pixels)
+    register_external_frames(project, action)
+    return project, action, arrays
+
+
+@pytest.mark.parametrize("alpha", [False, True])
+def test_original_preserves_border_color_pattern_and_source_alpha(tmp_path, monkeypatch, alpha):
+    project, action, expected = make_project(tmp_path, alpha=alpha)
+
+    def unwanted(*args, **kwargs):
+        pytest.fail("Original background must not run subject cleanup")
+
+    for name in ("key_pass", "cleanup_pass", "alpha_pass"):
+        monkeypatch.setattr(keying, name, unwanted)
+    output = run_pipeline(project, action)
+    for stage, paths in output.items():
+        if stage in ("stabilize", "hd", "pixel"):
+            continue
+        for path, pixels in zip(paths, expected):
+            with Image.open(path) as image:
+                assert image.size == (40, 24), stage
+                np.testing.assert_array_equal(np.asarray(image.convert("RGBA")), pixels)
+    for stage in ("hd", "pixel"):
+        for path in output[stage]:
+            with Image.open(path) as image:
+                assert image.size == (80, 80)
+    assert not (stage_dir(project, action, "key") / "key.json").exists()
+
+
+@pytest.mark.parametrize("cell,upscale", [
+    ((20, 20), False),
+    ((80, 80), True),
+    ((80, 80), False),
+])
+def test_original_profiles_apply_canvas_and_requested_palette(
+        tmp_path, cell, upscale):
+    project, action, _ = make_project(tmp_path, cell=cell, upscale=upscale)
+    output = run_pipeline(project, action)
+    for name in ("hd", "pixel"):
+        for path in output[name]:
+            with Image.open(path) as image:
+                assert image.size == cell
+                if name == "pixel":
+                    pixels = np.asarray(image.convert("RGBA"))
+                    colors = {tuple(rgb) for rgb in pixels[pixels[..., 3] > 0, :3]}
+                    assert colors <= {(0, 0, 0), (255, 255, 255)}
+
+
+def test_background_mode_cache_roundtrip_and_export_stale_guard(tmp_path):
+    project, action, _ = make_project(tmp_path)
+    first = run_pipeline(project, action)
+    expected = [path.read_bytes() for path in first["pixel"]]
+    original = {stage: stage_fingerprint(project, action, stage) for stage in STAGES}
+    project.background.mode = "transparent"
+    keyed = {stage: stage_fingerprint(project, action, stage) for stage in STAGES}
+    assert original["extract"] == keyed["extract"]
+    for stage in STAGES[1:]:
+        assert original[stage] != keyed[stage]
+        assert not is_stage_current(project, action, stage)
+    assert "stale" in ensure_profile_stages(project, action, ["hd"])["hd"]
+    run_pipeline(project, action, upto="stabilize")
+    project.background.mode = "original"
+    assert not is_stage_current(project, action, "stabilize")
+    output = run_pipeline(project, action)
+    assert [path.read_bytes() for path in output["pixel"]] == expected
+    assert all(is_stage_current(project, action, stage) for stage in STAGES)
+
+
+def test_original_cache_ignores_only_disabled_cleanup_and_fill_color_settings(tmp_path):
+    project, action, _ = make_project(tmp_path)
+    before = {stage: stage_fingerprint(project, action, stage) for stage in STAGES}
+    project.key.tolerance = 0.7
+    project.background.color = "#123456"
+    assert {stage: stage_fingerprint(project, action, stage) for stage in STAGES} == before
+    project.profile("pixel").cell_size = (20, 20)
+    assert stage_fingerprint(project, action, "pixel") != before["pixel"]
+    assert stage_fingerprint(project, action, "hd") == before["hd"]
+
+
+def test_transparent_and_solid_share_processing_cache(tmp_path):
+    project, action, _ = make_project(tmp_path)
+    project.background.mode = "transparent"
+    before = {stage: stage_fingerprint(project, action, stage) for stage in STAGES}
+    project.background.mode = "solid"
+    project.background.color = "#ABCDEF"
+    assert {stage: stage_fingerprint(project, action, stage) for stage in STAGES} == before

--- a/tests/sprite/test_pipeline_pixel.py
+++ b/tests/sprite/test_pipeline_pixel.py
@@ -169,10 +169,10 @@ def test_pixel_stage_second_run_with_fewer_frames_removes_stale_output(tmp_path)
     assert sorted(p.name for p in out_dir.glob("*.png")) == ["0001.png"]
 
 
-def test_pixel_stage_is_registered_at_code_version_2():
+def test_pixel_stage_is_registered_at_code_version_3():
     assert STAGE_RUNNERS["pixel"] is run_pixel_stage
     assert STAGE_SETTINGS["pixel"] is pixel_stage_settings
-    assert STAGE_CODE_VERSION["pixel"] == 2
+    assert STAGE_CODE_VERSION["pixel"] == 3
 
 
 def test_pixel_settings_drive_the_fingerprint(tmp_path):

--- a/tests/sprite/test_project.py
+++ b/tests/sprite/test_project.py
@@ -426,3 +426,51 @@ def test_action_card_rejects_an_id_that_is_not_a_single_path_segment(bad):
 def test_action_card_accepts_generated_and_short_ids():
     for good in (ActionCard.new_id(), "a1", "walk-cycle_2"):
         assert ActionCard.from_dict({"id": good, "name": "walk", "prompt": "p"}).id == good
+
+
+@pytest.mark.parametrize("mode", ["original", "transparent", "solid"])
+def test_background_settings_persist_without_changing_key_settings(tmp_path, mode):
+    from core.sprite.project import BackgroundSettings
+    project = SpriteProject(name="Background", project_dir=tmp_path)
+    project.background = BackgroundSettings(mode=mode, color="#12aBcD")
+    project.key.method = "ml"
+    loaded = SpriteProject.load(project.save())
+    assert loaded.background.mode == mode
+    assert loaded.background.color == "#12ABCD"
+    assert loaded.key.method == "ml"
+
+
+def test_old_project_keeps_transparent_background_default():
+    project = SpriteProject.from_dict({"name": "legacy", "key": {"method": "none"}})
+    assert project.background.mode == "transparent"
+    assert project.key.method == "none"
+
+
+@pytest.mark.parametrize("data", [{"mode": "unknown"}, {"color": "white"}, {"color": "#FFFFF"}])
+def test_invalid_background_settings_logged_and_rejected(data, caplog):
+    from core.sprite.project import BackgroundSettings
+    with pytest.raises(ValueError):
+        BackgroundSettings.from_dict(data)
+    assert any(record.levelname == "ERROR" for record in caplog.records)
+
+
+
+@pytest.mark.parametrize("mode", ["original", "transparent", "solid"])
+def test_sheet_metadata_keeps_profile_canvas_and_palette_in_every_background(tmp_path, mode):
+    from PIL import Image
+    from core.sprite.project import BackgroundSettings
+
+    project = SpriteProject(name="Original", project_dir=tmp_path,
+                            background=BackgroundSettings(mode=mode))
+    src = tmp_path / "source.png"
+    Image.new("RGBA", (40, 24), "#123456").save(src)
+    frame = FrameMeta(name="one", source_path=src, frame=(0, 0, 80, 80), source_size=(80, 80))
+    project.actions = [ActionCard(id="one", name="one", prompt="idle", frames=[frame])]
+    profile = project.profile("pixel")
+    profile.locked_palette = ["#000000", "#FFFFFF"]
+    meta = project.sheet_meta("pixel", warn=False)
+    assert meta.cell_size == profile.cell_size
+    assert meta.palette == profile.locked_palette
+    assert meta.frames[0].source_size == (80, 80)
+    assert meta.frames[0].frame == (0, 0, 80, 80)
+    assert frame.source_size == (80, 80)  # export metadata must not mutate the edit history

--- a/tests/sprite/test_project_copy.py
+++ b/tests/sprite/test_project_copy.py
@@ -1,0 +1,37 @@
+"""A named copy has independent media paths and leaves the source intact."""
+import pytest
+
+from core.sprite.project import ActionCard, ClipRecord, SpriteProjectManager
+from core.sprite.project_copy import copy_project
+
+
+def test_copy_repoints_media_and_preserves_original(tmp_path):
+    manager = SpriteProjectManager(tmp_path)
+    original = manager.create_project("Hero")
+    source = original.project_dir / "source" / "character.png"
+    source.write_bytes(b"image")
+    original.character_source = source
+    original.actions = [ActionCard(
+        id="idle", name="idle", prompt="", clip=ClipRecord.from_dict({"path": str(source)}))]
+    copied = copy_project(original, "Other Hero", manager)
+    assert copied.name == "Other Hero"
+    assert copied.character_source != source
+    assert copied.character_source.read_bytes() == b"image"
+    assert copied.actions[0].clip.path == copied.character_source
+    assert original.character_source == source
+    assert original.actions[0].clip.path == source
+    assert manager.load_project(copied.project_file()).character_source == copied.character_source
+
+
+def test_failed_copy_removes_only_its_partial_project(tmp_path, monkeypatch):
+    manager = SpriteProjectManager(tmp_path)
+    original = manager.create_project("Hero")
+    source = original.project_dir / "source" / "character.png"
+    source.write_bytes(b"image")
+    def fail(*args, **kwargs):
+        raise OSError("disk full")
+    monkeypatch.setattr("core.sprite.project_copy.shutil.copytree", fail)
+    with pytest.raises(OSError, match="disk full"):
+        copy_project(original, "Other Hero", manager)
+    assert source.read_bytes() == b"image"
+    assert [entry["name"] for entry in manager.list_projects()] == ["Hero"]

--- a/tests/sprite/test_sprite_source.py
+++ b/tests/sprite/test_sprite_source.py
@@ -80,3 +80,22 @@ def test_normalize_keeps_matching_aspect_unchanged(tmp_path):
 def test_normalize_rejects_missing_file(tmp_path):
     with pytest.raises(FileNotFoundError):
         normalize_source(tmp_path / "nope.png", tmp_path / "out.png")
+
+
+
+def test_preserve_background_intake_keeps_all_pixels_and_size(tmp_path):
+    import json
+    from PIL import Image
+    from core.sprite.source import normalize_source
+    source = tmp_path / "source.png"
+    out = tmp_path / "character.png"
+    image = Image.new("RGB", (30, 40), (51, 87, 192))
+    image.putpixel((0, 0), (255, 1, 2))
+    image.save(source)
+    normalize_source(source, out, aspect_ratio="16:9", preserve_background=True)
+    with Image.open(out) as actual:
+        assert actual.size == image.size
+        assert actual.convert("RGB").tobytes() == image.tobytes()
+        assert actual.getchannel("A").getextrema() == (255, 255)
+    meta = json.loads(out.with_suffix(".png.json").read_text())
+    assert meta["padded"] is False and meta["preserve_background"] is True


### PR DESCRIPTION
Sprite background selection now preserves the configured export geometry. A 256 x 256 profile produces a square export in Original, Transparent, and Solid modes; previously Original mode could produce 256 x 144 from a 16:9 clip. All modes honor the shared crop, padding, anchor, and output-profile settings.

The release also adds exact solid-color GIF backgrounds, cache freshness checks before export, named/searchable Sprite projects, last-project restoration, and Save As with independent media copies. Layout and Help load on demand, and replacing a lazy tab no longer initializes neighboring tabs. Includes the version-manager release and changelog for **0.48.0**.

### Validation

- Sprite core: **675 passed, 1 skipped**. Affected GUI, startup, and shared-path tests: **171 passed** in isolated processes.
- Real rock_3 frames exported through a temporary project at **256 x 256 HD** and **64 x 64 pixel**, retaining all nine frames. Existing project assets were untouched.
- Application Python compilation and whitespace checks passed. Baseline comparisons found **no added Ruff or mypy diagnostics**; repository-wide type checking remains non-clean.
- A combined GUI test process encountered a native Windows Qt heap exception during fixture cleanup; affected files passed when run in separate processes.
- Local review found no actionable issues. The attempted Claude review was unavailable because its OAuth session expired. Live providers and GPU upscalers were not exercised.

Existing projects should rerun the processing pipeline before exporting so the updated stage versions replace cached output.
